### PR TITLE
Make system health score accessible

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-performance.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-performance.php
@@ -257,7 +257,7 @@ class TTS_Performance {
      *
      * @return int Health score (0-100).
      */
-    private static function get_system_health_score() {
+    public static function get_system_health_score() {
         $score = 100;
         $checks = array();
         


### PR DESCRIPTION
## Summary
- change the visibility of TTS_Performance::get_system_health_score to public so external callers can use it

## Testing
- php /tmp/test_system_health.php

------
https://chatgpt.com/codex/tasks/task_e_68cb21392968832fbc68121575cfad14