### PR TITLE
Add centralized logger class

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-logger.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-logger.php
@@ -10,6 +10,230 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Centralized logger for the plugin.
+ */
+class TTS_Logger {
+
+    /**
+     * Supported log levels.
+     *
+     * @var array
+     */
+    private static $levels = array( 'debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency' );
+
+    /**
+     * Cache for the custom table availability check.
+     *
+     * @var null|bool
+     */
+    private static $table_exists = null;
+
+    /**
+     * Write a message to the logging facility.
+     *
+     * @param string|WP_Error $message Log message.
+     * @param string           $level   Log level.
+     * @param array            $context Optional context information.
+     */
+    public static function log( $message, $level = 'info', $context = array() ) {
+        $level   = self::normalize_level( $level );
+        $context = self::normalize_context( $context );
+
+        if ( empty( $context['component'] ) ) {
+            $context['component'] = self::determine_component();
+        }
+
+        $formatted_message = self::format_message( $message, $level, $context );
+        $logged_to_table   = self::log_to_custom_table( $message, $level, $context );
+
+        if ( ! $logged_to_table || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
+            error_log( $formatted_message );
+        }
+    }
+
+    /**
+     * Normalize provided log level.
+     *
+     * @param string $level Requested level.
+     *
+     * @return string
+     */
+    private static function normalize_level( $level ) {
+        $level = strtolower( (string) ( $level ?: 'info' ) );
+
+        if ( ! in_array( $level, self::$levels, true ) ) {
+            return 'info';
+        }
+
+        return $level;
+    }
+
+    /**
+     * Normalize context to an array.
+     *
+     * @param mixed $context Context data.
+     *
+     * @return array
+     */
+    private static function normalize_context( $context ) {
+        if ( empty( $context ) ) {
+            return array();
+        }
+
+        if ( $context instanceof WP_Error ) {
+            return array(
+                'code'    => $context->get_error_code(),
+                'message' => $context->get_error_message(),
+                'data'    => $context->get_error_data(),
+            );
+        }
+
+        if ( is_object( $context ) ) {
+            if ( method_exists( $context, 'to_array' ) ) {
+                $context = $context->to_array();
+            } else {
+                $context = json_decode( wp_json_encode( $context ), true );
+            }
+        }
+
+        if ( ! is_array( $context ) ) {
+            $context = array( 'value' => $context );
+        }
+
+        return $context;
+    }
+
+    /**
+     * Determine the component originating the log entry.
+     *
+     * @return string
+     */
+    private static function determine_component() {
+        $trace           = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 10 );
+        $ignored_classes = array( __CLASS__ );
+        $ignored_functions = array( 'log', __FUNCTION__, 'format_message', 'log_to_custom_table', 'normalize_level', 'normalize_context' );
+
+        foreach ( $trace as $frame ) {
+            if ( isset( $frame['class'] ) && ! in_array( $frame['class'], $ignored_classes, true ) ) {
+                return self::normalize_component_name( $frame['class'] );
+            }
+
+            if ( isset( $frame['function'] ) && ! in_array( $frame['function'], $ignored_functions, true ) ) {
+                if ( in_array( $frame['function'], array( 'call_user_func', 'call_user_func_array' ), true ) ) {
+                    continue;
+                }
+
+                return self::normalize_component_name( $frame['function'] );
+            }
+        }
+
+        return 'general';
+    }
+
+    /**
+     * Normalize component name.
+     *
+     * @param string $component Component identifier.
+     *
+     * @return string
+     */
+    private static function normalize_component_name( $component ) {
+        $component = preg_replace( '/^TTS[_\\]/', '', $component );
+        $component = strtolower( preg_replace( '/[^a-z0-9]+/i', '_', (string) $component ) );
+        $component = trim( $component, '_' );
+
+        return $component ? $component : 'general';
+    }
+
+    /**
+     * Format log message for error_log output.
+     *
+     * @param mixed  $message  Log message.
+     * @param string $level    Log level.
+     * @param array  $context  Context data.
+     *
+     * @return string
+     */
+    private static function format_message( $message, $level, $context ) {
+        if ( $message instanceof WP_Error ) {
+            $message = $message->get_error_message();
+        } elseif ( is_array( $message ) || is_object( $message ) ) {
+            $message = wp_json_encode( $message );
+        } else {
+            $message = (string) $message;
+        }
+
+        $component = strtoupper( str_replace( '-', '_', $context['component'] ?? 'general' ) );
+        $prefix    = sprintf( '[TTS][%s]', strtoupper( $level ) );
+
+        if ( $component ) {
+            $prefix .= sprintf( '[%s]', $component );
+        }
+
+        $context_for_log = $context;
+        unset( $context_for_log['component'] );
+
+        if ( ! empty( $context_for_log ) ) {
+            $message .= ' | Context: ' . wp_json_encode( $context_for_log );
+        }
+
+        return $prefix . ' ' . $message;
+    }
+
+    /**
+     * Persist the log entry in the custom table when available.
+     *
+     * @param mixed  $message Log message.
+     * @param string $level   Log level.
+     * @param array  $context Context data.
+     *
+     * @return bool
+     */
+    private static function log_to_custom_table( $message, $level, $context ) {
+        if ( ! function_exists( 'tts_log_event' ) ) {
+            return false;
+        }
+
+        if ( ! self::has_custom_table() ) {
+            return false;
+        }
+
+        $channel = ! empty( $context['component'] ) ? $context['component'] : 'system';
+        $response = empty( $context ) ? '' : $context;
+
+        tts_log_event( 0, $channel, $level, (string) ( is_scalar( $message ) ? $message : wp_json_encode( $message ) ), $response );
+
+        return true;
+    }
+
+    /**
+     * Check if the custom logs table is available.
+     *
+     * @return bool
+     */
+    private static function has_custom_table() {
+        if ( null !== self::$table_exists ) {
+            return self::$table_exists;
+        }
+
+        global $wpdb;
+
+        if ( ! isset( $wpdb ) || empty( $wpdb->prefix ) ) {
+            self::$table_exists = false;
+
+            return self::$table_exists;
+        }
+
+        $table_name = $wpdb->prefix . 'tts_logs';
+        $result     = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+
+        self::$table_exists = ( $result === $table_name );
+
+        return self::$table_exists;
+    }
+}
+
+/**
  * Create the tts logs table.
  */
 function tts_create_logs_table() {


### PR DESCRIPTION
## Summary
- add a reusable `TTS_Logger` class to centralize plugin logging
- normalize levels/context, auto-tag the originating component, and log to the custom table when available
- fall back to `error_log` (and keep WP_DEBUG support) so existing calls no longer trigger fatal errors

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/tts-logger.php

------
https://chatgpt.com/codex/tasks/task_e_68cad1ee98cc832fb800d49dee801fbc