### PR TITLE
Update log page slug references

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -1646,7 +1646,7 @@ class TTS_Admin {
             array(
                 'title' => __('View Logs', 'trello-social-auto-publisher'),
                 'description' => __('Check system logs and debugging info', 'trello-social-auto-publisher'),
-                'url' => admin_url('admin.php?page=tts-log'),
+                'url' => admin_url('admin.php?page=fp-publisher-log'),
                 'icon' => 'dashicons-list-view',
                 'color' => '#64748b'
             )

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-log-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-log-page.php
@@ -36,7 +36,7 @@ class TTS_Log_Page {
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__( 'Log', 'trello-social-auto-publisher' ) . '</h1>';
         echo '<form method="get">';
-        echo '<input type="hidden" name="page" value="tts-log" />';
+        echo '<input type="hidden" name="page" value="fp-publisher-log" />';
         $table->display();
         echo '</form>';
         echo '</div>';

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-advanced-features.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-advanced-features.js
@@ -23,7 +23,7 @@ class TTSAdvancedFeatures {
         this.shortcuts.set('ctrl+shift+c', () => this.navigateTo('tts-calendar'));
         this.shortcuts.set('ctrl+shift+a', () => this.navigateTo('tts-analytics'));
         this.shortcuts.set('ctrl+shift+h', () => this.navigateTo('tts-health'));
-        this.shortcuts.set('ctrl+shift+l', () => this.navigateTo('tts-log'));
+        this.shortcuts.set('ctrl+shift+l', () => this.navigateTo('fp-publisher-log'));
         this.shortcuts.set('ctrl+shift+n', () => this.navigateTo('fp-publisher-client-wizard'));
         this.shortcuts.set('ctrl+shift+r', () => this.refreshCurrentPage());
         this.shortcuts.set('ctrl+shift+e', () => this.openExportModal());
@@ -1035,7 +1035,7 @@ class TTSAdvancedFeatures {
                 case 'tts-health':
                     helpContent = this.getHealthHelp();
                     break;
-                case 'tts-log':
+                case 'fp-publisher-log':
                     helpContent = this.getLogHelp();
                     break;
                 default:

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -309,7 +309,7 @@ class TTS_Scheduler {
         if ( $error ) {
             if ( $attempt >= $max_attempts ) {
                 tts_log_event( $post_id, 'scheduler', 'error', __( 'Maximum retry attempts reached', 'trello-social-auto-publisher' ), '' );
-                $log_url = admin_url( 'admin.php?page=tts-log&post_id=' . $post_id );
+                $log_url = admin_url( 'admin.php?page=fp-publisher-log&post_id=' . $post_id );
                 $message = sprintf( __( 'Publishing failed for post %1$s. Log: %2$s', 'trello-social-auto-publisher' ), get_the_title( $post_id ), $log_url );
                 $notifier->notify_slack( $message );
                 $notifier->notify_email( __( 'Social publishing failed', 'trello-social-auto-publisher' ), $message );
@@ -412,7 +412,7 @@ class TTS_Scheduler {
 
         tts_log_event( $post_id, 'scheduler', 'complete', __( 'Publish process completed', 'trello-social-auto-publisher' ), $log );
 
-        $log_url = admin_url( 'admin.php?page=tts-log&post_id=' . $post_id );
+        $log_url = admin_url( 'admin.php?page=fp-publisher-log&post_id=' . $post_id );
         $message = sprintf( __( 'Publishing completed for post %1$s. Log: %2$s', 'trello-social-auto-publisher' ), get_the_title( $post_id ), $log_url );
         $notifier->notify_slack( $message );
         $notifier->notify_email( __( 'Social publishing completed', 'trello-social-auto-publisher' ), $message );


### PR DESCRIPTION
## Summary
- update admin quick action link to point to the fp-publisher-log page
- adjust scheduler notifications and the log page form to use the fp-publisher-log slug
- align advanced feature JavaScript helpers with the new log page slug

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbcbd384cc832f81a1a8f354b612f0