### PR TITLE
Fix log export column alias

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-advanced-utils.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-advanced-utils.php
@@ -106,7 +106,7 @@ class TTS_Advanced_Utils {
             if ( $options['logs'] ) {
                 global $wpdb;
                 $logs = $wpdb->get_results( $wpdb->prepare( "
-                    SELECT post_id, event_type, status, message, created_at
+                    SELECT post_id, channel AS event_type, status, message, created_at
                     FROM {$wpdb->prefix}tts_logs
                     WHERE created_at >= DATE_SUB(NOW(), INTERVAL %d DAY)
                     ORDER BY created_at DESC


### PR DESCRIPTION
## Summary
- update the log export query to select the channel column and alias it as event_type

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cad47a5090832fade20e3f6b6b984e