### PR TITLE
Fix log queries to use channel column

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -1230,7 +1230,7 @@ class TTS_Admin {
         
         // Get recent activity logs
         $recent_logs = $wpdb->get_results( $wpdb->prepare( "
-            SELECT event_type, status, message, created_at
+            SELECT channel, status, message, created_at
             FROM {$wpdb->prefix}tts_logs
             WHERE created_at >= DATE_SUB(NOW(), INTERVAL %d HOUR)
             ORDER BY created_at DESC
@@ -1249,10 +1249,12 @@ class TTS_Admin {
                 $status_icon = $log['status'] === 'success' ? '✅' : 
                               ( $log['status'] === 'error' ? '❌' : '⚠️' );
                 
+                $channel = ! empty( $log['channel'] ) ? $log['channel'] : __( 'Unknown channel', 'trello-social-auto-publisher' );
+
                 echo '<div class="tts-timeline-item">';
                 echo '<div class="tts-timeline-icon">' . $status_icon . '</div>';
                 echo '<div class="tts-timeline-content">';
-                echo '<div class="tts-timeline-event">' . esc_html( $log['event_type'] ) . '</div>';
+                echo '<div class="tts-timeline-event">' . esc_html( $channel ) . '</div>';
                 echo '<div class="tts-timeline-message">' . esc_html( wp_trim_words( $log['message'], 10 ) ) . '</div>';
                 echo '<div class="tts-timeline-time">' . esc_html( human_time_diff( strtotime( $log['created_at'] ) ) ) . ' ago</div>';
                 echo '</div>';

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-monitoring.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-monitoring.php
@@ -438,9 +438,38 @@ class TTS_Monitoring {
      */
     private static function get_daily_stats() {
         global $wpdb;
-        
+
         $today = current_time( 'Y-m-d' );
-        
+        $api_channels = array(
+            'facebook',
+            'instagram',
+            'youtube',
+            'tiktok',
+            'blog',
+            'facebook_story',
+            'instagram_story',
+            'trello',
+            'webhook',
+        );
+
+        $api_calls = 0;
+
+        if ( ! empty( $api_channels ) ) {
+            $placeholders = implode( ', ', array_fill( 0, count( $api_channels ), '%s' ) );
+            $query_args   = array_merge( $api_channels, array( $today ) );
+
+            $api_calls = (int) $wpdb->get_var(
+                $wpdb->prepare(
+                    "
+                        SELECT COUNT(*) FROM {$wpdb->prefix}tts_logs
+                        WHERE channel IN ($placeholders)
+                        AND DATE(created_at) = %s
+                    ",
+                    $query_args
+                )
+            );
+        }
+
         return array(
             'posts_created' => $wpdb->get_var( $wpdb->prepare( "
                 SELECT COUNT(*) FROM {$wpdb->posts}
@@ -458,11 +487,7 @@ class TTS_Monitoring {
                 WHERE status = 'error'
                 AND DATE(created_at) = %s
             ", $today ) ),
-            'api_calls' => $wpdb->get_var( $wpdb->prepare( "
-                SELECT COUNT(*) FROM {$wpdb->prefix}tts_logs
-                WHERE event_type LIKE '%api%'
-                AND DATE(created_at) = %s
-            ", $today ) )
+            'api_calls' => $api_calls,
         );
     }
     


### PR DESCRIPTION
## Summary
- update the dashboard timeline query to pull the `channel` field from the custom logs table and render it safely
- adjust daily monitoring stats to count API calls via the real `channel` column instead of the removed `event_type`

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-monitoring.php

------
https://chatgpt.com/codex/tasks/task_e_68cb225d47f8832fa0cd8991e4d953d2