### PR TITLE
Update FP Publisher slugs for admin helpers

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -1618,28 +1618,28 @@ class TTS_Admin {
             array(
                 'title' => __('View Calendar', 'trello-social-auto-publisher'),
                 'description' => __('See scheduled posts in calendar view', 'trello-social-auto-publisher'),
-                'url' => admin_url('admin.php?page=tts-calendar'),
+                'url' => admin_url('admin.php?page=fp-publisher-calendar'),
                 'icon' => 'dashicons-calendar',
                 'color' => '#f56e28'
             ),
             array(
                 'title' => __('Check Health Status', 'trello-social-auto-publisher'),
                 'description' => __('Monitor system health and tokens', 'trello-social-auto-publisher'),
-                'url' => admin_url('admin.php?page=tts-health'),
+                'url' => admin_url('admin.php?page=fp-publisher-health'),
                 'icon' => 'dashicons-heart',
                 'color' => '#00a32a'
             ),
             array(
                 'title' => __('View Analytics', 'trello-social-auto-publisher'),
                 'description' => __('Analyze performance and engagement', 'trello-social-auto-publisher'),
-                'url' => admin_url('admin.php?page=tts-analytics'),
+                'url' => admin_url('admin.php?page=fp-publisher-analytics'),
                 'icon' => 'dashicons-chart-area',
                 'color' => '#7c3aed'
             ),
             array(
                 'title' => __('Manage Posts', 'trello-social-auto-publisher'),
                 'description' => __('View and manage all social posts', 'trello-social-auto-publisher'),
-                'url' => admin_url('admin.php?page=tts-social-posts'),
+                'url' => admin_url('admin.php?page=fp-publisher-social-posts'),
                 'icon' => 'dashicons-admin-post',
                 'color' => '#2563eb'
             ),

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-advanced-features.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-advanced-features.js
@@ -20,9 +20,9 @@ class TTSAdvancedFeatures {
     setupKeyboardShortcuts() {
         // Define keyboard shortcuts
         this.shortcuts.set('ctrl+shift+d', () => this.navigateTo('fp-publisher-main'));
-        this.shortcuts.set('ctrl+shift+c', () => this.navigateTo('tts-calendar'));
-        this.shortcuts.set('ctrl+shift+a', () => this.navigateTo('tts-analytics'));
-        this.shortcuts.set('ctrl+shift+h', () => this.navigateTo('tts-health'));
+        this.shortcuts.set('ctrl+shift+c', () => this.navigateTo('fp-publisher-calendar'));
+        this.shortcuts.set('ctrl+shift+a', () => this.navigateTo('fp-publisher-analytics'));
+        this.shortcuts.set('ctrl+shift+h', () => this.navigateTo('fp-publisher-health'));
         this.shortcuts.set('ctrl+shift+l', () => this.navigateTo('fp-publisher-log'));
         this.shortcuts.set('ctrl+shift+n', () => this.navigateTo('fp-publisher-client-wizard'));
         this.shortcuts.set('ctrl+shift+r', () => this.refreshCurrentPage());
@@ -138,7 +138,7 @@ class TTSAdvancedFeatures {
 
     addKeyboardShortcutIndicator() {
         const adminBar = document.getElementById('wp-admin-bar-root');
-        if (adminBar && window.location.href.includes('page=tts-')) {
+        if (adminBar && window.location.href.includes('page=fp-publisher-')) {
             const shortcutItem = document.createElement('li');
             shortcutItem.id = 'wp-admin-bar-tts-shortcuts';
             shortcutItem.innerHTML = `
@@ -524,7 +524,7 @@ class TTSAdvancedFeatures {
         document.head.appendChild(controlStyles);
 
         // Add to page if on plugin pages
-        if (window.location.href.includes('page=tts-')) {
+        if (window.location.href.includes('page=fp-publisher-')) {
             document.body.appendChild(controlPanel);
             this.bindControlEvents(controlPanel);
         }
@@ -1026,13 +1026,13 @@ class TTSAdvancedFeatures {
                 case 'fp-publisher-main':
                     helpContent = this.getDashboardHelp();
                     break;
-                case 'tts-calendar':
+                case 'fp-publisher-calendar':
                     helpContent = this.getCalendarHelp();
                     break;
-                case 'tts-analytics':
+                case 'fp-publisher-analytics':
                     helpContent = this.getAnalyticsHelp();
                     break;
-                case 'tts-health':
+                case 'fp-publisher-health':
                     helpContent = this.getHealthHelp();
                     break;
                 case 'fp-publisher-log':
@@ -1153,7 +1153,7 @@ class TTSAdvancedFeatures {
 
 // Initialize advanced features
 document.addEventListener('DOMContentLoaded', () => {
-    if (window.location.href.includes('page=tts-')) {
+    if (window.location.href.includes('page=fp-publisher-')) {
         window.TTSAdvancedFeatures = new TTSAdvancedFeatures();
     }
 });

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-help-system.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-help-system.js
@@ -48,7 +48,7 @@ class TTSHelpSystem {
                     'Ctrl+Shift+K: Show keyboard shortcuts'
                 ]
             },
-            'tts-calendar': {
+            'fp-publisher-calendar': {
                 title: 'Calendar Help',
                 sections: [
                     {
@@ -67,7 +67,7 @@ class TTSHelpSystem {
                     'Left/Right arrows: Navigate months'
                 ]
             },
-            'tts-analytics': {
+            'fp-publisher-analytics': {
                 title: 'Analytics Help',
                 sections: [
                     {
@@ -86,7 +86,7 @@ class TTSHelpSystem {
                     'Ctrl+Shift+E: Export analytics'
                 ]
             },
-            'tts-health': {
+            'fp-publisher-health': {
                 title: 'Health Status Help',
                 sections: [
                     {
@@ -110,7 +110,7 @@ class TTSHelpSystem {
     addHelpButton() {
         // Add help button to admin bar
         const adminBar = document.getElementById('wp-admin-bar-root');
-        if (adminBar && window.location.href.includes('page=tts-')) {
+        if (adminBar && window.location.href.includes('page=fp-publisher-')) {
             const helpItem = document.createElement('li');
             helpItem.id = 'wp-admin-bar-tts-help';
             helpItem.innerHTML = `
@@ -307,7 +307,7 @@ class TTSHelpSystem {
         document.head.appendChild(helpStyles);
 
         // Add to page if on plugin pages
-        if (window.location.href.includes('page=tts-')) {
+        if (window.location.href.includes('page=fp-publisher-')) {
             document.body.appendChild(floatingHelp);
             this.bindFloatingHelpEvents(floatingHelp);
         }
@@ -704,7 +704,7 @@ class TTSHelpSystem {
 
 // Initialize help system and make it globally available
 document.addEventListener('DOMContentLoaded', () => {
-    if (window.location.href.includes('page=tts-')) {
+    if (window.location.href.includes('page=fp-publisher-')) {
         window.TTSHelpSystem = {
             instance: new TTSHelpSystem(),
             highlightElement: function(selector) {


### PR DESCRIPTION
## Summary
- update dashboard quick action links to point to the fp-publisher calendar, analytics, health, and social posts screens
- align keyboard shortcuts, navigation helpers, and contextual help routing with the fp-publisher page slugs
- refresh help system mappings so page detection and admin bar controls operate on the new slugs

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cbcccf5598832fa5ae2113413c6628