### PR TITLE
Update client wizard slug references

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -1549,7 +1549,7 @@ class TTS_Admin {
             echo '<span style="font-size: 48px; margin-bottom: 10px; display: block;">📝</span>';
             echo '<p style="margin: 0; font-size: 16px;">' . esc_html__('No social posts found.', 'trello-social-auto-publisher') . '</p>';
             echo '<p style="margin: 5px 0 0 0; font-size: 14px;">' . esc_html__('Create your first social media post to get started!', 'trello-social-auto-publisher') . '</p>';
-            echo '<a href="' . esc_url(admin_url('admin.php?page=tts-client-wizard')) . '" class="tts-btn" style="margin-top: 15px;">';
+            echo '<a href="' . esc_url(admin_url('admin.php?page=fp-publisher-client-wizard')) . '" class="tts-btn" style="margin-top: 15px;">';
             echo esc_html__('Add New Client', 'trello-social-auto-publisher');
             echo '</a>';
             echo '</div>';
@@ -1611,7 +1611,7 @@ class TTS_Admin {
             array(
                 'title' => __('Add New Client', 'trello-social-auto-publisher'),
                 'description' => __('Set up a new social media client', 'trello-social-auto-publisher'),
-                'url' => admin_url('admin.php?page=tts-client-wizard'),
+                'url' => admin_url('admin.php?page=fp-publisher-client-wizard'),
                 'icon' => 'dashicons-plus',
                 'color' => '#135e96'
             ),
@@ -2920,7 +2920,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                         <a href="<?php echo esc_url( admin_url( 'admin.php?page=tts-social-connections' ) ); ?>" class="button button-primary">
                             <?php esc_html_e( 'Configure Social Apps', 'trello-social-auto-publisher' ); ?>
                         </a>
-                        <a href="<?php echo esc_url( admin_url( 'admin.php?page=tts-client-wizard' ) ); ?>" class="button">
+                        <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-publisher-client-wizard' ) ); ?>" class="button">
                             <?php esc_html_e( 'Create Client', 'trello-social-auto-publisher' ); ?>
                         </a>
                     </div>

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-advanced-features.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-advanced-features.js
@@ -24,7 +24,7 @@ class TTSAdvancedFeatures {
         this.shortcuts.set('ctrl+shift+a', () => this.navigateTo('tts-analytics'));
         this.shortcuts.set('ctrl+shift+h', () => this.navigateTo('tts-health'));
         this.shortcuts.set('ctrl+shift+l', () => this.navigateTo('tts-log'));
-        this.shortcuts.set('ctrl+shift+n', () => this.navigateTo('tts-client-wizard'));
+        this.shortcuts.set('ctrl+shift+n', () => this.navigateTo('fp-publisher-client-wizard'));
         this.shortcuts.set('ctrl+shift+r', () => this.refreshCurrentPage());
         this.shortcuts.set('ctrl+shift+e', () => this.openExportModal());
         this.shortcuts.set('ctrl+shift+i', () => this.openImportModal());

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
@@ -751,7 +751,7 @@ class TTS_Client {
             set_transient( 'tts_oauth_' . $channel . '_token', $token, 15 * MINUTE_IN_SECONDS );
         }
 
-        wp_safe_redirect( add_query_arg( array( 'page' => 'tts-client-wizard', 'step' => $step ), admin_url( 'admin.php' ) ) );
+        wp_safe_redirect( add_query_arg( array( 'page' => 'fp-publisher-client-wizard', 'step' => $step ), admin_url( 'admin.php' ) ) );
         exit;
     }
 


### PR DESCRIPTION
## Summary
- update the OAuth handler redirect to use the fp-publisher client wizard slug
- replace remaining admin.php links to the new client wizard slug in PHP and JS

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cbbc5e7514832f92f0277157504339