### PR TITLE
Fix dynamic metrics method invocation

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
@@ -50,7 +50,7 @@ class TTS_Analytics {
                 $method = 'fetch_' . $ch . '_metrics';
                 if ( method_exists( __CLASS__, $method ) ) {
                     $creds  = isset( $tokens[ $ch ] ) ? $tokens[ $ch ] : '';
-                    $result = self::$method( $post_id, $creds );
+                    $result = call_user_func( array( __CLASS__, $method ), $post_id, $creds );
                     if ( ! is_wp_error( $result ) ) {
                         $metrics[ $ch ] = self::count_interactions( (array) $result );
                     }


### PR DESCRIPTION
## Summary
- update `TTS_Analytics::fetch_all()` to call dynamically resolved metric fetchers via `call_user_func`
- ensure each channel's metrics method executes and results persist without triggering static property usage errors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cad50b55f8832fa0890ea5f406cc77