### PR TITLE
Add media upload retry support across publishers

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
@@ -547,27 +547,89 @@ class TTS_Error_Recovery {
      * Retry API upload operation
      */
     private function retry_api_upload( $context ) {
-        $platform = $context['platform'] ?? '';
+        $platform   = isset( $context['platform'] ) ? strtolower( (string) $context['platform'] ) : '';
         $media_path = $context['media_path'] ?? '';
-        
-        if ( ! $platform || ! $media_path ) {
+
+        if ( empty( $platform ) || empty( $media_path ) ) {
             return array(
                 'success' => false,
-                'error' => 'Missing platform or media path'
+                'error'   => 'Missing platform or media path',
             );
         }
-        
-        // Attempt to re-upload media
-        $publisher_class = 'TTS_Publisher_' . ucfirst( $platform );
-        if ( class_exists( $publisher_class ) ) {
-            $publisher = new $publisher_class();
-            return $publisher->upload_media( $media_path );
-        }
-        
-        return array(
-            'success' => false,
-            'error' => 'Publisher not found: ' . $publisher_class
+
+        $class_map = array(
+            'facebook'        => 'TTS_Publisher_Facebook',
+            'facebook_story'  => 'TTS_Publisher_Facebook_Story',
+            'facebook-story'  => 'TTS_Publisher_Facebook_Story',
+            'instagram'       => 'TTS_Publisher_Instagram',
+            'instagram_story' => 'TTS_Publisher_Instagram_Story',
+            'instagram-story' => 'TTS_Publisher_Instagram_Story',
+            'tiktok'          => 'TTS_Publisher_TikTok',
+            'youtube'         => 'TTS_Publisher_YouTube',
         );
+
+        if ( isset( $class_map[ $platform ] ) ) {
+            $publisher_class = $class_map[ $platform ];
+        } else {
+            $normalized      = str_replace( array( '-', ' ' ), '_', $platform );
+            $parts           = array_map( 'ucfirst', explode( '_', $normalized ) );
+            $publisher_class = 'TTS_Publisher_' . implode( '_', $parts );
+        }
+
+        if ( ! class_exists( $publisher_class ) ) {
+            return array(
+                'success' => false,
+                'error'   => 'Publisher not found: ' . $publisher_class,
+            );
+        }
+
+        $publisher      = new $publisher_class();
+        $upload_context = array();
+        $allowed_keys   = array(
+            'post_id',
+            'credentials',
+            'media_type',
+            'message',
+            'token',
+            'page_id',
+            'ig_user_id',
+            'client_id',
+            'lat',
+            'lng',
+            'title',
+            'media_id',
+            'creds',
+        );
+
+        foreach ( $allowed_keys as $key ) {
+            if ( array_key_exists( $key, $context ) ) {
+                $upload_context[ $key ] = $context[ $key ];
+            }
+        }
+
+        if ( ! isset( $upload_context['message'] ) && isset( $context['caption'] ) ) {
+            $upload_context['message'] = $context['caption'];
+        }
+
+        $result = $publisher->upload_media( $media_path, $upload_context );
+
+        if ( is_wp_error( $result ) ) {
+            return array(
+                'success'    => false,
+                'error'      => $result->get_error_message(),
+                'error_code' => $result->get_error_code(),
+                'error_data' => $result->get_error_data(),
+            );
+        }
+
+        if ( ! is_array( $result ) || ! array_key_exists( 'success', $result ) ) {
+            return array(
+                'success' => false,
+                'error'   => 'Invalid upload response',
+            );
+        }
+
+        return $result;
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook-story.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook-story.php
@@ -15,39 +15,64 @@ if ( ! defined( 'ABSPATH' ) ) {
 class TTS_Publisher_Facebook_Story {
 
     /**
-     * Publish a Story to Facebook.
+     * Upload media to Facebook Stories.
      *
-     * @param int    $post_id     Post ID.
-     * @param mixed  $credentials Page ID and access token.
-     * @param string $media_url   URL of the media to publish.
-     * @return array|\WP_Error Log data or error.
+     * @param string $media_path Remote URL of the media.
+     * @param array  $context    Additional context for the upload.
+     * @return array Result data with success flag.
      */
-    public function publish_story( $post_id, $credentials, $media_url ) {
-        if ( empty( $credentials ) || empty( $media_url ) ) {
+    public function upload_media( $media_path, array $context = array() ) {
+        $post_id     = isset( $context['post_id'] ) ? absint( $context['post_id'] ) : 0;
+        $credentials = $context['credentials'] ?? '';
+        $page_id     = $context['page_id'] ?? '';
+        $token       = $context['token'] ?? '';
+
+        if ( empty( $media_path ) ) {
             $error = __( 'Missing credentials or media for Facebook Story', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'facebook_story', 'error', $error, '' );
-            tts_notify_publication( $post_id, 'error', 'facebook_story' );
-            return new \WP_Error( 'facebook_story_missing_data', $error );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'facebook_story_missing_data',
+            );
         }
 
-        $page_id = '';
-        $token   = $credentials;
-        if ( false !== strpos( $credentials, '|' ) ) {
-            list( $page_id, $token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
-        } else {
+        if ( ( empty( $page_id ) || empty( $token ) ) && ! empty( $credentials ) ) {
+            if ( false !== strpos( $credentials, '|' ) ) {
+                list( $cred_page_id, $cred_token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
+                if ( empty( $page_id ) ) {
+                    $page_id = $cred_page_id;
+                }
+                if ( empty( $token ) ) {
+                    $token = $cred_token;
+                }
+            } else {
+                if ( empty( $token ) ) {
+                    $token = $credentials;
+                }
+            }
+        }
+
+        if ( empty( $page_id ) && $post_id ) {
             $page_id = get_post_meta( $post_id, '_tts_fb_page_id', true );
         }
+
         if ( empty( $page_id ) || empty( $token ) ) {
             $error = __( 'Invalid Facebook credentials', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'facebook_story', 'error', $error, '' );
-            tts_notify_publication( $post_id, 'error', 'facebook_story' );
-            return new \WP_Error( 'facebook_story_bad_credentials', $error );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'facebook_story_bad_credentials',
+            );
         }
 
         $endpoint = sprintf( 'https://graph.facebook.com/%s/stories', $page_id );
         $body     = array(
             'access_token' => $token,
-            'file_url'     => $media_url,
+            'file_url'     => $media_path,
         );
 
         $result = wp_remote_post(
@@ -57,28 +82,74 @@ class TTS_Publisher_Facebook_Story {
                 'timeout' => 20,
             )
         );
+
         if ( is_wp_error( $result ) ) {
             $error = $result->get_error_message();
             tts_log_event( $post_id, 'facebook_story', 'error', $error, '' );
-            tts_notify_publication( $post_id, 'error', 'facebook_story' );
-            return $result;
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'facebook_story_request_error',
+            );
         }
 
         $data = json_decode( wp_remote_retrieve_body( $result ), true );
         $code = wp_remote_retrieve_response_code( $result );
+
         if ( 200 !== $code || empty( $data['id'] ) ) {
             $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'facebook_story', 'error', $error, $data );
-            tts_notify_publication( $post_id, 'error', 'facebook_story' );
-            return new \WP_Error( 'facebook_story_error', $error, $data );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'facebook_story_error',
+                'error_data' => $data,
+            );
         }
 
+        return array(
+            'success' => true,
+            'data'    => $data,
+        );
+    }
+
+    /**
+     * Publish a Story to Facebook.
+     *
+     * @param int    $post_id     Post ID.
+     * @param mixed  $credentials Page ID and access token.
+     * @param string $media_url   URL of the media to publish.
+     * @return array|\WP_Error Log data or error.
+     */
+    public function publish_story( $post_id, $credentials, $media_url ) {
+        $result = $this->upload_media(
+            $media_url,
+            array(
+                'post_id'     => $post_id,
+                'credentials' => $credentials,
+            )
+        );
+
+        if ( empty( $result['success'] ) ) {
+            tts_notify_publication( $post_id, 'error', 'facebook_story' );
+            $error_code = $result['error_code'] ?? 'facebook_story_error';
+            $error_data = $result['error_data'] ?? array();
+            $error_msg  = $result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+
+            return new \WP_Error( $error_code, $error_msg, $error_data );
+        }
+
+        $data     = $result['data'] ?? array();
         $response = array(
             'message' => __( 'Published Facebook Story', 'trello-social-auto-publisher' ),
-            'id'      => $data['id'],
+            'id'      => $data['id'] ?? '',
         );
-        tts_log_event( $post_id, 'facebook_story', 'success', $response['message'], '' );
+
+        tts_log_event( $post_id, 'facebook_story', 'success', $response['message'], $data );
         tts_notify_publication( $post_id, 'success', 'facebook_story' );
+
         return $response;
     }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
@@ -15,6 +15,136 @@ if ( ! defined( 'ABSPATH' ) ) {
 class TTS_Publisher_Facebook {
 
     /**
+     * Upload a single media item to Facebook.
+     *
+     * @param string $media_path Remote URL to the media item.
+     * @param array  $context    Additional context (post_id, credentials, message, etc.).
+     * @return array Result data with success flag.
+     */
+    public function upload_media( $media_path, array $context = array() ) {
+        $post_id     = isset( $context['post_id'] ) ? absint( $context['post_id'] ) : 0;
+        $credentials = $context['credentials'] ?? '';
+
+        list( $page_id, $token ) = $this->resolve_credentials( $credentials, $post_id, $context );
+
+        if ( empty( $page_id ) || empty( $token ) ) {
+            $error = __( 'Invalid Facebook credentials', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'facebook', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'facebook_bad_credentials',
+            );
+        }
+
+        if ( empty( $media_path ) ) {
+            $error = __( 'Missing media path for Facebook upload', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'facebook', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'facebook_missing_media',
+            );
+        }
+
+        $media_type = strtolower( $context['media_type'] ?? '' );
+        if ( ! $media_type ) {
+            $filetype = wp_check_filetype( $media_path );
+            if ( ! empty( $filetype['type'] ) ) {
+                if ( 0 === strpos( $filetype['type'], 'video/' ) ) {
+                    $media_type = 'video';
+                } elseif ( 0 === strpos( $filetype['type'], 'image/' ) ) {
+                    $media_type = 'image';
+                }
+            }
+        }
+
+        if ( 'photo' === $media_type ) {
+            $media_type = 'image';
+        }
+
+        if ( ! in_array( $media_type, array( 'video', 'image' ), true ) ) {
+            $media_type = 'image';
+        }
+
+        $message = $context['message'] ?? '';
+        $lat     = $context['lat'] ?? ( $post_id ? get_post_meta( $post_id, '_tts_lat', true ) : '' );
+        $lng     = $context['lng'] ?? ( $post_id ? get_post_meta( $post_id, '_tts_lng', true ) : '' );
+
+        if ( 'video' === $media_type ) {
+            $endpoint = sprintf( 'https://graph.facebook.com/%s/videos', $page_id );
+            $body     = array(
+                'access_token' => $token,
+                'file_url'     => $media_path,
+            );
+
+            if ( '' !== $message ) {
+                $body['description'] = $message;
+            }
+        } else {
+            $endpoint = sprintf( 'https://graph.facebook.com/%s/photos', $page_id );
+            $body     = array(
+                'access_token' => $token,
+                'source'       => $media_path,
+            );
+
+            if ( '' !== $message ) {
+                $body['message'] = $message;
+            }
+        }
+
+        if ( $lat && $lng ) {
+            $body['location'] = array(
+                'latitude'  => $lat,
+                'longitude' => $lng,
+            );
+        }
+
+        $result = wp_remote_post(
+            $endpoint,
+            array(
+                'body'    => $body,
+                'timeout' => 20,
+            )
+        );
+
+        if ( is_wp_error( $result ) ) {
+            $error = $result->get_error_message();
+            tts_log_event( $post_id, 'facebook', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'facebook_request_error',
+            );
+        }
+
+        $code = wp_remote_retrieve_response_code( $result );
+        $data = json_decode( wp_remote_retrieve_body( $result ), true );
+
+        if ( 200 !== $code || empty( $data['id'] ) ) {
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'facebook', 'error', $error, $data );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'facebook_error',
+                'error_data' => $data,
+            );
+        }
+
+        return array(
+            'success'    => true,
+            'data'       => $data,
+            'media_type' => $media_type,
+            'endpoint'   => $endpoint,
+        );
+    }
+
+    /**
      * Publish the post to Facebook.
      *
      * Requires the `pages_manage_posts` permission to publish and
@@ -124,85 +254,107 @@ class TTS_Publisher_Facebook {
             return new \WP_Error( 'facebook_error', $error, $data );
         }
 
+        $last_response  = array();
+        $common_context = array(
+            'post_id'     => $post_id,
+            'credentials' => $credentials,
+            'token'       => $token,
+            'page_id'     => $page_id,
+            'lat'         => $lat,
+            'lng'         => $lng,
+        );
+
         foreach ( $videos as $index => $video_id ) {
-            $endpoint   = sprintf( 'https://graph.facebook.com/%s/videos', $page_id );
-            $video_body = array(
-                'access_token' => $token,
-                'file_url'     => wp_get_attachment_url( $video_id ),
-            );
-            if ( 0 === $index ) {
-                $video_body['description'] = $message;
-            }
-            if ( $lat && $lng ) {
-                $video_body['location'] = array(
-                    'latitude'  => $lat,
-                    'longitude' => $lng,
-                );
-            }
-            $result = wp_remote_post(
-                $endpoint,
-                array(
-                    'body'    => $video_body,
-                    'timeout' => 20,
+            $video_url    = wp_get_attachment_url( $video_id );
+            $video_result = $this->upload_media(
+                $video_url,
+                array_merge(
+                    $common_context,
+                    array(
+                        'media_type' => 'video',
+                        'message'    => 0 === $index ? $message : '',
+                        'media_id'   => $video_id,
+                    )
                 )
             );
-            if ( is_wp_error( $result ) ) {
-                $error = $result->get_error_message();
-                tts_log_event( $post_id, 'facebook', 'error', $error, '' );
+
+            if ( empty( $video_result['success'] ) ) {
                 tts_notify_publication( $post_id, 'error', 'facebook' );
-                return $result;
+                $error_code = $video_result['error_code'] ?? 'facebook_error';
+                $error_data = $video_result['error_data'] ?? array();
+                $error_msg  = $video_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+
+                return new \WP_Error( $error_code, $error_msg, $error_data );
             }
-            $code = wp_remote_retrieve_response_code( $result );
-            $data = json_decode( wp_remote_retrieve_body( $result ), true );
-            if ( 200 !== $code || empty( $data['id'] ) ) {
-                $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'facebook', 'error', $error, $data );
-                tts_notify_publication( $post_id, 'error', 'facebook' );
-                return new \WP_Error( 'facebook_error', $error, $data );
-            }
+
+            $last_response = $video_result['data'];
         }
 
         foreach ( $images as $image_id => $image_url ) {
-            $endpoint  = sprintf( 'https://graph.facebook.com/%s/photos', $page_id );
-            $img_body  = array(
-                'access_token' => $token,
-                'source'       => $image_url,
-            );
-            if ( empty( $videos ) && $image_id === array_key_first( $images ) ) {
-                $img_body['message'] = $message;
-            }
-            if ( $lat && $lng ) {
-                $img_body['location'] = array(
-                    'latitude'  => $lat,
-                    'longitude' => $lng,
-                );
-            }
-            $result = wp_remote_post(
-                $endpoint,
-                array(
-                    'body'    => $img_body,
-                    'timeout' => 20,
+            $image_result = $this->upload_media(
+                $image_url,
+                array_merge(
+                    $common_context,
+                    array(
+                        'media_type' => 'image',
+                        'message'    => ( empty( $videos ) && $image_id === array_key_first( $images ) ) ? $message : '',
+                        'media_id'   => $image_id,
+                    )
                 )
             );
-            if ( is_wp_error( $result ) ) {
-                $error = $result->get_error_message();
-                tts_log_event( $post_id, 'facebook', 'error', $error, '' );
+
+            if ( empty( $image_result['success'] ) ) {
                 tts_notify_publication( $post_id, 'error', 'facebook' );
-                return $result;
+                $error_code = $image_result['error_code'] ?? 'facebook_error';
+                $error_data = $image_result['error_data'] ?? array();
+                $error_msg  = $image_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+
+                return new \WP_Error( $error_code, $error_msg, $error_data );
             }
-            $code = wp_remote_retrieve_response_code( $result );
-            $data = json_decode( wp_remote_retrieve_body( $result ), true );
-            if ( 200 !== $code || empty( $data['id'] ) ) {
-                $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'facebook', 'error', $error, $data );
-                tts_notify_publication( $post_id, 'error', 'facebook' );
-                return new \WP_Error( 'facebook_error', $error, $data );
-            }
+
+            $last_response = $image_result['data'];
         }
 
         $response = __( 'Published to Facebook', 'trello-social-auto-publisher' );
-        tts_log_event( $post_id, 'facebook', 'success', $response, $data );
+        tts_log_event( $post_id, 'facebook', 'success', $response, $last_response );
         tts_notify_publication( $post_id, 'success', 'facebook' );
         return $response;
+    }
+
+    /**
+     * Resolve Facebook page credentials.
+     *
+     * @param string $credentials Raw credentials string.
+     * @param int    $post_id     Related post ID.
+     * @param array  $context     Additional context.
+     * @return array Array with page ID and token.
+     */
+    private function resolve_credentials( $credentials, $post_id, array $context = array() ) {
+        $page_id = $context['page_id'] ?? '';
+        $token   = $context['token'] ?? '';
+
+        if ( empty( $page_id ) || empty( $token ) ) {
+            if ( ! empty( $credentials ) ) {
+                if ( false !== strpos( $credentials, '|' ) ) {
+                    list( $cred_page_id, $cred_token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
+                    if ( empty( $page_id ) ) {
+                        $page_id = $cred_page_id;
+                    }
+                    if ( empty( $token ) ) {
+                        $token = $cred_token;
+                    }
+                } else {
+                    if ( empty( $token ) ) {
+                        $token = $credentials;
+                    }
+                }
+            }
+        }
+
+        if ( empty( $page_id ) && $post_id ) {
+            $page_id = get_post_meta( $post_id, '_tts_fb_page_id', true );
+        }
+
+        return array( $page_id, $token );
     }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram-story.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram-story.php
@@ -15,40 +15,50 @@ if ( ! defined( 'ABSPATH' ) ) {
 class TTS_Publisher_Instagram_Story {
 
     /**
-     * Publish a Story to Instagram.
+     * Upload media to Instagram Stories.
      *
-     * @param int    $post_id     Post ID.
-     * @param string $credentials IG user ID and access token.
-     * @param string $media_url   URL of the media to publish.
-     * @return array|\WP_Error Log data or error.
+     * @param string $media_path Remote media URL.
+     * @param array  $context    Additional context (post ID, credentials, etc.).
+     * @return array Result data with success flag.
      */
-    public function publish_story( $post_id, $credentials, $media_url ) {
-        if ( empty( $credentials ) || empty( $media_url ) ) {
+    public function upload_media( $media_path, array $context = array() ) {
+        $post_id     = isset( $context['post_id'] ) ? absint( $context['post_id'] ) : 0;
+        $credentials = $context['credentials'] ?? '';
+        $ig_user_id  = $context['ig_user_id'] ?? '';
+        $token       = $context['token'] ?? '';
+
+        if ( ( empty( $ig_user_id ) || empty( $token ) ) && ! empty( $credentials ) ) {
+            list( $cred_user_id, $cred_token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
+            if ( empty( $ig_user_id ) ) {
+                $ig_user_id = $cred_user_id;
+            }
+            if ( empty( $token ) ) {
+                $token = $cred_token;
+            }
+        }
+
+        if ( empty( $ig_user_id ) || empty( $token ) || empty( $media_path ) ) {
             $error = __( 'Missing credentials or media for Instagram Story', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'instagram_story', 'error', $error, '' );
-            tts_notify_publication( $post_id, 'error', 'instagram_story' );
-            return new \WP_Error( 'instagram_story_missing_data', $error );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => empty( $media_path ) ? 'instagram_story_missing_data' : 'instagram_story_bad_credentials',
+            );
         }
 
-        list( $ig_user_id, $token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
-        if ( empty( $ig_user_id ) || empty( $token ) ) {
-            $error = __( 'Invalid Instagram credentials', 'trello-social-auto-publisher' );
-            tts_log_event( $post_id, 'instagram_story', 'error', $error, '' );
-            tts_notify_publication( $post_id, 'error', 'instagram_story' );
-            return new \WP_Error( 'instagram_story_bad_credentials', $error );
-        }
-
-        $mime = wp_check_filetype( $media_url );
+        $mime     = wp_check_filetype( $media_path );
         $endpoint = sprintf( 'https://graph.facebook.com/%s/media', $ig_user_id );
         $body     = array(
             'access_token' => $token,
             'media_type'   => 'STORIES',
         );
 
-        if ( 0 === strpos( $mime['type'], 'image/' ) ) {
-            $body['image_url'] = $media_url;
+        if ( ! empty( $mime['type'] ) && 0 === strpos( $mime['type'], 'image/' ) ) {
+            $body['image_url'] = $media_path;
         } else {
-            $body['video_url'] = $media_url;
+            $body['video_url'] = $media_path;
         }
 
         $result = wp_remote_post(
@@ -62,17 +72,27 @@ class TTS_Publisher_Instagram_Story {
         if ( is_wp_error( $result ) ) {
             $error = $result->get_error_message();
             tts_log_event( $post_id, 'instagram_story', 'error', $error, '' );
-            tts_notify_publication( $post_id, 'error', 'instagram_story' );
-            return $result;
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_story_request_error',
+            );
         }
 
         $data = json_decode( wp_remote_retrieve_body( $result ), true );
         $code = wp_remote_retrieve_response_code( $result );
+
         if ( 200 !== $code || empty( $data['id'] ) ) {
             $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'instagram_story', 'error', $error, $data );
-            tts_notify_publication( $post_id, 'error', 'instagram_story' );
-            return new \WP_Error( 'instagram_story_error', $error, $data );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_story_error',
+                'error_data' => $data,
+            );
         }
 
         $publish_endpoint = sprintf( 'https://graph.facebook.com/%s/media_publish', $ig_user_id );
@@ -90,25 +110,70 @@ class TTS_Publisher_Instagram_Story {
         if ( is_wp_error( $publish_result ) ) {
             $error = $publish_result->get_error_message();
             tts_log_event( $post_id, 'instagram_story', 'error', $error, '' );
-            tts_notify_publication( $post_id, 'error', 'instagram_story' );
-            return $publish_result;
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_story_publish_request_error',
+            );
         }
 
         $publish_data = json_decode( wp_remote_retrieve_body( $publish_result ), true );
         $publish_code = wp_remote_retrieve_response_code( $publish_result );
+
         if ( 200 !== $publish_code || empty( $publish_data['id'] ) ) {
             $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'instagram_story', 'error', $error, $publish_data );
-            tts_notify_publication( $post_id, 'error', 'instagram_story' );
-            return new \WP_Error( 'instagram_story_error', $error, $publish_data );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_story_error',
+                'error_data' => $publish_data,
+            );
         }
 
+        return array(
+            'success' => true,
+            'data'    => $publish_data,
+        );
+    }
+
+    /**
+     * Publish a Story to Instagram.
+     *
+     * @param int    $post_id     Post ID.
+     * @param string $credentials IG user ID and access token.
+     * @param string $media_url   URL of the media to publish.
+     * @return array|\WP_Error Log data or error.
+     */
+    public function publish_story( $post_id, $credentials, $media_url ) {
+        $result = $this->upload_media(
+            $media_url,
+            array(
+                'post_id'     => $post_id,
+                'credentials' => $credentials,
+            )
+        );
+
+        if ( empty( $result['success'] ) ) {
+            tts_notify_publication( $post_id, 'error', 'instagram_story' );
+            $error_code = $result['error_code'] ?? 'instagram_story_error';
+            $error_data = $result['error_data'] ?? array();
+            $error_msg  = $result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+
+            return new \WP_Error( $error_code, $error_msg, $error_data );
+        }
+
+        $data     = $result['data'] ?? array();
         $response = array(
             'message' => __( 'Published Instagram Story', 'trello-social-auto-publisher' ),
-            'id'      => $publish_data['id'],
+            'id'      => $data['id'] ?? '',
         );
-        tts_log_event( $post_id, 'instagram_story', 'success', $response['message'], '' );
+
+        tts_log_event( $post_id, 'instagram_story', 'success', $response['message'], $data );
         tts_notify_publication( $post_id, 'success', 'instagram_story' );
+
         return $response;
     }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
@@ -29,6 +29,174 @@ class TTS_Publisher_Instagram {
     private $post_id = 0;
 
     /**
+     * Upload a single media item to Instagram.
+     *
+     * @param string $media_path Remote URL of the media item.
+     * @param array  $context    Additional context such as post ID and credentials.
+     * @return array Result data with success flag.
+     */
+    public function upload_media( $media_path, array $context = array() ) {
+        $post_id     = isset( $context['post_id'] ) ? absint( $context['post_id'] ) : 0;
+        $credentials = $context['credentials'] ?? '';
+        $ig_user_id  = $context['ig_user_id'] ?? '';
+        $token       = $context['token'] ?? '';
+
+        if ( ( empty( $ig_user_id ) || empty( $token ) ) && ! empty( $credentials ) ) {
+            list( $cred_user_id, $cred_token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
+            if ( empty( $ig_user_id ) ) {
+                $ig_user_id = $cred_user_id;
+            }
+            if ( empty( $token ) ) {
+                $token = $cred_token;
+            }
+        }
+
+        if ( empty( $ig_user_id ) || empty( $token ) ) {
+            $error = __( 'Invalid Instagram credentials', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'instagram', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_bad_credentials',
+            );
+        }
+
+        if ( empty( $media_path ) ) {
+            $error = __( 'No image or video to publish', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'instagram', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_no_media',
+            );
+        }
+
+        $message    = $context['message'] ?? '';
+        $lat        = $context['lat'] ?? ( $post_id ? get_post_meta( $post_id, '_tts_lat', true ) : '' );
+        $lng        = $context['lng'] ?? ( $post_id ? get_post_meta( $post_id, '_tts_lng', true ) : '' );
+        $media_type = strtoupper( $context['media_type'] ?? '' );
+
+        if ( ! $media_type ) {
+            $filetype = wp_check_filetype( $media_path );
+            if ( ! empty( $filetype['type'] ) && 0 === strpos( $filetype['type'], 'video/' ) ) {
+                $media_type = 'VIDEO';
+            } else {
+                $media_type = 'IMAGE';
+            }
+        }
+
+        if ( ! in_array( $media_type, array( 'IMAGE', 'VIDEO' ), true ) ) {
+            $media_type = 'IMAGE';
+        }
+
+        $endpoint = sprintf( 'https://graph.facebook.com/%s/media', $ig_user_id );
+        $body     = array(
+            'caption'      => $message,
+            'access_token' => $token,
+        );
+
+        if ( $lat && $lng ) {
+            $body['location'] = array(
+                'latitude'  => $lat,
+                'longitude' => $lng,
+            );
+        }
+
+        if ( 'IMAGE' === $media_type ) {
+            $body['image_url'] = $media_path;
+        } else {
+            $body['media_type'] = 'VIDEO';
+            $body['video_url']  = $media_path;
+        }
+
+        $result = wp_remote_post(
+            $endpoint,
+            array(
+                'body'    => $body,
+                'timeout' => 20,
+            )
+        );
+
+        if ( is_wp_error( $result ) ) {
+            $error = $result->get_error_message();
+            tts_log_event( $post_id, 'instagram', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_request_error',
+            );
+        }
+
+        $code = wp_remote_retrieve_response_code( $result );
+        $data = json_decode( wp_remote_retrieve_body( $result ), true );
+
+        if ( 200 !== $code || empty( $data['id'] ) ) {
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'instagram', 'error', $error, $data );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_error',
+                'error_data' => $data,
+            );
+        }
+
+        $publish_endpoint = sprintf( 'https://graph.facebook.com/%s/media_publish', $ig_user_id );
+        $publish_body     = array(
+            'creation_id'  => $data['id'],
+            'access_token' => $token,
+        );
+
+        $publish_result = wp_remote_post(
+            $publish_endpoint,
+            array(
+                'body'    => $publish_body,
+                'timeout' => 20,
+            )
+        );
+
+        if ( is_wp_error( $publish_result ) ) {
+            $error = $publish_result->get_error_message();
+            tts_log_event( $post_id, 'instagram', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_publish_request_error',
+            );
+        }
+
+        $publish_code = wp_remote_retrieve_response_code( $publish_result );
+        $publish_data = json_decode( wp_remote_retrieve_body( $publish_result ), true );
+
+        if ( 200 !== $publish_code || empty( $publish_data['id'] ) ) {
+            $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'instagram', 'error', $error, $publish_data );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'instagram_error',
+                'error_data' => $publish_data,
+            );
+        }
+
+        $this->post_id = $post_id ?: $this->post_id;
+        $this->token   = $token;
+
+        return array(
+            'success'      => true,
+            'data'         => $publish_data,
+            'creation_id'  => $data['id'],
+            'media_type'   => $media_type,
+        );
+    }
+
+    /**
      * Publish the post to Instagram.
      *
      * Credentials must be provided in the form `{ig-user-id}|{access-token}` where `ig-user-id` is
@@ -107,72 +275,31 @@ class TTS_Publisher_Instagram {
         }
         $first_media_id = '';
         foreach ( $media_items as $index => $item ) {
-            $endpoint = sprintf( 'https://graph.facebook.com/%s/media', $ig_user_id );
-            $body     = array(
-                'caption'      => 0 === $index ? $message : '',
-                'access_token' => $token,
-            );
-            if ( $lat && $lng ) {
-                $body['location'] = array(
-                    'latitude'  => $lat,
-                    'longitude' => $lng,
-                );
-            }
-            if ( 'IMAGE' === $item['type'] ) {
-                $body['image_url'] = $item['url'];
-            } else {
-                $body['media_type'] = 'VIDEO';
-                $body['video_url']  = $item['url'];
-            }
-            $result = wp_remote_post(
-                $endpoint,
+            $upload_result = $this->upload_media(
+                $item['url'],
                 array(
-                    'body'    => $body,
-                    'timeout' => 20,
+                    'post_id'     => $post_id,
+                    'credentials' => $credentials,
+                    'ig_user_id'  => $ig_user_id,
+                    'token'       => $token,
+                    'media_type'  => $item['type'],
+                    'message'     => 0 === $index ? $message : '',
+                    'lat'         => $lat,
+                    'lng'         => $lng,
                 )
             );
-            if ( is_wp_error( $result ) ) {
-                $error = $result->get_error_message();
-                tts_log_event( $post_id, 'instagram', 'error', $error, '' );
+
+            if ( empty( $upload_result['success'] ) ) {
                 tts_notify_publication( $post_id, 'error', 'instagram' );
-                return $result;
+                $error_code = $upload_result['error_code'] ?? 'instagram_error';
+                $error_data = $upload_result['error_data'] ?? array();
+                $error_msg  = $upload_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+
+                return new \WP_Error( $error_code, $error_msg, $error_data );
             }
-            $code = wp_remote_retrieve_response_code( $result );
-            $data = json_decode( wp_remote_retrieve_body( $result ), true );
-            if ( 200 !== $code || empty( $data['id'] ) ) {
-                $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'instagram', 'error', $error, $data );
-                tts_notify_publication( $post_id, 'error', 'instagram' );
-                return new \WP_Error( 'instagram_error', $error, $data );
-            }
-            $publish_endpoint = sprintf( 'https://graph.facebook.com/%s/media_publish', $ig_user_id );
-            $publish_body     = array(
-                'creation_id'  => $data['id'],
-                'access_token' => $token,
-            );
-            $publish_result   = wp_remote_post(
-                $publish_endpoint,
-                array(
-                    'body'    => $publish_body,
-                    'timeout' => 20,
-                )
-            );
-            if ( is_wp_error( $publish_result ) ) {
-                $error = $publish_result->get_error_message();
-                tts_log_event( $post_id, 'instagram', 'error', $error, '' );
-                tts_notify_publication( $post_id, 'error', 'instagram' );
-                return $publish_result;
-            }
-            $publish_code = wp_remote_retrieve_response_code( $publish_result );
-            $publish_data = json_decode( wp_remote_retrieve_body( $publish_result ), true );
-            if ( 200 !== $publish_code || empty( $publish_data['id'] ) ) {
-                $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'instagram', 'error', $error, $publish_data );
-                tts_notify_publication( $post_id, 'error', 'instagram' );
-                return new \WP_Error( 'instagram_error', $error, $publish_data );
-            }
+
             if ( '' === $first_media_id ) {
-                $first_media_id = $publish_data['id'];
+                $first_media_id = $upload_result['data']['id'] ?? '';
             }
         }
         $response = array(

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php
@@ -15,6 +15,200 @@ if ( ! defined( 'ABSPATH' ) ) {
 class TTS_Publisher_TikTok {
 
     /**
+     * Upload a single TikTok video.
+     *
+     * @param string $media_path Absolute path or URL to the video file.
+     * @param array  $context    Additional context (post ID, token, message, etc.).
+     * @return array Result data with success flag.
+     */
+    public function upload_media( $media_path, array $context = array() ) {
+        $post_id = isset( $context['post_id'] ) ? absint( $context['post_id'] ) : 0;
+        $token   = $context['token'] ?? ( $context['credentials'] ?? '' );
+
+        if ( empty( $token ) ) {
+            $error = __( 'TikTok token missing or lacks video.upload scope', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'tiktok_no_token',
+            );
+        }
+
+        if ( empty( $media_path ) ) {
+            $error = __( 'Video file not found', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'tiktok_video_missing',
+            );
+        }
+
+        $video_path = '';
+        $cleanup    = false;
+
+        if ( file_exists( $media_path ) ) {
+            $video_path = $media_path;
+        } elseif ( ! empty( $context['media_id'] ) ) {
+            $possible_path = get_attached_file( (int) $context['media_id'] );
+            if ( $possible_path && file_exists( $possible_path ) ) {
+                $video_path = $possible_path;
+            }
+        }
+
+        if ( empty( $video_path ) && filter_var( $media_path, FILTER_VALIDATE_URL ) ) {
+            $downloaded = download_url( $media_path );
+            if ( is_wp_error( $downloaded ) ) {
+                $error = $downloaded->get_error_message();
+                tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
+
+                return array(
+                    'success'    => false,
+                    'error'      => $error,
+                    'error_code' => 'tiktok_video_download_failed',
+                );
+            }
+
+            $video_path = $downloaded;
+            $cleanup    = true;
+        }
+
+        if ( empty( $video_path ) || ! file_exists( $video_path ) ) {
+            $error = __( 'Video file not found', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'tiktok_video_missing',
+            );
+        }
+
+        $video_contents = file_get_contents( $video_path );
+
+        if ( false === $video_contents ) {
+            if ( $cleanup ) {
+                @unlink( $video_path );
+            }
+
+            $error = __( 'Unable to read video file', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'tiktok_video_read_error',
+            );
+        }
+
+        $upload_result = wp_remote_post(
+            'https://open.tiktokapis.com/v2/video/upload/',
+            array(
+                'headers' => array(
+                    'Authorization' => 'Bearer ' . $token,
+                    'Content-Type'  => 'video/mp4',
+                ),
+                'body'    => $video_contents,
+                'timeout' => 60,
+            )
+        );
+
+        if ( $cleanup ) {
+            @unlink( $video_path );
+        }
+
+        if ( is_wp_error( $upload_result ) ) {
+            $error = $upload_result->get_error_message();
+            tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'tiktok_upload_error',
+            );
+        }
+
+        $upload_code = wp_remote_retrieve_response_code( $upload_result );
+        $upload_data = json_decode( wp_remote_retrieve_body( $upload_result ), true );
+
+        if ( 200 !== $upload_code || empty( $upload_data['data']['video_id'] ) ) {
+            $error = isset( $upload_data['error']['message'] ) ? $upload_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'tiktok', 'error', $error, $upload_data );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'tiktok_upload_error',
+                'error_data' => $upload_data,
+            );
+        }
+
+        $message = $context['message'] ?? '';
+        $lat     = $context['lat'] ?? ( $post_id ? get_post_meta( $post_id, '_tts_lat', true ) : '' );
+        $lng     = $context['lng'] ?? ( $post_id ? get_post_meta( $post_id, '_tts_lng', true ) : '' );
+
+        $publish_body = array(
+            'video_id' => $upload_data['data']['video_id'],
+            'caption'  => $message,
+        );
+
+        if ( $lat && $lng ) {
+            $publish_body['location'] = array(
+                'latitude'  => $lat,
+                'longitude' => $lng,
+            );
+        }
+
+        $publish_result = wp_remote_post(
+            'https://open.tiktokapis.com/v2/video/publish/',
+            array(
+                'headers' => array(
+                    'Authorization' => 'Bearer ' . $token,
+                    'Content-Type'  => 'application/json',
+                ),
+                'body'    => wp_json_encode( $publish_body ),
+                'timeout' => 60,
+            )
+        );
+
+        if ( is_wp_error( $publish_result ) ) {
+            $error = $publish_result->get_error_message();
+            tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'tiktok_publish_error',
+            );
+        }
+
+        $publish_code = wp_remote_retrieve_response_code( $publish_result );
+        $publish_data = json_decode( wp_remote_retrieve_body( $publish_result ), true );
+
+        if ( 200 !== $publish_code || empty( $publish_data['data']['video_id'] ) ) {
+            $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'tiktok', 'error', $error, $publish_data );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'tiktok_publish_error',
+                'error_data' => $publish_data,
+            );
+        }
+
+        return array(
+            'success'  => true,
+            'data'     => $publish_data,
+            'video_id' => $upload_data['data']['video_id'],
+        );
+    }
+
+
+    /**
      * Publish the post to TikTok.
      *
      * Requires an OAuth 2.0 access token granted with the `video.upload`
@@ -58,74 +252,26 @@ class TTS_Publisher_TikTok {
             return new \WP_Error( 'tiktok_no_video', $error );
         }
         foreach ( $videos as $video_id ) {
-            $video_path = get_attached_file( $video_id );
-            if ( empty( $video_path ) || ! file_exists( $video_path ) ) {
-                $error = __( 'Video file not found', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
-                tts_notify_publication( $post_id, 'error', 'tiktok' );
-                return new \WP_Error( 'tiktok_video_missing', $error );
-            }
-            $upload_endpoint = 'https://open.tiktokapis.com/v2/video/upload/';
-            $upload_result   = wp_remote_post(
-                $upload_endpoint,
+            $video_path    = get_attached_file( $video_id );
+            $upload_result = $this->upload_media(
+                $video_path,
                 array(
-                    'headers' => array(
-                        'Authorization' => 'Bearer ' . $token,
-                        'Content-Type'  => 'video/mp4',
-                    ),
-                    'body'    => file_get_contents( $video_path ),
-                    'timeout' => 60,
+                    'post_id'   => $post_id,
+                    'token'     => $token,
+                    'message'   => $message,
+                    'lat'       => $lat,
+                    'lng'       => $lng,
+                    'media_id'  => $video_id,
                 )
             );
-            if ( is_wp_error( $upload_result ) ) {
-                $error = $upload_result->get_error_message();
-                tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
+
+            if ( empty( $upload_result['success'] ) ) {
                 tts_notify_publication( $post_id, 'error', 'tiktok' );
-                return $upload_result;
-            }
-            $upload_code = wp_remote_retrieve_response_code( $upload_result );
-            $upload_data = json_decode( wp_remote_retrieve_body( $upload_result ), true );
-            if ( 200 !== $upload_code || empty( $upload_data['data']['video_id'] ) ) {
-                $error = isset( $upload_data['error']['message'] ) ? $upload_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'tiktok', 'error', $error, $upload_data );
-                tts_notify_publication( $post_id, 'error', 'tiktok' );
-                return new \WP_Error( 'tiktok_upload_error', $error, $upload_data );
-            }
-            $publish_endpoint = 'https://open.tiktokapis.com/v2/video/publish/';
-            $publish_body     = array(
-                'video_id' => $upload_data['data']['video_id'],
-                'caption'  => $message,
-            );
-            if ( $lat && $lng ) {
-                $publish_body['location'] = array(
-                    'latitude'  => $lat,
-                    'longitude' => $lng,
-                );
-            }
-            $publish_result = wp_remote_post(
-                $publish_endpoint,
-                array(
-                    'headers' => array(
-                        'Authorization' => 'Bearer ' . $token,
-                        'Content-Type'  => 'application/json',
-                    ),
-                    'body'    => wp_json_encode( $publish_body ),
-                    'timeout' => 60,
-                )
-            );
-            if ( is_wp_error( $publish_result ) ) {
-                $error = $publish_result->get_error_message();
-                tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
-                tts_notify_publication( $post_id, 'error', 'tiktok' );
-                return $publish_result;
-            }
-            $publish_code = wp_remote_retrieve_response_code( $publish_result );
-            $publish_data = json_decode( wp_remote_retrieve_body( $publish_result ), true );
-            if ( 200 !== $publish_code || empty( $publish_data['data']['video_id'] ) ) {
-                $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'tiktok', 'error', $error, $publish_data );
-                tts_notify_publication( $post_id, 'error', 'tiktok' );
-                return new \WP_Error( 'tiktok_publish_error', $error, $publish_data );
+                $error_code = $upload_result['error_code'] ?? 'tiktok_error';
+                $error_data = $upload_result['error_data'] ?? array();
+                $error_msg  = $upload_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+
+                return new \WP_Error( $error_code, $error_msg, $error_data );
             }
         }
         $response = __( 'Published to TikTok', 'trello-social-auto-publisher' );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
@@ -15,6 +15,214 @@ if ( ! defined( 'ABSPATH' ) ) {
 class TTS_Publisher_YouTube {
 
     /**
+     * Upload a single YouTube Shorts video.
+     *
+     * @param string $media_path Absolute path or URL to the video file.
+     * @param array  $context    Additional context (post ID, credentials, etc.).
+     * @return array Result data with success flag.
+     */
+    public function upload_media( $media_path, array $context = array() ) {
+        $post_id     = isset( $context['post_id'] ) ? absint( $context['post_id'] ) : 0;
+        $credentials = $context['credentials'] ?? '';
+        $client_id   = $context['client_id'] ?? '';
+        $message     = $context['message'] ?? '';
+        $title       = $context['title'] ?? ( $post_id ? get_the_title( $post_id ) : '' );
+        $lat         = $context['lat'] ?? ( $post_id ? get_post_meta( $post_id, '_tts_lat', true ) : '' );
+        $lng         = $context['lng'] ?? ( $post_id ? get_post_meta( $post_id, '_tts_lng', true ) : '' );
+        $token       = $context['token'] ?? '';
+        $creds       = $context['creds'] ?? null;
+
+        if ( empty( $token ) ) {
+            $source_credentials = null !== $creds ? $creds : $credentials;
+            list( $token, $creds, $client_id ) = $this->resolve_access_token( $source_credentials, $post_id, $client_id );
+        }
+
+        if ( empty( $token ) ) {
+            $error = __( 'Unable to obtain YouTube access token', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'youtube_no_access_token',
+            );
+        }
+
+        $video_path = '';
+        $cleanup    = false;
+
+        if ( $media_path && file_exists( $media_path ) ) {
+            $video_path = $media_path;
+        } elseif ( ! empty( $context['media_id'] ) ) {
+            $possible_path = get_attached_file( (int) $context['media_id'] );
+            if ( $possible_path && file_exists( $possible_path ) ) {
+                $video_path = $possible_path;
+            }
+        }
+
+        if ( empty( $video_path ) && $media_path && filter_var( $media_path, FILTER_VALIDATE_URL ) ) {
+            $downloaded = download_url( $media_path );
+            if ( is_wp_error( $downloaded ) ) {
+                $error = $downloaded->get_error_message();
+                tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+
+                return array(
+                    'success'    => false,
+                    'error'      => $error,
+                    'error_code' => 'youtube_video_download_failed',
+                );
+            }
+            $video_path = $downloaded;
+            $cleanup    = true;
+        }
+
+        if ( empty( $video_path ) || ! file_exists( $video_path ) ) {
+            $error = __( 'Video file not found', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'youtube_video_missing',
+            );
+        }
+
+        $snippet = array(
+            'title'           => $title,
+            'description'     => $message,
+            'categoryId'      => '22',
+            'shortsVideoType' => 'SHORTS',
+        );
+        $status = array(
+            'privacyStatus'  => 'public',
+            'shortsEligible' => true,
+        );
+        $metadata = array(
+            'snippet' => $snippet,
+            'status'  => $status,
+        );
+
+        if ( $lat && $lng ) {
+            $metadata['recordingDetails'] = array(
+                'location' => array(
+                    'latitude'  => (float) $lat,
+                    'longitude' => (float) $lng,
+                ),
+            );
+        }
+
+        $endpoint = 'https://www.googleapis.com/upload/youtube/v3/videos?part=snippet,status';
+        if ( $lat && $lng ) {
+            $endpoint .= ',recordingDetails';
+        }
+        $endpoint .= '&uploadType=resumable';
+
+        $init = wp_remote_request(
+            $endpoint,
+            array(
+                'method'  => 'POST',
+                'headers' => array(
+                    'Authorization'           => 'Bearer ' . $token,
+                    'Content-Type'            => 'application/json; charset=UTF-8',
+                    'X-Upload-Content-Type'   => 'video/mp4',
+                    'X-Upload-Content-Length' => filesize( $video_path ),
+                ),
+                'body'    => wp_json_encode( $metadata ),
+                'timeout' => 60,
+            )
+        );
+
+        if ( is_wp_error( $init ) ) {
+            if ( $cleanup ) {
+                @unlink( $video_path );
+            }
+            $error = $init->get_error_message();
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'youtube_request_error',
+            );
+        }
+
+        $upload_url = wp_remote_retrieve_header( $init, 'location' );
+        if ( empty( $upload_url ) ) {
+            if ( $cleanup ) {
+                @unlink( $video_path );
+            }
+            $error = __( 'Upload URL missing', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'youtube_no_upload_url',
+            );
+        }
+
+        $video_body = file_get_contents( $video_path );
+        if ( $cleanup ) {
+            @unlink( $video_path );
+        }
+
+        if ( false === $video_body ) {
+            $error = __( 'Unable to read video file', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'youtube_video_read_error',
+            );
+        }
+
+        $upload = wp_remote_request(
+            $upload_url,
+            array(
+                'method'  => 'PUT',
+                'headers' => array(
+                    'Content-Type'   => 'video/mp4',
+                    'Content-Length' => strlen( $video_body ),
+                ),
+                'body'    => $video_body,
+                'timeout' => 60,
+            )
+        );
+
+        if ( is_wp_error( $upload ) ) {
+            $error = $upload->get_error_message();
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'youtube_error',
+            );
+        }
+
+        $code = wp_remote_retrieve_response_code( $upload );
+        $data = json_decode( wp_remote_retrieve_body( $upload ), true );
+
+        if ( 200 !== $code || empty( $data['id'] ) ) {
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'youtube', 'error', $error, $data );
+
+            return array(
+                'success'    => false,
+                'error'      => $error,
+                'error_code' => 'youtube_error',
+                'error_data' => $data,
+            );
+        }
+
+        return array(
+            'success' => true,
+            'data'    => $data,
+        );
+    }
+
+    /**
      * Publish the post to YouTube Shorts.
      *
      * @param int    $post_id     Post ID.
@@ -30,43 +238,7 @@ class TTS_Publisher_YouTube {
             return new \WP_Error( 'youtube_no_token', $error );
         }
 
-        $client_id = get_post_meta( $post_id, '_tts_client_id', true );
-
-        // Credentials may be a plain token string or a JSON object with refresh token data.
-        $creds      = is_string( $credentials ) ? json_decode( $credentials, true ) : $credentials;
-        $access_tok = '';
-        if ( is_array( $creds ) ) {
-            $access_tok = isset( $creds['access_token'] ) ? $creds['access_token'] : '';
-            if ( empty( $access_tok ) && ! empty( $creds['refresh_token'] ) && ! empty( $creds['client_id'] ) && ! empty( $creds['client_secret'] ) ) {
-                // Request a new access token using the refresh token.
-                $token_resp = wp_remote_post(
-                    'https://oauth2.googleapis.com/token',
-                    array(
-                        'body'    => array(
-                            'client_id'     => $creds['client_id'],
-                            'client_secret' => $creds['client_secret'],
-                            'refresh_token' => $creds['refresh_token'],
-                            'grant_type'    => 'refresh_token',
-                            'scope'         => 'https://www.googleapis.com/auth/youtube.upload',
-                        ),
-                        'timeout' => 20,
-                    )
-                );
-                if ( ! is_wp_error( $token_resp ) ) {
-                    $token_body = json_decode( wp_remote_retrieve_body( $token_resp ), true );
-                    if ( ! empty( $token_body['access_token'] ) ) {
-                        $access_tok            = $token_body['access_token'];
-                        $creds['access_token'] = $access_tok;
-                        if ( $client_id ) {
-                            update_post_meta( $client_id, '_tts_yt_token', wp_json_encode( $creds ) );
-                        }
-                    }
-                }
-            }
-        } else {
-            // Backward compatibility: plain token string.
-            $access_tok = $credentials;
-        }
+        list( $access_tok, $creds, $client_id ) = $this->resolve_access_token( $credentials, $post_id );
 
         if ( empty( $access_tok ) ) {
             $error = __( 'Unable to obtain YouTube access token', 'trello-social-auto-publisher' );
@@ -100,97 +272,84 @@ class TTS_Publisher_YouTube {
             return new \WP_Error( 'youtube_no_video', $error );
         }
         foreach ( $videos as $video_id ) {
-            $video_path = get_attached_file( $video_id );
-            if ( empty( $video_path ) || ! file_exists( $video_path ) ) {
-                $error = __( 'Video file not found', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'youtube', 'error', $error, '' );
-                tts_notify_publication( $post_id, 'error', 'youtube' );
-                return new \WP_Error( 'youtube_video_missing', $error );
-            }
-            $snippet = array(
-                'title'           => get_the_title( $post_id ),
-                'description'     => $message,
-                'categoryId'      => '22',
-                'shortsVideoType' => 'SHORTS',
-            );
-            $status = array(
-                'privacyStatus'  => 'public',
-                'shortsEligible' => true,
-            );
-            $metadata = array(
-                'snippet' => $snippet,
-                'status'  => $status,
-            );
-            if ( $lat && $lng ) {
-                $metadata['recordingDetails'] = array(
-                    'location' => array(
-                        'latitude'  => (float) $lat,
-                        'longitude' => (float) $lng,
-                    ),
-                );
-            }
-            $endpoint = 'https://www.googleapis.com/upload/youtube/v3/videos?part=snippet,status';
-            if ( $lat && $lng ) {
-                $endpoint .= ',recordingDetails';
-            }
-            $endpoint .= '&uploadType=resumable';
-            $init     = wp_remote_request(
-                $endpoint,
+            $video_path    = get_attached_file( $video_id );
+            $upload_result = $this->upload_media(
+                $video_path,
                 array(
-                    'method'  => 'POST',
-                    'headers' => array(
-                        'Authorization'           => 'Bearer ' . $access_tok,
-                        'Content-Type'            => 'application/json; charset=UTF-8',
-                        'X-Upload-Content-Type'   => 'video/mp4',
-                        'X-Upload-Content-Length' => filesize( $video_path ),
-                    ),
-                    'body'    => wp_json_encode( $metadata ),
-                    'timeout' => 60,
+                    'post_id'     => $post_id,
+                    'token'       => $access_tok,
+                    'credentials' => $creds,
+                    'client_id'   => $client_id,
+                    'message'     => $message,
+                    'title'       => get_the_title( $post_id ),
+                    'lat'         => $lat,
+                    'lng'         => $lng,
+                    'media_id'    => $video_id,
                 )
             );
-            if ( is_wp_error( $init ) ) {
-                $error = $init->get_error_message();
-                tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+
+            if ( empty( $upload_result['success'] ) ) {
                 tts_notify_publication( $post_id, 'error', 'youtube' );
-                return $init;
-            }
-            $upload_url = wp_remote_retrieve_header( $init, 'location' );
-            if ( empty( $upload_url ) ) {
-                $error = __( 'Upload URL missing', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'youtube', 'error', $error, '' );
-                tts_notify_publication( $post_id, 'error', 'youtube' );
-                return new \WP_Error( 'youtube_no_upload_url', $error );
-            }
-            $upload = wp_remote_request(
-                $upload_url,
-                array(
-                    'method'  => 'PUT',
-                    'headers' => array(
-                        'Content-Type'   => 'video/mp4',
-                        'Content-Length' => filesize( $video_path ),
-                    ),
-                    'body'    => file_get_contents( $video_path ),
-                    'timeout' => 60,
-                )
-            );
-            if ( is_wp_error( $upload ) ) {
-                $error = $upload->get_error_message();
-                tts_log_event( $post_id, 'youtube', 'error', $error, '' );
-                tts_notify_publication( $post_id, 'error', 'youtube' );
-                return $upload;
-            }
-            $code = wp_remote_retrieve_response_code( $upload );
-            $data = json_decode( wp_remote_retrieve_body( $upload ), true );
-            if ( 200 !== $code || empty( $data['id'] ) ) {
-                $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
-                tts_log_event( $post_id, 'youtube', 'error', $error, $data );
-                tts_notify_publication( $post_id, 'error', 'youtube' );
-                return new \WP_Error( 'youtube_error', $error, $data );
+                $error_code = $upload_result['error_code'] ?? 'youtube_error';
+                $error_data = $upload_result['error_data'] ?? array();
+                $error_msg  = $upload_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+
+                return new \WP_Error( $error_code, $error_msg, $error_data );
             }
         }
         $response = __( 'Published to YouTube', 'trello-social-auto-publisher' );
         tts_log_event( $post_id, 'youtube', 'success', $response, '' );
         tts_notify_publication( $post_id, 'success', 'youtube' );
         return $response;
+}
+
+    /**
+     * Resolve YouTube access token from credentials.
+     *
+     * @param mixed $credentials Raw credentials data.
+     * @param int   $post_id     Related post ID.
+     * @param mixed $client_id   Optional client post ID storing the token.
+     * @return array Array containing access token, normalized credentials, and client ID.
+     */
+    private function resolve_access_token( $credentials, $post_id, $client_id = '' ) {
+        $client_id = $client_id ?: get_post_meta( $post_id, '_tts_client_id', true );
+        $creds     = is_string( $credentials ) ? json_decode( $credentials, true ) : $credentials;
+        $access_tok = '';
+
+        if ( is_array( $creds ) ) {
+            $access_tok = $creds['access_token'] ?? '';
+
+            if ( empty( $access_tok ) && ! empty( $creds['refresh_token'] ) && ! empty( $creds['client_id'] ) && ! empty( $creds['client_secret'] ) ) {
+                $token_resp = wp_remote_post(
+                    'https://oauth2.googleapis.com/token',
+                    array(
+                        'body'    => array(
+                            'client_id'     => $creds['client_id'],
+                            'client_secret' => $creds['client_secret'],
+                            'refresh_token' => $creds['refresh_token'],
+                            'grant_type'    => 'refresh_token',
+                            'scope'         => 'https://www.googleapis.com/auth/youtube.upload',
+                        ),
+                        'timeout' => 20,
+                    )
+                );
+
+                if ( ! is_wp_error( $token_resp ) ) {
+                    $token_body = json_decode( wp_remote_retrieve_body( $token_resp ), true );
+                    if ( ! empty( $token_body['access_token'] ) ) {
+                        $access_tok            = $token_body['access_token'];
+                        $creds['access_token'] = $access_tok;
+
+                        if ( $client_id ) {
+                            update_post_meta( $client_id, '_tts_yt_token', wp_json_encode( $creds ) );
+                        }
+                    }
+                }
+            }
+        } else {
+            $access_tok = $credentials;
+        }
+
+        return array( $access_tok, $creds, $client_id );
     }
 }


### PR DESCRIPTION
## Summary
- add `upload_media` helpers to Facebook, Instagram, TikTok and YouTube publishers and refactor their publish flows to reuse the API upload logic
- expose upload support for Facebook and Instagram story publishers and ensure logging/notifications remain consistent
- enhance `retry_api_upload()` to forward context metadata and surface uniform success/error results when invoking the new helpers

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook-story.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram-story.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php

------
https://chatgpt.com/codex/tasks/task_e_68cad9a8fd5c832fa7849da9812672ae