### PR TITLE
Use action hook for manual publish endpoint

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
@@ -68,8 +68,8 @@ class TTS_REST {
     public function publish( WP_REST_Request $request ) {
         $id = intval( $request['id'] );
 
-        // Trigger publish via scheduler.
-        TTS_Scheduler::publish_social_post( array( 'post_id' => $id ) );
+        // Trigger publish via scheduler using the registered action hook.
+        do_action( 'tts_publish_social_post', array( 'post_id' => $id ) );
 
         return rest_ensure_response( array( 'post_id' => $id ) );
     }


### PR DESCRIPTION
## Summary
- trigger the social post publish REST endpoint via the existing `tts_publish_social_post` action hook instead of calling the scheduler statically

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cad10124bc832f8f51aa9e1fbde1f3