### PR TITLE
Align social publish hook arguments with new scheduler signature

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -2172,8 +2172,9 @@ class TTS_Admin {
                 wp_die( esc_html__( 'Sorry, you are not allowed to publish this post.', 'trello-social-auto-publisher' ) );
             }
 
-            check_admin_referer( 'tts_publish_social_post_' . absint( $_GET['post'] ) );
-            do_action( 'tts_publish_social_post', array( 'post_id' => absint( $_GET['post'] ) ) );
+            $post_id = absint( $_GET['post'] );
+            check_admin_referer( 'tts_publish_social_post_' . $post_id );
+            do_action( 'tts_publish_social_post', $post_id );
             echo '<div class="notice notice-success"><p>' . esc_html__( 'Post published.', 'trello-social-auto-publisher' ) . '</p></div>';
         }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
@@ -482,15 +482,10 @@ class TTS_Error_Recovery {
             );
         }
 
-        $args = array( 'post_id' => $post_id );
-        if ( $channel ) {
-            $args['channel'] = $channel;
-        }
-
         $previous_status = get_post_meta( $post_id, '_published_status', true );
 
         try {
-            do_action( 'tts_publish_social_post', $args );
+            do_action( 'tts_publish_social_post', $post_id, $channel );
         } catch ( Throwable $throwable ) {
             return array(
                 'success' => false,

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-frequency-monitor.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-frequency-monitor.php
@@ -20,7 +20,7 @@ class TTS_Frequency_Monitor {
     public function __construct() {
         add_action( 'init', array( $this, 'schedule_frequency_check' ) );
         add_action( 'tts_check_publishing_frequencies', array( $this, 'check_all_clients' ) );
-        add_action( 'tts_publish_social_post', array( $this, 'record_publication' ), 20 );
+        add_action( 'tts_publish_social_post', array( $this, 'record_publication' ), 20, 2 );
     }
 
     /**
@@ -135,12 +135,19 @@ class TTS_Frequency_Monitor {
     /**
      * Record a publication when a post is published.
      *
-     * @param array $args Action Scheduler arguments from publish action.
+     * @param int|array $post_id Post ID or legacy argument array.
+     * @param string    $channel Channel slug if explicitly provided.
      */
-    public function record_publication( $args ) {
-        $post_id = isset( $args['post_id'] ) ? intval( $args['post_id'] ) : 0;
-        $channel = isset( $args['channel'] ) ? sanitize_text_field( $args['channel'] ) : '';
-        
+    public function record_publication( $post_id, $channel = '' ) {
+        if ( is_array( $post_id ) ) {
+            $args    = $post_id;
+            $post_id = isset( $args['post_id'] ) ? intval( $args['post_id'] ) : ( isset( $args[0] ) ? intval( $args[0] ) : 0 );
+            $channel = isset( $args['channel'] ) ? $args['channel'] : ( isset( $args[1] ) ? $args[1] : '' );
+        }
+
+        $post_id = intval( $post_id );
+        $channel = is_string( $channel ) ? sanitize_text_field( $channel ) : '';
+
         if ( ! $post_id ) {
             return;
         }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
@@ -69,7 +69,7 @@ class TTS_REST {
         $id = intval( $request['id'] );
 
         // Trigger publish via scheduler using the registered action hook.
-        do_action( 'tts_publish_social_post', array( 'post_id' => $id ) );
+        do_action( 'tts_publish_social_post', $id );
 
         return rest_ensure_response( array( 'post_id' => $id ) );
     }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -19,7 +19,7 @@ class TTS_Scheduler {
      */
     public function __construct() {
         add_action( 'save_post_tts_social_post', array( $this, 'schedule_post' ), 10, 3 );
-        add_action( 'tts_publish_social_post', array( $this, 'publish_social_post' ) );
+        add_action( 'tts_publish_social_post', array( $this, 'publish_social_post' ), 10, 2 );
     }
 
     /**
@@ -47,7 +47,8 @@ class TTS_Scheduler {
             }
         }
 
-        as_unschedule_all_actions( 'tts_publish_social_post', array( 'post_id' => $post_id ) );
+        $existing_channels = get_post_meta( $post_id, '_tts_social_channel', true );
+        $this->unschedule_post_actions( $post_id, $existing_channels );
 
         $approved  = isset( $_POST['_tts_approved'] ) ? (bool) sanitize_text_field( $_POST['_tts_approved'] ) : (bool) get_post_meta( $post_id, '_tts_approved', true );
         if ( ! $approved ) {
@@ -60,28 +61,72 @@ class TTS_Scheduler {
         if ( ! empty( $publish_at ) ) {
             $timestamp = strtotime( $publish_at );
             if ( $timestamp ) {
+                $channels = is_array( $channels ) ? $channels : ( $channels ? array( $channels ) : array() );
+                $this->unschedule_post_actions( $post_id, $channels );
+
                 if ( ! empty( $channels ) ) {
                     $options = get_option( 'tts_settings', array() );
                     foreach ( $channels as $channel ) {
                         $offset = isset( $options[ $channel . '_offset' ] ) ? intval( $options[ $channel . '_offset' ] ) : 0;
                         $when   = $timestamp + $offset * MINUTE_IN_SECONDS;
-                        as_schedule_single_action( $when, 'tts_publish_social_post', array( 'post_id' => $post_id, 'channel' => $channel ) );
+                        as_schedule_single_action( $when, 'tts_publish_social_post', array( $post_id, $channel ) );
                     }
                 } else {
-                    as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( 'post_id' => $post_id ) );
+                    as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( $post_id ) );
                 }
             }
         }
     }
 
     /**
+     * Unschedule any pending publish actions for a post.
+     *
+     * @param int          $post_id  Post ID.
+     * @param string|array $channels Optional channel or list of channels.
+     */
+    private function unschedule_post_actions( $post_id, $channels = array() ) {
+        $post_id = absint( $post_id );
+
+        if ( ! $post_id ) {
+            return;
+        }
+
+        as_unschedule_all_actions( 'tts_publish_social_post', array( $post_id ) );
+        as_unschedule_all_actions( 'tts_publish_social_post', array( 'post_id' => $post_id ) );
+
+        if ( empty( $channels ) ) {
+            return;
+        }
+
+        if ( ! is_array( $channels ) ) {
+            $channels = array( $channels );
+        }
+
+        foreach ( $channels as $channel ) {
+            if ( ! is_string( $channel ) || '' === $channel ) {
+                continue;
+            }
+
+            as_unschedule_all_actions( 'tts_publish_social_post', array( $post_id, $channel ) );
+            as_unschedule_all_actions( 'tts_publish_social_post', array( 'post_id' => $post_id, 'channel' => $channel ) );
+        }
+    }
+
+    /**
      * Publish the social post to configured networks.
      *
-     * @param array $args Action Scheduler arguments.
+     * @param int|array $post_id Post ID or legacy argument array.
+     * @param string    $channel Optional channel override.
      */
-    public function publish_social_post( $args ) {
-        $post_id       = isset( $args['post_id'] ) ? intval( $args['post_id'] ) : 0;
-        $forced_channel = isset( $args['channel'] ) ? sanitize_text_field( $args['channel'] ) : '';
+    public function publish_social_post( $post_id, $channel = '' ) {
+        if ( is_array( $post_id ) ) {
+            $args    = $post_id;
+            $post_id = isset( $args['post_id'] ) ? intval( $args['post_id'] ) : ( isset( $args[0] ) ? intval( $args[0] ) : 0 );
+            $channel = isset( $args['channel'] ) ? $args['channel'] : ( isset( $args[1] ) ? $args[1] : '' );
+        }
+
+        $post_id        = intval( $post_id );
+        $forced_channel = is_string( $channel ) ? sanitize_text_field( $channel ) : '';
         if ( ! $post_id ) {
             return;
         }
@@ -276,7 +321,7 @@ class TTS_Scheduler {
 
             $delay     = $this->calculate_backoff_delay( $attempt );
             $timestamp = time() + $delay * MINUTE_IN_SECONDS;
-            as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( 'post_id' => $post_id ) );
+            as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( $post_id ) );
 
             tts_log_event( $post_id, 'scheduler', 'retry', sprintf( __( 'Retry #%1$d scheduled in %2$d minutes', 'trello-social-auto-publisher' ), $attempt, $delay ), '' );
             return;

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
@@ -389,7 +389,7 @@ class TTS_Webhook {
                 update_post_meta( $post_id, '_tts_publish_at', $publish_at );
                 $timestamp = strtotime( $publish_at );
                 if ( $timestamp ) {
-                    as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( 'post_id' => $post_id ) );
+                    as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( $post_id ) );
                     tts_log_event(
                         $post_id,
                         'webhook',


### PR DESCRIPTION
## Summary
- update the scheduler to accept scalar arguments for the publish action, gracefully handle legacy payloads, and ensure pending jobs are unscheduled before rescheduling
- adjust the frequency monitor subscriber to the new action signature and keep channel logging intact for both legacy and updated triggers
- standardize manual triggers, error recovery, REST, and webhook scheduling to pass positional arguments to the publish hook

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-frequency-monitor.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php

------
https://chatgpt.com/codex/tasks/task_e_68cb26be2c7c832f85c6ac068915add5