### PR TITLE
Update plugin translations to fp-publisher domain

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -535,10 +535,10 @@ class TTS_Admin {
                 'ajaxUrl' => admin_url( 'admin-ajax.php' ),
                 'nonce'   => wp_create_nonce( 'tts_wizard' ),
                 'strings' => array(
-                    'validating' => __( 'Validating...', 'trello-social-auto-publisher' ),
-                    'connecting' => __( 'Connecting...', 'trello-social-auto-publisher' ),
-                    'success' => __( 'Success!', 'trello-social-auto-publisher' ),
-                    'error' => __( 'Error occurred', 'trello-social-auto-publisher' ),
+                    'validating' => __( 'Validating...', 'fp-publisher' ),
+                    'connecting' => __( 'Connecting...', 'fp-publisher' ),
+                    'success' => __( 'Success!', 'fp-publisher' ),
+                    'error' => __( 'Error occurred', 'fp-publisher' ),
                 )
             )
         );
@@ -575,7 +575,7 @@ class TTS_Admin {
     public function register_scheduled_posts_widget() {
         wp_add_dashboard_widget(
             'tts_scheduled_posts',
-            __( 'Social Post programmati', 'trello-social-auto-publisher' ),
+            __( 'Social Post programmati', 'fp-publisher' ),
             array( $this, 'render_scheduled_posts_widget' )
         );
     }
@@ -616,7 +616,7 @@ class TTS_Admin {
         );
 
         if ( empty( $posts ) ) {
-            $output = '<p>' . esc_html__( 'Nessun post programmato.', 'trello-social-auto-publisher' ) . '</p>';
+            $output = '<p>' . esc_html__( 'Nessun post programmato.', 'fp-publisher' ) . '</p>';
             set_transient( $cache_key, $output, 300 ); // Cache for 5 minutes
             echo $output;
             return;
@@ -710,7 +710,7 @@ class TTS_Admin {
 
         // Check user capabilities
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( __( 'You do not have permission to perform this action.', 'trello-social-auto-publisher' ) );
+            wp_send_json_error( __( 'You do not have permission to perform this action.', 'fp-publisher' ) );
         }
 
         $board = isset( $_POST['board'] ) ? sanitize_text_field( $_POST['board'] ) : '';
@@ -719,18 +719,18 @@ class TTS_Admin {
 
         // Enhanced validation with specific error messages
         if ( empty( $board ) ) {
-            wp_send_json_error( __( 'Board ID is required.', 'trello-social-auto-publisher' ) );
+            wp_send_json_error( __( 'Board ID is required.', 'fp-publisher' ) );
         }
         if ( empty( $key ) ) {
-            wp_send_json_error( __( 'Trello API key is required.', 'trello-social-auto-publisher' ) );
+            wp_send_json_error( __( 'Trello API key is required.', 'fp-publisher' ) );
         }
         if ( empty( $token ) ) {
-            wp_send_json_error( __( 'Trello token is required.', 'trello-social-auto-publisher' ) );
+            wp_send_json_error( __( 'Trello token is required.', 'fp-publisher' ) );
         }
 
         // Validate board ID format (should be 24 character hex string)
         if ( ! preg_match( '/^[a-f0-9]{24}$/i', $board ) ) {
-            wp_send_json_error( __( 'Invalid board ID format.', 'trello-social-auto-publisher' ) );
+            wp_send_json_error( __( 'Invalid board ID format.', 'fp-publisher' ) );
         }
 
         $response = wp_remote_get(
@@ -742,7 +742,7 @@ class TTS_Admin {
             error_log( 'TTS AJAX Error: ' . $response->get_error_message() );
             wp_send_json_error( 
                 sprintf( 
-                    __( 'Failed to connect to Trello API: %s', 'trello-social-auto-publisher' ), 
+                    __( 'Failed to connect to Trello API: %s', 'fp-publisher' ), 
                     $response->get_error_message() 
                 ) 
             );
@@ -753,7 +753,7 @@ class TTS_Admin {
             error_log( "TTS AJAX Error: HTTP $http_code from Trello API" );
             wp_send_json_error( 
                 sprintf( 
-                    __( 'Trello API returned error code %d. Please check your credentials.', 'trello-social-auto-publisher' ), 
+                    __( 'Trello API returned error code %d. Please check your credentials.', 'fp-publisher' ), 
                     $http_code 
                 ) 
             );
@@ -764,7 +764,7 @@ class TTS_Admin {
         
         if ( json_last_error() !== JSON_ERROR_NONE ) {
             error_log( 'TTS AJAX Error: Invalid JSON response from Trello API' );
-            wp_send_json_error( __( 'Invalid response from Trello API.', 'trello-social-auto-publisher' ) );
+            wp_send_json_error( __( 'Invalid response from Trello API.', 'fp-publisher' ) );
         }
 
         wp_send_json_success( $data );
@@ -778,7 +778,7 @@ class TTS_Admin {
 
         // Check user capabilities
         if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( __( 'You do not have permission to view posts.', 'trello-social-auto-publisher' ) );
+            wp_send_json_error( __( 'You do not have permission to view posts.', 'fp-publisher' ) );
         }
 
         try {
@@ -804,7 +804,7 @@ class TTS_Admin {
             if ( empty( $posts ) ) {
                 wp_send_json_success( array(
                     'posts' => array(),
-                    'message' => __( 'No posts found.', 'trello-social-auto-publisher' ),
+                    'message' => __( 'No posts found.', 'fp-publisher' ),
                     'timestamp' => current_time( 'timestamp' )
                 ) );
             }
@@ -832,7 +832,7 @@ class TTS_Admin {
                         '%d post refreshed successfully', 
                         '%d posts refreshed successfully', 
                         count( $formatted_posts ), 
-                        'trello-social-auto-publisher' 
+                        'fp-publisher' 
                     ), 
                     count( $formatted_posts ) 
                 ),
@@ -841,7 +841,7 @@ class TTS_Admin {
 
         } catch ( Exception $e ) {
             error_log( 'TTS Refresh Posts Error: ' . $e->getMessage() );
-            wp_send_json_error( __( 'An error occurred while refreshing posts. Please try again.', 'trello-social-auto-publisher' ) );
+            wp_send_json_error( __( 'An error occurred while refreshing posts. Please try again.', 'fp-publisher' ) );
         }
     }
 
@@ -853,38 +853,38 @@ class TTS_Admin {
 
         // Rate limiting check
         if (!$this->check_rate_limit('delete_post', 20, 60)) {
-            wp_send_json_error(__('Too many delete requests. Please wait a moment and try again.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('Too many delete requests. Please wait a moment and try again.', 'fp-publisher'));
         }
 
         if (!current_user_can('delete_posts')) {
-            wp_send_json_error(__('You do not have permission to delete posts.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('You do not have permission to delete posts.', 'fp-publisher'));
         }
 
         $post_id = isset($_POST['postId']) ? intval($_POST['postId']) : 0;
         
         if (!$post_id || $post_id <= 0) {
-            wp_send_json_error(__('Invalid post ID.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('Invalid post ID.', 'fp-publisher'));
         }
 
         $post = get_post($post_id);
         if (!$post || $post->post_type !== 'tts_social_post') {
-            wp_send_json_error(__('Post not found.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('Post not found.', 'fp-publisher'));
         }
 
         // Check specific delete permission for this post
         if (!current_user_can('delete_post', $post_id)) {
-            wp_send_json_error(__('You do not have permission to delete this specific post.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('You do not have permission to delete this specific post.', 'fp-publisher'));
         }
 
         $result = wp_delete_post($post_id, true);
         
         if ($result) {
             wp_send_json_success(array(
-                'message' => __('Post deleted successfully.', 'trello-social-auto-publisher'),
+                'message' => __('Post deleted successfully.', 'fp-publisher'),
                 'refresh' => true
             ));
         } else {
-            wp_send_json_error(__('Failed to delete post.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('Failed to delete post.', 'fp-publisher'));
         }
     }
 
@@ -896,11 +896,11 @@ class TTS_Admin {
 
         // Rate limiting check
         if (!$this->check_rate_limit('bulk_action', 10, 60)) {
-            wp_send_json_error(__('Too many requests. Please wait a moment and try again.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('Too many requests. Please wait a moment and try again.', 'fp-publisher'));
         }
 
         if (!current_user_can('edit_posts')) {
-            wp_send_json_error(__('You do not have permission to perform this action.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('You do not have permission to perform this action.', 'fp-publisher'));
         }
 
         $action = isset($_POST['bulkAction']) ? sanitize_text_field($_POST['bulkAction']) : '';
@@ -908,18 +908,18 @@ class TTS_Admin {
 
         // Input validation
         if (!$action || empty($post_ids)) {
-            wp_send_json_error(__('Invalid action or no posts selected.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('Invalid action or no posts selected.', 'fp-publisher'));
         }
 
         // Validate action is allowed
         $allowed_actions = array('delete', 'approve', 'revoke');
         if (!in_array($action, $allowed_actions, true)) {
-            wp_send_json_error(__('Invalid action specified.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('Invalid action specified.', 'fp-publisher'));
         }
 
         // Limit number of posts that can be processed at once
         if (count($post_ids) > 100) {
-            wp_send_json_error(__('Too many posts selected. Please select 100 or fewer posts.', 'trello-social-auto-publisher'));
+            wp_send_json_error(__('Too many posts selected. Please select 100 or fewer posts.', 'fp-publisher'));
         }
 
         $processed = 0;
@@ -928,13 +928,13 @@ class TTS_Admin {
         foreach ($post_ids as $post_id) {
             // Additional validation for each post ID
             if ($post_id <= 0) {
-                $errors[] = __('Invalid post ID provided.', 'trello-social-auto-publisher');
+                $errors[] = __('Invalid post ID provided.', 'fp-publisher');
                 continue;
             }
 
             $post = get_post($post_id);
             if (!$post || $post->post_type !== 'tts_social_post') {
-                $errors[] = sprintf(__('Post ID %d not found.', 'trello-social-auto-publisher'), $post_id);
+                $errors[] = sprintf(__('Post ID %d not found.', 'fp-publisher'), $post_id);
                 continue;
             }
 
@@ -944,10 +944,10 @@ class TTS_Admin {
                         if (wp_delete_post($post_id, true)) {
                             $processed++;
                         } else {
-                            $errors[] = sprintf(__('Failed to delete post ID %d.', 'trello-social-auto-publisher'), $post_id);
+                            $errors[] = sprintf(__('Failed to delete post ID %d.', 'fp-publisher'), $post_id);
                         }
                     } else {
-                        $errors[] = sprintf(__('You do not have permission to delete post ID %d.', 'trello-social-auto-publisher'), $post_id);
+                        $errors[] = sprintf(__('You do not have permission to delete post ID %d.', 'fp-publisher'), $post_id);
                     }
                     break;
 
@@ -958,7 +958,7 @@ class TTS_Admin {
                         do_action('tts_post_approved', $post_id);
                         $processed++;
                     } else {
-                        $errors[] = sprintf(__('You do not have permission to approve post ID %d.', 'trello-social-auto-publisher'), $post_id);
+                        $errors[] = sprintf(__('You do not have permission to approve post ID %d.', 'fp-publisher'), $post_id);
                     }
                     break;
 
@@ -968,7 +968,7 @@ class TTS_Admin {
                         do_action('save_post_tts_social_post', $post_id, $post, true);
                         $processed++;
                     } else {
-                        $errors[] = sprintf(__('You do not have permission to revoke approval for post ID %d.', 'trello-social-auto-publisher'), $post_id);
+                        $errors[] = sprintf(__('You do not have permission to revoke approval for post ID %d.', 'fp-publisher'), $post_id);
                     }
                     break;
             }
@@ -980,13 +980,13 @@ class TTS_Admin {
                     '%d post processed successfully.',
                     '%d posts processed successfully.',
                     $processed,
-                    'trello-social-auto-publisher'
+                    'fp-publisher'
                 ),
                 $processed
             );
 
             if (!empty($errors)) {
-                $message .= ' ' . sprintf(__('However, %d errors occurred.', 'trello-social-auto-publisher'), count($errors));
+                $message .= ' ' . sprintf(__('However, %d errors occurred.', 'fp-publisher'), count($errors));
             }
 
             wp_send_json_success(array(
@@ -996,7 +996,7 @@ class TTS_Admin {
                 'refresh' => true
             ));
         } else {
-            wp_send_json_error(__('No posts were processed.', 'trello-social-auto-publisher') . ' ' . implode(' ', $errors));
+            wp_send_json_error(__('No posts were processed.', 'fp-publisher') . ' ' . implode(' ', $errors));
         }
     }
 
@@ -1005,7 +1005,7 @@ class TTS_Admin {
      */
     public function render_dashboard_page() {
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Social Auto Publisher Dashboard', 'trello-social-auto-publisher' ) . '</h1>';
+        echo '<h1>' . esc_html__( 'Social Auto Publisher Dashboard', 'fp-publisher' ) . '</h1>';
         
         // Add notification area
         echo '<div id="tts-notification-area" style="margin: 15px 0;"></div>';
@@ -1071,7 +1071,7 @@ class TTS_Admin {
      */
     private function render_monitoring_dashboard() {
         echo '<div class="tts-monitoring-section">';
-        echo '<h2>' . esc_html__( 'System Monitoring', 'trello-social-auto-publisher' ) . '</h2>';
+        echo '<h2>' . esc_html__( 'System Monitoring', 'fp-publisher' ) . '</h2>';
         
         echo '<div class="tts-monitoring-grid">';
         
@@ -1099,9 +1099,9 @@ class TTS_Admin {
         
         echo '<div class="tts-monitoring-card tts-health-score-card">';
         echo '<div class="tts-card-header">';
-        echo '<h3>' . esc_html__( 'System Health', 'trello-social-auto-publisher' ) . '</h3>';
-        echo '<button class="tts-btn small" data-ajax-action="tts_refresh_health" data-loading-text="' . esc_attr__( 'Checking...', 'trello-social-auto-publisher' ) . '">';
-        echo esc_html__( 'Refresh', 'trello-social-auto-publisher' );
+        echo '<h3>' . esc_html__( 'System Health', 'fp-publisher' ) . '</h3>';
+        echo '<button class="tts-btn small" data-ajax-action="tts_refresh_health" data-loading-text="' . esc_attr__( 'Checking...', 'fp-publisher' ) . '">';
+        echo esc_html__( 'Refresh', 'fp-publisher' );
         echo '</button>';
         echo '</div>';
         
@@ -1132,7 +1132,7 @@ class TTS_Admin {
         
         echo '<div class="tts-monitoring-card">';
         echo '<div class="tts-card-header">';
-        echo '<h3>' . esc_html__( 'Performance Metrics', 'trello-social-auto-publisher' ) . '</h3>';
+        echo '<h3>' . esc_html__( 'Performance Metrics', 'fp-publisher' ) . '</h3>';
         echo '</div>';
         
         echo '<div class="tts-metrics-display">';
@@ -1191,7 +1191,7 @@ class TTS_Admin {
         
         echo '<div class="tts-monitoring-card">';
         echo '<div class="tts-card-header">';
-        echo '<h3>' . esc_html__( 'API Connections', 'trello-social-auto-publisher' ) . '</h3>';
+        echo '<h3>' . esc_html__( 'API Connections', 'fp-publisher' ) . '</h3>';
         echo '</div>';
         
         echo '<div class="tts-api-status-display">';
@@ -1215,7 +1215,7 @@ class TTS_Admin {
                 echo '</div>';
             }
         } else {
-            echo '<p class="tts-no-data">' . esc_html__( 'No API connection data available', 'trello-social-auto-publisher' ) . '</p>';
+            echo '<p class="tts-no-data">' . esc_html__( 'No API connection data available', 'fp-publisher' ) . '</p>';
         }
         
         echo '</div>';
@@ -1239,7 +1239,7 @@ class TTS_Admin {
         
         echo '<div class="tts-monitoring-card tts-activity-timeline">';
         echo '<div class="tts-card-header">';
-        echo '<h3>' . esc_html__( 'Recent Activity', 'trello-social-auto-publisher' ) . '</h3>';
+        echo '<h3>' . esc_html__( 'Recent Activity', 'fp-publisher' ) . '</h3>';
         echo '</div>';
         
         echo '<div class="tts-timeline-container">';
@@ -1249,7 +1249,7 @@ class TTS_Admin {
                 $status_icon = $log['status'] === 'success' ? '✅' : 
                               ( $log['status'] === 'error' ? '❌' : '⚠️' );
                 
-                $channel = ! empty( $log['channel'] ) ? $log['channel'] : __( 'Unknown channel', 'trello-social-auto-publisher' );
+                $channel = ! empty( $log['channel'] ) ? $log['channel'] : __( 'Unknown channel', 'fp-publisher' );
 
                 echo '<div class="tts-timeline-item">';
                 echo '<div class="tts-timeline-icon">' . $status_icon . '</div>';
@@ -1261,7 +1261,7 @@ class TTS_Admin {
                 echo '</div>';
             }
         } else {
-            echo '<p class="tts-no-data">' . esc_html__( 'No recent activity', 'trello-social-auto-publisher' ) . '</p>';
+            echo '<p class="tts-no-data">' . esc_html__( 'No recent activity', 'fp-publisher' ) . '</p>';
         }
         
         echo '</div>';
@@ -1273,42 +1273,42 @@ class TTS_Admin {
      */
     private function render_advanced_tools_section() {
         echo '<div class="tts-advanced-tools-section">';
-        echo '<h2>' . esc_html__( 'Advanced Tools', 'trello-social-auto-publisher' ) . '</h2>';
+        echo '<h2>' . esc_html__( 'Advanced Tools', 'fp-publisher' ) . '</h2>';
         
         echo '<div class="tts-tools-grid">';
         
         // Export/Import Tools
         echo '<div class="tts-tool-card">';
-        echo '<h3>📦 ' . esc_html__( 'Export & Import', 'trello-social-auto-publisher' ) . '</h3>';
-        echo '<p>' . esc_html__( 'Backup your settings and data or migrate from another installation.', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<h3>📦 ' . esc_html__( 'Export & Import', 'fp-publisher' ) . '</h3>';
+        echo '<p>' . esc_html__( 'Backup your settings and data or migrate from another installation.', 'fp-publisher' ) . '</p>';
         echo '<div class="tts-tool-actions">';
         echo '<button class="tts-btn primary" data-ajax-action="tts_show_export_modal">';
-        echo esc_html__( 'Export Data', 'trello-social-auto-publisher' );
+        echo esc_html__( 'Export Data', 'fp-publisher' );
         echo '</button>';
         echo '<button class="tts-btn secondary" data-ajax-action="tts_show_import_modal">';
-        echo esc_html__( 'Import Data', 'trello-social-auto-publisher' );
+        echo esc_html__( 'Import Data', 'fp-publisher' );
         echo '</button>';
         echo '</div>';
         echo '</div>';
         
         // System Maintenance
         echo '<div class="tts-tool-card">';
-        echo '<h3>🔧 ' . esc_html__( 'System Maintenance', 'trello-social-auto-publisher' ) . '</h3>';
-        echo '<p>' . esc_html__( 'Optimize database, clear cache, and perform system cleanup.', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<h3>🔧 ' . esc_html__( 'System Maintenance', 'fp-publisher' ) . '</h3>';
+        echo '<p>' . esc_html__( 'Optimize database, clear cache, and perform system cleanup.', 'fp-publisher' ) . '</p>';
         echo '<div class="tts-tool-actions">';
-        echo '<button class="tts-btn warning" data-ajax-action="tts_system_maintenance" data-confirm="' . esc_attr__( 'This will perform system maintenance. Continue?', 'trello-social-auto-publisher' ) . '">';
-        echo esc_html__( 'Run Maintenance', 'trello-social-auto-publisher' );
+        echo '<button class="tts-btn warning" data-ajax-action="tts_system_maintenance" data-confirm="' . esc_attr__( 'This will perform system maintenance. Continue?', 'fp-publisher' ) . '">';
+        echo esc_html__( 'Run Maintenance', 'fp-publisher' );
         echo '</button>';
         echo '</div>';
         echo '</div>';
         
         // System Report
         echo '<div class="tts-tool-card">';
-        echo '<h3>📊 ' . esc_html__( 'System Report', 'trello-social-auto-publisher' ) . '</h3>';
-        echo '<p>' . esc_html__( 'Generate comprehensive system report for troubleshooting.', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<h3>📊 ' . esc_html__( 'System Report', 'fp-publisher' ) . '</h3>';
+        echo '<p>' . esc_html__( 'Generate comprehensive system report for troubleshooting.', 'fp-publisher' ) . '</p>';
         echo '<div class="tts-tool-actions">';
         echo '<button class="tts-btn info" data-ajax-action="tts_generate_report">';
-        echo esc_html__( 'Generate Report', 'trello-social-auto-publisher' );
+        echo esc_html__( 'Generate Report', 'fp-publisher' );
         echo '</button>';
         echo '</div>';
         echo '</div>';
@@ -1346,7 +1346,7 @@ class TTS_Admin {
         
         // Total Posts Card
         echo '<div class="tts-stat-card tts-tooltip">';
-        echo '<h3>' . esc_html__('Total Posts', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Total Posts', 'fp-publisher') . '</h3>';
         echo '<span class="tts-stat-number">' . intval($total_posts->publish + $total_posts->draft + $total_posts->private) . '</span>';
         echo '<div class="tts-stat-trend">All time posts created</div>';
         echo '<span class="tts-tooltiptext">Total number of social media posts created in the system</span>';
@@ -1354,7 +1354,7 @@ class TTS_Admin {
         
         // Active Clients Card
         echo '<div class="tts-stat-card tts-tooltip">';
-        echo '<h3>' . esc_html__('Active Clients', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Active Clients', 'fp-publisher') . '</h3>';
         echo '<span class="tts-stat-number">' . intval($total_clients->publish) . '</span>';
         echo '<div class="tts-stat-trend">Currently configured</div>';
         echo '<span class="tts-tooltiptext">Number of clients with active social media configurations</span>';
@@ -1362,7 +1362,7 @@ class TTS_Admin {
         
         // Scheduled Posts Card
         echo '<div class="tts-stat-card tts-tooltip">';
-        echo '<h3>' . esc_html__('Scheduled Posts', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Scheduled Posts', 'fp-publisher') . '</h3>';
         echo '<span class="tts-stat-number">' . intval($scheduled_posts) . '</span>';
         echo '<div class="tts-stat-trend">Awaiting publication</div>';
         echo '<span class="tts-tooltiptext">Posts scheduled for future publication</span>';
@@ -1374,7 +1374,7 @@ class TTS_Admin {
         $trend_icon = $trend_percentage > 0 ? '↗' : ($trend_percentage < 0 ? '↘' : '→');
         
         echo '<div class="tts-stat-card tts-tooltip">';
-        echo '<h3>' . esc_html__('Published Today', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Published Today', 'fp-publisher') . '</h3>';
         echo '<span class="tts-stat-number">' . $today_count . '</span>';
         if ($published_yesterday > 0) {
             echo '<div class="tts-stat-trend ' . esc_attr($trend_class) . '">';
@@ -1393,7 +1393,7 @@ class TTS_Admin {
         
         // Failed Posts Today
         echo '<div class="tts-stat-card tts-tooltip">';
-        echo '<h3>' . esc_html__('Failed Today', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Failed Today', 'fp-publisher') . '</h3>';
         echo '<span class="tts-stat-number" style="color: #d63638;">' . $failed_today . '</span>';
         echo '<div class="tts-stat-trend">Requires attention</div>';
         echo '<span class="tts-tooltiptext">Posts that failed to publish today and need attention</span>';
@@ -1401,7 +1401,7 @@ class TTS_Admin {
 
         // Success Rate (already calculated in optimized method)
         echo '<div class="tts-stat-card tts-tooltip">';
-        echo '<h3>' . esc_html__('Success Rate', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Success Rate', 'fp-publisher') . '</h3>';
         echo '<span class="tts-stat-number" style="color: ' . ($success_rate >= 95 ? '#00a32a' : ($success_rate >= 80 ? '#f56e28' : '#d63638')) . ';">' . $success_rate . '%</span>';
         echo '<div class="tts-stat-trend">Today\'s performance</div>';
         echo '<span class="tts-tooltiptext">Percentage of successful publications today</span>';
@@ -1409,7 +1409,7 @@ class TTS_Admin {
 
         // Next Scheduled (already fetched in optimized method)
         echo '<div class="tts-stat-card tts-tooltip">';
-        echo '<h3>' . esc_html__('Next Post', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Next Post', 'fp-publisher') . '</h3>';
         if ($next_scheduled) {
             $time_diff = human_time_diff(current_time('timestamp'), strtotime($next_scheduled->publish_at));
             echo '<span class="tts-stat-number" style="font-size: 20px;">in ' . $time_diff . '</span>';
@@ -1423,7 +1423,7 @@ class TTS_Admin {
 
         // Weekly Average (already calculated in optimized method)
         echo '<div class="tts-stat-card tts-tooltip">';
-        echo '<h3>' . esc_html__('Daily Average', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Daily Average', 'fp-publisher') . '</h3>';
         echo '<span class="tts-stat-number">' . $weekly_average . '</span>';
         echo '<div class="tts-stat-trend">Posts per day (7-day avg)</div>';
         echo '<span class="tts-tooltiptext">Average number of posts published per day over the last week</span>';
@@ -1433,7 +1433,7 @@ class TTS_Admin {
         if ( isset( $stats['performance_metrics'] ) ) {
             $perf = $stats['performance_metrics'];
             echo '<div class="tts-stat-card tts-performance-card tts-tooltip">';
-            echo '<h3>' . esc_html__('Performance', 'trello-social-auto-publisher') . '</h3>';
+            echo '<h3>' . esc_html__('Performance', 'fp-publisher') . '</h3>';
             echo '<div class="tts-perf-metrics">';
             echo '<div class="tts-perf-item">DB: ' . ( isset( $perf['database_response_ms'] ) ? $perf['database_response_ms'] : 'N/A' ) . 'ms</div>';
             echo '<div class="tts-perf-item">Memory: ' . ( isset( $perf['memory_usage_mb'] ) ? $perf['memory_usage_mb'] : 'N/A' ) . 'MB</div>';
@@ -1452,10 +1452,10 @@ class TTS_Admin {
     private function render_recent_posts_section() {
         echo '<div class="tts-dashboard-section">';
         echo '<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">';
-        echo '<h2 style="margin: 0;">' . esc_html__('Recent Social Posts', 'trello-social-auto-publisher') . '</h2>';
+        echo '<h2 style="margin: 0;">' . esc_html__('Recent Social Posts', 'fp-publisher') . '</h2>';
         echo '<div>';
-        echo '<button class="tts-btn small" data-ajax-action="tts_refresh_posts" data-loading-text="' . esc_attr__('Refreshing...', 'trello-social-auto-publisher') . '">';
-        echo esc_html__('Refresh', 'trello-social-auto-publisher');
+        echo '<button class="tts-btn small" data-ajax-action="tts_refresh_posts" data-loading-text="' . esc_attr__('Refreshing...', 'fp-publisher') . '">';
+        echo esc_html__('Refresh', 'fp-publisher');
         echo '</button>';
         echo '</div>';
         echo '</div>';
@@ -1473,11 +1473,11 @@ class TTS_Admin {
             echo '<table class="widefat tts-enhanced-table">';
             echo '<thead><tr>';
             echo '<th style="width: 20px;"><input type="checkbox" class="tts-bulk-select-all"></th>';
-            echo '<th>' . esc_html__('Title', 'trello-social-auto-publisher') . '</th>';
-            echo '<th>' . esc_html__('Channel', 'trello-social-auto-publisher') . '</th>';
-            echo '<th>' . esc_html__('Status', 'trello-social-auto-publisher') . '</th>';
-            echo '<th>' . esc_html__('Date', 'trello-social-auto-publisher') . '</th>';
-            echo '<th>' . esc_html__('Actions', 'trello-social-auto-publisher') . '</th>';
+            echo '<th>' . esc_html__('Title', 'fp-publisher') . '</th>';
+            echo '<th>' . esc_html__('Channel', 'fp-publisher') . '</th>';
+            echo '<th>' . esc_html__('Status', 'fp-publisher') . '</th>';
+            echo '<th>' . esc_html__('Date', 'fp-publisher') . '</th>';
+            echo '<th>' . esc_html__('Actions', 'fp-publisher') . '</th>';
             echo '</tr></thead><tbody>';
             
             foreach ($recent_posts as $post) {
@@ -1487,18 +1487,18 @@ class TTS_Admin {
                 
                 // Determine status class and text
                 $status_class = $status === 'published' ? 'success' : ($status === 'failed' ? 'error' : 'warning');
-                $status_text = $status ?: __('Scheduled', 'trello-social-auto-publisher');
+                $status_text = $status ?: __('Scheduled', 'fp-publisher');
                 
                 echo '<tr class="tts-list-item">';
                 echo '<td><input type="checkbox" class="tts-bulk-select-item" value="' . esc_attr($post->ID) . '"></td>';
                 echo '<td>';
                 echo '<a href="' . esc_url(get_edit_post_link($post->ID)) . '" class="tts-tooltip">';
                 echo '<strong>' . esc_html($post->post_title) . '</strong>';
-                echo '<span class="tts-tooltiptext">' . esc_html__('Click to edit this post', 'trello-social-auto-publisher') . '</span>';
+                echo '<span class="tts-tooltiptext">' . esc_html__('Click to edit this post', 'fp-publisher') . '</span>';
                 echo '</a>';
                 echo '<div class="row-actions">';
-                echo '<span class="edit"><a href="' . esc_url(get_edit_post_link($post->ID)) . '">' . esc_html__('Edit', 'trello-social-auto-publisher') . '</a> | </span>';
-                echo '<span class="delete"><a href="#" data-confirm="' . esc_attr__('Are you sure you want to delete this post?', 'trello-social-auto-publisher') . '" data-dangerous data-ajax-action="tts_delete_post" data-post-id="' . esc_attr($post->ID) . '">' . esc_html__('Delete', 'trello-social-auto-publisher') . '</a></span>';
+                echo '<span class="edit"><a href="' . esc_url(get_edit_post_link($post->ID)) . '">' . esc_html__('Edit', 'fp-publisher') . '</a> | </span>';
+                echo '<span class="delete"><a href="#" data-confirm="' . esc_attr__('Are you sure you want to delete this post?', 'fp-publisher') . '" data-dangerous data-ajax-action="tts_delete_post" data-post-id="' . esc_attr($post->ID) . '">' . esc_html__('Delete', 'fp-publisher') . '</a></span>';
                 echo '</div>';
                 echo '</td>';
                 echo '<td>';
@@ -1507,7 +1507,7 @@ class TTS_Admin {
                         echo '<span class="tts-status-badge info" style="margin-right: 5px;">' . esc_html($ch) . '</span>';
                     }
                 } else {
-                    echo '<span class="tts-status-badge info">' . esc_html($channel ?: __('No channel', 'trello-social-auto-publisher')) . '</span>';
+                    echo '<span class="tts-status-badge info">' . esc_html($channel ?: __('No channel', 'fp-publisher')) . '</span>';
                 }
                 echo '</td>';
                 echo '<td><span class="tts-status-badge ' . $status_class . '">' . esc_html($status_text) . '</span></td>';
@@ -1520,7 +1520,7 @@ class TTS_Admin {
                 echo '</td>';
                 echo '<td>';
                 echo '<a href="' . esc_url(admin_url('admin.php?page=fp-publisher-social-posts&action=log&post=' . $post->ID)) . '" class="tts-btn small secondary">';
-                echo esc_html__('View Log', 'trello-social-auto-publisher');
+                echo esc_html__('View Log', 'fp-publisher');
                 echo '</a>';
                 echo '</td>';
                 echo '</tr>';
@@ -1530,16 +1530,16 @@ class TTS_Admin {
             
             // Bulk actions
             echo '<div class="tts-bulk-actions">';
-            echo '<h4>' . esc_html__('Bulk Actions', 'trello-social-auto-publisher') . '</h4>';
+            echo '<h4>' . esc_html__('Bulk Actions', 'fp-publisher') . '</h4>';
             echo '<div style="display: flex; gap: 10px; align-items: center;">';
             echo '<select class="tts-bulk-action-select">';
-            echo '<option value="">' . esc_html__('Choose an action...', 'trello-social-auto-publisher') . '</option>';
-            echo '<option value="delete">' . esc_html__('Delete', 'trello-social-auto-publisher') . '</option>';
-            echo '<option value="approve">' . esc_html__('Approve', 'trello-social-auto-publisher') . '</option>';
-            echo '<option value="revoke">' . esc_html__('Revoke', 'trello-social-auto-publisher') . '</option>';
+            echo '<option value="">' . esc_html__('Choose an action...', 'fp-publisher') . '</option>';
+            echo '<option value="delete">' . esc_html__('Delete', 'fp-publisher') . '</option>';
+            echo '<option value="approve">' . esc_html__('Approve', 'fp-publisher') . '</option>';
+            echo '<option value="revoke">' . esc_html__('Revoke', 'fp-publisher') . '</option>';
             echo '</select>';
-            echo '<button class="tts-btn" data-ajax-action="tts_bulk_action" data-confirm="' . esc_attr__('Are you sure you want to perform this action on the selected posts?', 'trello-social-auto-publisher') . '">';
-            echo esc_html__('Apply', 'trello-social-auto-publisher');
+            echo '<button class="tts-btn" data-ajax-action="tts_bulk_action" data-confirm="' . esc_attr__('Are you sure you want to perform this action on the selected posts?', 'fp-publisher') . '">';
+            echo esc_html__('Apply', 'fp-publisher');
             echo '</button>';
             echo '</div>';
             echo '</div>';
@@ -1547,10 +1547,10 @@ class TTS_Admin {
         } else {
             echo '<div style="text-align: center; padding: 40px; color: #666;">';
             echo '<span style="font-size: 48px; margin-bottom: 10px; display: block;">📝</span>';
-            echo '<p style="margin: 0; font-size: 16px;">' . esc_html__('No social posts found.', 'trello-social-auto-publisher') . '</p>';
-            echo '<p style="margin: 5px 0 0 0; font-size: 14px;">' . esc_html__('Create your first social media post to get started!', 'trello-social-auto-publisher') . '</p>';
+            echo '<p style="margin: 0; font-size: 16px;">' . esc_html__('No social posts found.', 'fp-publisher') . '</p>';
+            echo '<p style="margin: 5px 0 0 0; font-size: 14px;">' . esc_html__('Create your first social media post to get started!', 'fp-publisher') . '</p>';
             echo '<a href="' . esc_url(admin_url('admin.php?page=fp-publisher-client-wizard')) . '" class="tts-btn" style="margin-top: 15px;">';
-            echo esc_html__('Add New Client', 'trello-social-auto-publisher');
+            echo esc_html__('Add New Client', 'fp-publisher');
             echo '</a>';
             echo '</div>';
         }
@@ -1604,48 +1604,48 @@ class TTS_Admin {
      */
     private function render_quick_actions_section() {
         echo '<div class="tts-dashboard-section">';
-        echo '<h2>' . esc_html__('Quick Actions', 'trello-social-auto-publisher') . '</h2>';
+        echo '<h2>' . esc_html__('Quick Actions', 'fp-publisher') . '</h2>';
         echo '<div class="tts-quick-actions">';
         
         $actions = array(
             array(
-                'title' => __('Add New Client', 'trello-social-auto-publisher'),
-                'description' => __('Set up a new social media client', 'trello-social-auto-publisher'),
+                'title' => __('Add New Client', 'fp-publisher'),
+                'description' => __('Set up a new social media client', 'fp-publisher'),
                 'url' => admin_url('admin.php?page=fp-publisher-client-wizard'),
                 'icon' => 'dashicons-plus',
                 'color' => '#135e96'
             ),
             array(
-                'title' => __('View Calendar', 'trello-social-auto-publisher'),
-                'description' => __('See scheduled posts in calendar view', 'trello-social-auto-publisher'),
+                'title' => __('View Calendar', 'fp-publisher'),
+                'description' => __('See scheduled posts in calendar view', 'fp-publisher'),
                 'url' => admin_url('admin.php?page=fp-publisher-calendar'),
                 'icon' => 'dashicons-calendar',
                 'color' => '#f56e28'
             ),
             array(
-                'title' => __('Check Health Status', 'trello-social-auto-publisher'),
-                'description' => __('Monitor system health and tokens', 'trello-social-auto-publisher'),
+                'title' => __('Check Health Status', 'fp-publisher'),
+                'description' => __('Monitor system health and tokens', 'fp-publisher'),
                 'url' => admin_url('admin.php?page=fp-publisher-health'),
                 'icon' => 'dashicons-heart',
                 'color' => '#00a32a'
             ),
             array(
-                'title' => __('View Analytics', 'trello-social-auto-publisher'),
-                'description' => __('Analyze performance and engagement', 'trello-social-auto-publisher'),
+                'title' => __('View Analytics', 'fp-publisher'),
+                'description' => __('Analyze performance and engagement', 'fp-publisher'),
                 'url' => admin_url('admin.php?page=fp-publisher-analytics'),
                 'icon' => 'dashicons-chart-area',
                 'color' => '#7c3aed'
             ),
             array(
-                'title' => __('Manage Posts', 'trello-social-auto-publisher'),
-                'description' => __('View and manage all social posts', 'trello-social-auto-publisher'),
+                'title' => __('Manage Posts', 'fp-publisher'),
+                'description' => __('View and manage all social posts', 'fp-publisher'),
                 'url' => admin_url('admin.php?page=fp-publisher-social-posts'),
                 'icon' => 'dashicons-admin-post',
                 'color' => '#2563eb'
             ),
             array(
-                'title' => __('View Logs', 'trello-social-auto-publisher'),
-                'description' => __('Check system logs and debugging info', 'trello-social-auto-publisher'),
+                'title' => __('View Logs', 'fp-publisher'),
+                'description' => __('Check system logs and debugging info', 'fp-publisher'),
                 'url' => admin_url('admin.php?page=fp-publisher-log'),
                 'icon' => 'dashicons-list-view',
                 'color' => '#64748b'
@@ -1674,7 +1674,7 @@ class TTS_Admin {
      */
     private function render_system_status_widget() {
         echo '<div class="tts-dashboard-section">';
-        echo '<h2>' . esc_html__('System Status', 'trello-social-auto-publisher') . '</h2>';
+        echo '<h2>' . esc_html__('System Status', 'fp-publisher') . '</h2>';
         
         // Check various system components
         $status_checks = array();
@@ -1729,7 +1729,7 @@ class TTS_Admin {
         echo '<div style="text-align: center; margin-bottom: 15px;">';
         $health_color = $health_percentage >= 80 ? '#00a32a' : ($health_percentage >= 60 ? '#f56e28' : '#d63638');
         echo '<div style="font-size: 24px; color: ' . $health_color . '; font-weight: bold;">';
-        echo $health_percentage . '% ' . esc_html__('Healthy', 'trello-social-auto-publisher');
+        echo $health_percentage . '% ' . esc_html__('Healthy', 'fp-publisher');
         echo '</div>';
         echo '</div>';
         
@@ -1761,7 +1761,7 @@ class TTS_Admin {
             )
         );
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Clienti', 'trello-social-auto-publisher' ) . '</h1>';
+        echo '<h1>' . esc_html__( 'Clienti', 'fp-publisher' ) . '</h1>';
         if ( ! empty( $clients ) ) {
             echo '<ul>';
             foreach ( $clients as $client ) {
@@ -1770,7 +1770,7 @@ class TTS_Admin {
             }
             echo '</ul>';
         } else {
-            echo '<p>' . esc_html__( 'Nessun cliente trovato.', 'trello-social-auto-publisher' ) . '</p>';
+            echo '<p>' . esc_html__( 'Nessun cliente trovato.', 'fp-publisher' ) . '</p>';
         }
         echo '</div>';
     }
@@ -1786,22 +1786,22 @@ class TTS_Admin {
         // Security: Verify nonce for form submissions
         if ( isset( $_POST['step'] ) && $_POST['step'] > 1 ) {
             if ( ! wp_verify_nonce( $_POST['tts_wizard_nonce'], 'tts_client_wizard' ) ) {
-                wp_die( esc_html__( 'Security verification failed. Please try again.', 'trello-social-auto-publisher' ) );
+                wp_die( esc_html__( 'Security verification failed. Please try again.', 'fp-publisher' ) );
             }
         }
 
         $step = isset( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 
         echo '<div class="wrap tts-client-wizard">';
-        echo '<h1>' . esc_html__( 'Client Wizard', 'trello-social-auto-publisher' ) . '</h1>';
+        echo '<h1>' . esc_html__( 'Client Wizard', 'fp-publisher' ) . '</h1>';
 
         // Add helpful notice about social media setup
         if ( 2 === $step ) {
             echo '<div class="notice notice-info">';
-            echo '<h3>' . esc_html__( 'Social Media Setup Required', 'trello-social-auto-publisher' ) . '</h3>';
-            echo '<p>' . esc_html__( 'To connect social media accounts, you must first configure OAuth apps for each platform. Click "Configure App" for platforms that are not set up.', 'trello-social-auto-publisher' ) . '</p>';
-            echo '<p><a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-social-connections' ) ) . '" class="button">' . esc_html__( 'Manage Social Connections', 'trello-social-auto-publisher' ) . '</a> ';
-            echo '<a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-help' ) ) . '" target="_blank">' . esc_html__( 'View Setup Guide', 'trello-social-auto-publisher' ) . '</a></p>';
+            echo '<h3>' . esc_html__( 'Social Media Setup Required', 'fp-publisher' ) . '</h3>';
+            echo '<p>' . esc_html__( 'To connect social media accounts, you must first configure OAuth apps for each platform. Click "Configure App" for platforms that are not set up.', 'fp-publisher' ) . '</p>';
+            echo '<p><a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-social-connections' ) ) . '" class="button">' . esc_html__( 'Manage Social Connections', 'fp-publisher' ) . '</a> ';
+            echo '<a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-help' ) ) . '" target="_blank">' . esc_html__( 'View Setup Guide', 'fp-publisher' ) . '</a></p>';
             echo '</div>';
         }
 
@@ -1819,9 +1819,9 @@ class TTS_Admin {
             echo '<form method="post" class="tts-wizard-step tts-step-1">';
             wp_nonce_field( 'tts_client_wizard', 'tts_wizard_nonce' );
             echo '<input type="hidden" name="step" value="2" />';
-            echo '<p><label>' . esc_html__( 'Trello API Key', 'trello-social-auto-publisher' ) . '<br />';
+            echo '<p><label>' . esc_html__( 'Trello API Key', 'fp-publisher' ) . '<br />';
             echo '<input type="text" name="trello_key" value="' . esc_attr( $trello_key ) . '" required /></label></p>';
-            echo '<p><label>' . esc_html__( 'Trello Token', 'trello-social-auto-publisher' ) . '<br />';
+            echo '<p><label>' . esc_html__( 'Trello Token', 'fp-publisher' ) . '<br />';
             echo '<input type="text" name="trello_token" value="' . esc_attr( $trello_token ) . '" required /></label></p>';
 
             $boards = array();
@@ -1836,7 +1836,7 @@ class TTS_Admin {
             }
 
             if ( ! empty( $boards ) ) {
-                echo '<p><label>' . esc_html__( 'Trello Board', 'trello-social-auto-publisher' ) . '<br />';
+                echo '<p><label>' . esc_html__( 'Trello Board', 'fp-publisher' ) . '<br />';
                 echo '<select name="trello_board">';
                 foreach ( $boards as $b ) {
                     printf( '<option value="%s" %s>%s</option>', esc_attr( $b['id'] ), selected( $board, $b['id'], false ), esc_html( $b['name'] ) );
@@ -1844,7 +1844,7 @@ class TTS_Admin {
                 echo '</select></label></p>';
             }
 
-            echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Next', 'trello-social-auto-publisher' ) . '</button></p>';
+            echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Next', 'fp-publisher' ) . '</button></p>';
             echo '</form>';
         } elseif ( 2 === $step ) {
             echo '<form method="post" class="tts-wizard-step tts-step-2">';
@@ -1855,10 +1855,10 @@ class TTS_Admin {
             echo '<input type="hidden" name="trello_board" value="' . esc_attr( $board ) . '" />';
 
             $opts = array(
-                'facebook'  => __( 'Facebook', 'trello-social-auto-publisher' ),
-                'instagram' => __( 'Instagram', 'trello-social-auto-publisher' ),
-                'youtube'   => __( 'YouTube', 'trello-social-auto-publisher' ),
-                'tiktok'    => __( 'TikTok', 'trello-social-auto-publisher' ),
+                'facebook'  => __( 'Facebook', 'fp-publisher' ),
+                'instagram' => __( 'Instagram', 'fp-publisher' ),
+                'youtube'   => __( 'YouTube', 'fp-publisher' ),
+                'tiktok'    => __( 'TikTok', 'fp-publisher' ),
             );
 
             foreach ( $opts as $slug => $label ) {
@@ -1897,19 +1897,19 @@ class TTS_Admin {
                 echo '<p><label><input type="checkbox" name="channels[]" value="' . esc_attr( $slug ) . '" ' . checked( in_array( $slug, $channels, true ) || $connected, true, false ) . ' /> <strong>' . esc_html( $label ) . '</strong></label>';
                 
                 if ( ! $app_configured ) {
-                    echo '<br><span style="color: #d63638;">⚠️ ' . esc_html__( 'App not configured', 'trello-social-auto-publisher' ) . '</span>';
-                    echo '<br><a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-social-connections' ) ) . '" class="button">' . esc_html__( 'Configure App', 'trello-social-auto-publisher' ) . '</a>';
+                    echo '<br><span style="color: #d63638;">⚠️ ' . esc_html__( 'App not configured', 'fp-publisher' ) . '</span>';
+                    echo '<br><a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-social-connections' ) ) . '" class="button">' . esc_html__( 'Configure App', 'fp-publisher' ) . '</a>';
                 } elseif ( $connected ) {
-                    echo '<br><span style="color: #00a32a;">✅ ' . esc_html__( 'Connected', 'trello-social-auto-publisher' ) . '</span>';
+                    echo '<br><span style="color: #00a32a;">✅ ' . esc_html__( 'Connected', 'fp-publisher' ) . '</span>';
                 } else {
                     $url = add_query_arg( array( 'action' => 'tts_oauth_' . $slug, 'step' => 2 ), admin_url( 'admin-post.php' ) );
-                    echo '<br><span style="color: #f56e28;">🟡 ' . esc_html__( 'Ready to connect', 'trello-social-auto-publisher' ) . '</span>';
-                    echo '<br><a href="' . esc_url( $url ) . '" class="button button-primary">' . esc_html__( 'Connect Account', 'trello-social-auto-publisher' ) . '</a>';
+                    echo '<br><span style="color: #f56e28;">🟡 ' . esc_html__( 'Ready to connect', 'fp-publisher' ) . '</span>';
+                    echo '<br><a href="' . esc_url( $url ) . '" class="button button-primary">' . esc_html__( 'Connect Account', 'fp-publisher' ) . '</a>';
                 }
                 echo '</div>';
             }
 
-            echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Next', 'trello-social-auto-publisher' ) . '</button></p>';
+            echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Next', 'fp-publisher' ) . '</button></p>';
             echo '</form>';
         } elseif ( 3 === $step ) {
             echo '<form method="post" class="tts-wizard-step tts-step-3">';
@@ -1921,7 +1921,7 @@ class TTS_Admin {
                 echo '<input type="hidden" name="channels[]" value="' . esc_attr( $ch ) . '" />';
             }
             echo '<div id="tts-lists" data-board="' . esc_attr( $board ) . '" data-key="' . esc_attr( $trello_key ) . '" data-token="' . esc_attr( $trello_token ) . '"></div>';
-            echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Next', 'trello-social-auto-publisher' ) . '</button></p>';
+            echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Next', 'fp-publisher' ) . '</button></p>';
             echo '</form>';
         } else {
             if ( isset( $_POST['finalize'] ) ) {
@@ -1968,7 +1968,7 @@ class TTS_Admin {
                     delete_transient( 'tts_oauth_youtube_token' );
                     delete_transient( 'tts_oauth_tiktok_token' );
 
-                    echo '<p>' . esc_html__( 'Client created.', 'trello-social-auto-publisher' ) . '</p>';
+                    echo '<p>' . esc_html__( 'Client created.', 'fp-publisher' ) . '</p>';
                 }
                 echo '</div>';
                 return;
@@ -1989,10 +1989,10 @@ class TTS_Admin {
                 }
             }
 
-            echo '<h2>' . esc_html__( 'Summary', 'trello-social-auto-publisher' ) . '</h2>';
-            echo '<p>' . esc_html__( 'Trello Board:', 'trello-social-auto-publisher' ) . ' ' . esc_html( $board ) . '</p>';
-            echo '<p>' . esc_html__( 'Channels:', 'trello-social-auto-publisher' ) . ' ' . esc_html( implode( ', ', $channels ) ) . '</p>';
-            echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Create Client', 'trello-social-auto-publisher' ) . '</button></p>';
+            echo '<h2>' . esc_html__( 'Summary', 'fp-publisher' ) . '</h2>';
+            echo '<p>' . esc_html__( 'Trello Board:', 'fp-publisher' ) . ' ' . esc_html( $board ) . '</p>';
+            echo '<p>' . esc_html__( 'Channels:', 'fp-publisher' ) . ' ' . esc_html( implode( ', ', $channels ) ) . '</p>';
+            echo '<p><button type="submit" class="button button-primary">' . esc_html__( 'Create Client', 'fp-publisher' ) . '</button></p>';
             echo '</form>';
         }
 
@@ -2017,7 +2017,7 @@ class TTS_Admin {
             )
         );
         echo '<select name="tts_client">';
-        echo '<option value="">' . esc_html__( 'All Clients', 'trello-social-auto-publisher' ) . '</option>';
+        echo '<option value="">' . esc_html__( 'All Clients', 'fp-publisher' ) . '</option>';
         foreach ( $clients as $client ) {
             printf(
                 '<option value="%1$d" %3$s>%2$s</option>',
@@ -2068,9 +2068,9 @@ class TTS_Admin {
 
         $selected = isset( $_GET['tts_approved'] ) ? sanitize_text_field( $_GET['tts_approved'] ) : '';
         echo '<select name="tts_approved">';
-        echo '<option value="">' . esc_html__( 'Stato approvazione', 'trello-social-auto-publisher' ) . '</option>';
-        echo '<option value="1" ' . selected( $selected, '1', false ) . '>' . esc_html__( 'Approvato', 'trello-social-auto-publisher' ) . '</option>';
-        echo '<option value="0" ' . selected( $selected, '0', false ) . '>' . esc_html__( 'Non approvato', 'trello-social-auto-publisher' ) . '</option>';
+        echo '<option value="">' . esc_html__( 'Stato approvazione', 'fp-publisher' ) . '</option>';
+        echo '<option value="1" ' . selected( $selected, '1', false ) . '>' . esc_html__( 'Approvato', 'fp-publisher' ) . '</option>';
+        echo '<option value="0" ' . selected( $selected, '0', false ) . '>' . esc_html__( 'Non approvato', 'fp-publisher' ) . '</option>';
         echo '</select>';
     }
 
@@ -2106,7 +2106,7 @@ class TTS_Admin {
      * @return array
      */
     public function add_approved_column( $columns ) {
-        $columns['tts_approved'] = __( 'Approvato', 'trello-social-auto-publisher' );
+        $columns['tts_approved'] = __( 'Approvato', 'fp-publisher' );
         return $columns;
     }
 
@@ -2119,7 +2119,7 @@ class TTS_Admin {
     public function render_approved_column( $column, $post_id ) {
         if ( 'tts_approved' === $column ) {
             $approved = (bool) get_post_meta( $post_id, '_tts_approved', true );
-            echo $approved ? esc_html__( 'Si', 'trello-social-auto-publisher' ) : esc_html__( 'No', 'trello-social-auto-publisher' );
+            echo $approved ? esc_html__( 'Si', 'fp-publisher' ) : esc_html__( 'No', 'fp-publisher' );
         }
     }
 
@@ -2131,8 +2131,8 @@ class TTS_Admin {
      * @return array
      */
     public function register_bulk_actions( $actions ) {
-        $actions['tts_approve'] = __( 'Approva', 'trello-social-auto-publisher' );
-        $actions['tts_revoke']  = __( 'Revoca', 'trello-social-auto-publisher' );
+        $actions['tts_approve'] = __( 'Approva', 'fp-publisher' );
+        $actions['tts_revoke']  = __( 'Revoca', 'fp-publisher' );
         return $actions;
     }
 
@@ -2169,20 +2169,20 @@ class TTS_Admin {
         // Handle publish now action.
         if ( isset( $_GET['action'], $_GET['post'] ) && 'publish' === $_GET['action'] ) {
             if ( ! current_user_can( 'publish_posts' ) ) {
-                wp_die( esc_html__( 'Sorry, you are not allowed to publish this post.', 'trello-social-auto-publisher' ) );
+                wp_die( esc_html__( 'Sorry, you are not allowed to publish this post.', 'fp-publisher' ) );
             }
 
             $post_id = absint( $_GET['post'] );
             check_admin_referer( 'tts_publish_social_post_' . $post_id );
             do_action( 'tts_publish_social_post', $post_id );
-            echo '<div class="notice notice-success"><p>' . esc_html__( 'Post published.', 'trello-social-auto-publisher' ) . '</p></div>';
+            echo '<div class="notice notice-success"><p>' . esc_html__( 'Post published.', 'fp-publisher' ) . '</p></div>';
         }
 
         // Handle log view.
         if ( isset( $_GET['action'], $_GET['post'] ) && 'log' === $_GET['action'] ) {
             $log = get_post_meta( absint( $_GET['post'] ), '_tts_publish_log', true );
             echo '<div class="wrap">';
-            echo '<h1>' . esc_html__( 'Log', 'trello-social-auto-publisher' ) . '</h1>';
+            echo '<h1>' . esc_html__( 'Log', 'fp-publisher' ) . '</h1>';
             if ( ! empty( $log ) ) {
                 echo '<div class="tts-log-display">';
                 if ( is_array( $log ) || is_object( $log ) ) {
@@ -2192,7 +2192,7 @@ class TTS_Admin {
                 }
                 echo '</div>';
             } else {
-                echo '<p>' . esc_html__( 'No log entries found.', 'trello-social-auto-publisher' ) . '</p>';
+                echo '<p>' . esc_html__( 'No log entries found.', 'fp-publisher' ) . '</p>';
             }
             echo '</div>';
             return;
@@ -2202,7 +2202,7 @@ class TTS_Admin {
         $table->prepare_items();
 
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Social Post', 'trello-social-auto-publisher' ) . '</h1>';
+        echo '<h1>' . esc_html__( 'Social Post', 'fp-publisher' ) . '</h1>';
         $table->display();
         echo '</div>';
     }
@@ -2329,10 +2329,10 @@ class TTS_Social_Posts_Table extends WP_List_Table {
      */
     public function get_columns() {
         return array(
-            'title'        => __( 'Titolo', 'trello-social-auto-publisher' ),
-            'channel'      => __( 'Canale', 'trello-social-auto-publisher' ),
-            'publish_date' => __( 'Data Pubblicazione', 'trello-social-auto-publisher' ),
-            'status'       => __( 'Stato', 'trello-social-auto-publisher' ),
+            'title'        => __( 'Titolo', 'fp-publisher' ),
+            'channel'      => __( 'Canale', 'fp-publisher' ),
+            'publish_date' => __( 'Data Pubblicazione', 'fp-publisher' ),
+            'status'       => __( 'Stato', 'fp-publisher' ),
         );
     }
 
@@ -2359,7 +2359,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                 'title'       => $post->post_title,
                 'channel'     => is_array( $channel ) ? implode( ', ', $channel ) : $channel,
                 'publish_date'=> $publish ? date_i18n( 'Y-m-d H:i', strtotime( $publish ) ) : '',
-                'status'      => $status ? $status : __( 'scheduled', 'trello-social-auto-publisher' ),
+                'status'      => $status ? $status : __( 'scheduled', 'fp-publisher' ),
             );
         }
 
@@ -2387,9 +2387,9 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         );
 
         $actions = array(
-            'publish'  => sprintf( '<a href="%s">%s</a>', esc_url( $publish_url ), __( 'Publish Now', 'trello-social-auto-publisher' ) ),
-            'edit'     => sprintf( '<a href="%s">%s</a>', get_edit_post_link( $item['ID'] ), __( 'Edit', 'trello-social-auto-publisher' ) ),
-            'view_log' => sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => 'fp-publisher-social-posts', 'action' => 'log', 'post' => $item['ID'] ), admin_url( 'admin.php' ) ) ), __( 'View Log', 'trello-social-auto-publisher' ) ),
+            'publish'  => sprintf( '<a href="%s">%s</a>', esc_url( $publish_url ), __( 'Publish Now', 'fp-publisher' ) ),
+            'edit'     => sprintf( '<a href="%s">%s</a>', get_edit_post_link( $item['ID'] ), __( 'Edit', 'fp-publisher' ) ),
+            'view_log' => sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => 'fp-publisher-social-posts', 'action' => 'log', 'post' => $item['ID'] ), admin_url( 'admin.php' ) ) ), __( 'View Log', 'fp-publisher' ) ),
         );
 
         return sprintf( '<strong>%1$s</strong>%2$s', esc_html( $item['title'] ), $this->row_actions( $actions ) );
@@ -2442,10 +2442,10 @@ class TTS_Social_Posts_Table extends WP_List_Table {
     public function render_settings_page() {
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e( 'Social Auto Publisher Settings', 'trello-social-auto-publisher' ); ?></h1>
+            <h1><?php esc_html_e( 'Social Auto Publisher Settings', 'fp-publisher' ); ?></h1>
             
             <div class="notice notice-info">
-                <p><?php esc_html_e( 'Configure your global plugin settings here. For social media connections, please visit the Social Connections page.', 'trello-social-auto-publisher' ); ?></p>
+                <p><?php esc_html_e( 'Configure your global plugin settings here. For social media connections, please visit the Social Connections page.', 'fp-publisher' ); ?></p>
             </div>
 
             <form action="options.php" method="post">
@@ -2478,25 +2478,25 @@ class TTS_Social_Posts_Table extends WP_List_Table {
             if ( isset( $_POST['action'] ) && $_POST['action'] === 'save_social_apps' ) {
                 if ( wp_verify_nonce( $_POST['tts_social_nonce'], 'tts_save_social_apps' ) ) {
                     $this->save_social_app_settings();
-                    echo '<div class="notice notice-success"><p>' . esc_html__( 'Social media app settings saved successfully!', 'trello-social-auto-publisher' ) . '</p></div>';
+                    echo '<div class="notice notice-success"><p>' . esc_html__( 'Social media app settings saved successfully!', 'fp-publisher' ) . '</p></div>';
                 }
             }
 
             $settings = get_option( 'tts_social_apps', array() );
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e( 'Social Media Connections', 'trello-social-auto-publisher' ); ?></h1>
+            <h1><?php esc_html_e( 'Social Media Connections', 'fp-publisher' ); ?></h1>
             
             <div class="notice notice-info">
-                <h3><?php esc_html_e( 'Setup Instructions', 'trello-social-auto-publisher' ); ?></h3>
-                <p><?php esc_html_e( 'To connect your social media accounts, you need to create apps on each platform and configure OAuth credentials:', 'trello-social-auto-publisher' ); ?></p>
+                <h3><?php esc_html_e( 'Setup Instructions', 'fp-publisher' ); ?></h3>
+                <p><?php esc_html_e( 'To connect your social media accounts, you need to create apps on each platform and configure OAuth credentials:', 'fp-publisher' ); ?></p>
                 <ol>
-                    <li><strong>Facebook:</strong> <?php esc_html_e( 'Create an app at', 'trello-social-auto-publisher' ); ?> <a href="https://developers.facebook.com/apps/" target="_blank">Facebook Developers</a></li>
-                    <li><strong>Instagram:</strong> <?php esc_html_e( 'Use Facebook app with Instagram Basic Display product', 'trello-social-auto-publisher' ); ?></li>
-                    <li><strong>YouTube:</strong> <?php esc_html_e( 'Create a project at', 'trello-social-auto-publisher' ); ?> <a href="https://console.developers.google.com/" target="_blank">Google Developers Console</a></li>
-                    <li><strong>TikTok:</strong> <?php esc_html_e( 'Apply for TikTok for Developers at', 'trello-social-auto-publisher' ); ?> <a href="https://developers.tiktok.com/" target="_blank">TikTok Developers</a></li>
+                    <li><strong>Facebook:</strong> <?php esc_html_e( 'Create an app at', 'fp-publisher' ); ?> <a href="https://developers.facebook.com/apps/" target="_blank">Facebook Developers</a></li>
+                    <li><strong>Instagram:</strong> <?php esc_html_e( 'Use Facebook app with Instagram Basic Display product', 'fp-publisher' ); ?></li>
+                    <li><strong>YouTube:</strong> <?php esc_html_e( 'Create a project at', 'fp-publisher' ); ?> <a href="https://console.developers.google.com/" target="_blank">Google Developers Console</a></li>
+                    <li><strong>TikTok:</strong> <?php esc_html_e( 'Apply for TikTok for Developers at', 'fp-publisher' ); ?> <a href="https://developers.tiktok.com/" target="_blank">TikTok Developers</a></li>
                 </ol>
-                <p><strong><?php esc_html_e( 'Redirect URI:', 'trello-social-auto-publisher' ); ?></strong> <code><?php echo esc_url( admin_url( 'admin-post.php' ) ); ?></code></p>
+                <p><strong><?php esc_html_e( 'Redirect URI:', 'fp-publisher' ); ?></strong> <code><?php echo esc_url( admin_url( 'admin-post.php' ) ); ?></code></p>
             </div>
 
             <div class="tts-social-apps-container">
@@ -2556,7 +2556,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                             $connection_status = $this->check_platform_connection_status( $platform );
                             ?>
                             <div class="tts-connection-status">
-                                <strong><?php esc_html_e( 'Status:', 'trello-social-auto-publisher' ); ?></strong>
+                                <strong><?php esc_html_e( 'Status:', 'fp-publisher' ); ?></strong>
                                 <span class="tts-status-<?php echo esc_attr( $connection_status['status'] ); ?>">
                                     <?php echo esc_html( $connection_status['message'] ); ?>
                                 </span>
@@ -2565,11 +2565,11 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                                     <div class="tts-platform-actions">
                                         <a href="<?php echo esc_url( $this->get_oauth_url( $platform ) ); ?>" 
                                            class="button button-primary">
-                                            <?php esc_html_e( 'Connect Account', 'trello-social-auto-publisher' ); ?>
+                                            <?php esc_html_e( 'Connect Account', 'fp-publisher' ); ?>
                                         </a>
                                         <button type="button" class="button tts-test-connection" 
                                                 data-platform="<?php echo esc_attr( $platform ); ?>">
-                                            <?php esc_html_e( 'Test Connection', 'trello-social-auto-publisher' ); ?>
+                                            <?php esc_html_e( 'Test Connection', 'fp-publisher' ); ?>
                                         </button>
                                     </div>
                                     <div class="tts-test-result" id="test-result-<?php echo esc_attr( $platform ); ?>" style="display: none;"></div>
@@ -2579,7 +2579,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                                     <div class="tts-rate-limit-info" id="rate-limit-<?php echo esc_attr( $platform ); ?>">
                                         <button type="button" class="button tts-check-limits" 
                                                 data-platform="<?php echo esc_attr( $platform ); ?>">
-                                            <?php esc_html_e( 'Check API Limits', 'trello-social-auto-publisher' ); ?>
+                                            <?php esc_html_e( 'Check API Limits', 'fp-publisher' ); ?>
                                         </button>
                                     </div>
                                 <?php endif; ?>
@@ -2589,7 +2589,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                     </div>
 
                     <p class="submit">
-                        <input type="submit" class="button-primary" value="<?php esc_attr_e( 'Save App Settings', 'trello-social-auto-publisher' ); ?>" />
+                        <input type="submit" class="button-primary" value="<?php esc_attr_e( 'Save App Settings', 'fp-publisher' ); ?>" />
                     </p>
                 </form>
             </div>
@@ -2602,7 +2602,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                     var resultDiv = $('#test-result-' + platform);
                     var button = $(this);
                     
-                    button.prop('disabled', true).text('<?php esc_html_e( 'Testing...', 'trello-social-auto-publisher' ); ?>');
+                    button.prop('disabled', true).text('<?php esc_html_e( 'Testing...', 'fp-publisher' ); ?>');
                     resultDiv.hide();
                     
                     $.post(ajaxurl, {
@@ -2610,7 +2610,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                         platform: platform,
                         nonce: '<?php echo wp_create_nonce( 'tts_test_connection' ); ?>'
                     }, function(response) {
-                        button.prop('disabled', false).text('<?php esc_html_e( 'Test Connection', 'trello-social-auto-publisher' ); ?>');
+                        button.prop('disabled', false).text('<?php esc_html_e( 'Test Connection', 'fp-publisher' ); ?>');
                         
                         if (response.success) {
                             resultDiv.removeClass('error').addClass('success')
@@ -2620,7 +2620,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                                      .html('❌ ' + (response.data.message || 'Connection test failed')).show();
                         }
                     }).fail(function() {
-                        button.prop('disabled', false).text('<?php esc_html_e( 'Test Connection', 'trello-social-auto-publisher' ); ?>');
+                        button.prop('disabled', false).text('<?php esc_html_e( 'Test Connection', 'fp-publisher' ); ?>');
                         resultDiv.removeClass('success').addClass('error')
                                  .html('❌ Failed to test connection').show();
                     });
@@ -2632,22 +2632,22 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                     var container = $('#rate-limit-' + platform);
                     var button = $(this);
                     
-                    button.prop('disabled', true).text('<?php esc_html_e( 'Checking...', 'trello-social-auto-publisher' ); ?>');
+                    button.prop('disabled', true).text('<?php esc_html_e( 'Checking...', 'fp-publisher' ); ?>');
                     
                     $.post(ajaxurl, {
                         action: 'tts_check_rate_limits',
                         platform: platform,
                         nonce: '<?php echo wp_create_nonce( 'tts_check_rate_limits' ); ?>'
                     }, function(response) {
-                        button.prop('disabled', false).text('<?php esc_html_e( 'Check API Limits', 'trello-social-auto-publisher' ); ?>');
+                        button.prop('disabled', false).text('<?php esc_html_e( 'Check API Limits', 'fp-publisher' ); ?>');
                         
                         if (response.success) {
                             var limits = response.data;
                             var html = '<div class="tts-rate-limit-display">';
-                            html += '<strong><?php esc_html_e( 'API Rate Limits:', 'trello-social-auto-publisher' ); ?></strong><br>';
-                            html += '<?php esc_html_e( 'Used:', 'trello-social-auto-publisher' ); ?> ' + limits.used + ' / ' + limits.limit + '<br>';
-                            html += '<?php esc_html_e( 'Remaining:', 'trello-social-auto-publisher' ); ?> ' + limits.remaining + '<br>';
-                            html += '<?php esc_html_e( 'Reset:', 'trello-social-auto-publisher' ); ?> ' + limits.reset_time;
+                            html += '<strong><?php esc_html_e( 'API Rate Limits:', 'fp-publisher' ); ?></strong><br>';
+                            html += '<?php esc_html_e( 'Used:', 'fp-publisher' ); ?> ' + limits.used + ' / ' + limits.limit + '<br>';
+                            html += '<?php esc_html_e( 'Remaining:', 'fp-publisher' ); ?> ' + limits.remaining + '<br>';
+                            html += '<?php esc_html_e( 'Reset:', 'fp-publisher' ); ?> ' + limits.reset_time;
                             html += '</div>';
                             container.append(html);
                         }
@@ -2798,7 +2798,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         if ( ! $configured ) {
             return array(
                 'status' => 'not-configured',
-                'message' => __( 'App credentials not configured', 'trello-social-auto-publisher' )
+                'message' => __( 'App credentials not configured', 'fp-publisher' )
             );
         }
 
@@ -2817,13 +2817,13 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         if ( ! empty( $connected_clients ) ) {
             return array(
                 'status' => 'connected',
-                'message' => sprintf( __( '%d account(s) connected', 'trello-social-auto-publisher' ), count( $connected_clients ) )
+                'message' => sprintf( __( '%d account(s) connected', 'fp-publisher' ), count( $connected_clients ) )
             );
         }
 
         return array(
             'status' => 'configured',
-            'message' => __( 'Ready to connect accounts', 'trello-social-auto-publisher' )
+            'message' => __( 'Ready to connect accounts', 'fp-publisher' )
         );
     }
 
@@ -2902,182 +2902,182 @@ class TTS_Social_Posts_Table extends WP_List_Table {
     public function render_help_page() {
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e( 'Help & Setup Guide', 'trello-social-auto-publisher' ); ?></h1>
+            <h1><?php esc_html_e( 'Help & Setup Guide', 'fp-publisher' ); ?></h1>
             
             <div class="tts-help-container">
                 <div class="tts-help-sidebar">
-                    <h3><?php esc_html_e( 'Quick Links', 'trello-social-auto-publisher' ); ?></h3>
+                    <h3><?php esc_html_e( 'Quick Links', 'fp-publisher' ); ?></h3>
                     <ul>
-                        <li><a href="#overview"><?php esc_html_e( 'Overview', 'trello-social-auto-publisher' ); ?></a></li>
-                        <li><a href="#facebook"><?php esc_html_e( 'Facebook Setup', 'trello-social-auto-publisher' ); ?></a></li>
-                        <li><a href="#instagram"><?php esc_html_e( 'Instagram Setup', 'trello-social-auto-publisher' ); ?></a></li>
-                        <li><a href="#youtube"><?php esc_html_e( 'YouTube Setup', 'trello-social-auto-publisher' ); ?></a></li>
-                        <li><a href="#tiktok"><?php esc_html_e( 'TikTok Setup', 'trello-social-auto-publisher' ); ?></a></li>
-                        <li><a href="#troubleshooting"><?php esc_html_e( 'Troubleshooting', 'trello-social-auto-publisher' ); ?></a></li>
+                        <li><a href="#overview"><?php esc_html_e( 'Overview', 'fp-publisher' ); ?></a></li>
+                        <li><a href="#facebook"><?php esc_html_e( 'Facebook Setup', 'fp-publisher' ); ?></a></li>
+                        <li><a href="#instagram"><?php esc_html_e( 'Instagram Setup', 'fp-publisher' ); ?></a></li>
+                        <li><a href="#youtube"><?php esc_html_e( 'YouTube Setup', 'fp-publisher' ); ?></a></li>
+                        <li><a href="#tiktok"><?php esc_html_e( 'TikTok Setup', 'fp-publisher' ); ?></a></li>
+                        <li><a href="#troubleshooting"><?php esc_html_e( 'Troubleshooting', 'fp-publisher' ); ?></a></li>
                     </ul>
                     
                     <div class="tts-help-actions">
                         <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-publisher-social-connections' ) ); ?>" class="button button-primary">
-                            <?php esc_html_e( 'Configure Social Apps', 'trello-social-auto-publisher' ); ?>
+                            <?php esc_html_e( 'Configure Social Apps', 'fp-publisher' ); ?>
                         </a>
                         <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-publisher-client-wizard' ) ); ?>" class="button">
-                            <?php esc_html_e( 'Create Client', 'trello-social-auto-publisher' ); ?>
+                            <?php esc_html_e( 'Create Client', 'fp-publisher' ); ?>
                         </a>
                     </div>
                 </div>
                 
                 <div class="tts-help-content">
                     <section id="overview">
-                        <h2><?php esc_html_e( '🚀 Getting Started', 'trello-social-auto-publisher' ); ?></h2>
-                        <p><?php esc_html_e( 'To use the Social Auto Publisher, you need to:', 'trello-social-auto-publisher' ); ?></p>
+                        <h2><?php esc_html_e( '🚀 Getting Started', 'fp-publisher' ); ?></h2>
+                        <p><?php esc_html_e( 'To use the Social Auto Publisher, you need to:', 'fp-publisher' ); ?></p>
                         <ol>
-                            <li><strong><?php esc_html_e( 'Create developer apps', 'trello-social-auto-publisher' ); ?></strong> <?php esc_html_e( 'on each social media platform', 'trello-social-auto-publisher' ); ?></li>
-                            <li><strong><?php esc_html_e( 'Configure OAuth credentials', 'trello-social-auto-publisher' ); ?></strong> <?php esc_html_e( 'in Social Connections', 'trello-social-auto-publisher' ); ?></li>
-                            <li><strong><?php esc_html_e( 'Connect your accounts', 'trello-social-auto-publisher' ); ?></strong> <?php esc_html_e( 'using the OAuth flow', 'trello-social-auto-publisher' ); ?></li>
-                            <li><strong><?php esc_html_e( 'Create clients', 'trello-social-auto-publisher' ); ?></strong> <?php esc_html_e( 'and assign social accounts', 'trello-social-auto-publisher' ); ?></li>
+                            <li><strong><?php esc_html_e( 'Create developer apps', 'fp-publisher' ); ?></strong> <?php esc_html_e( 'on each social media platform', 'fp-publisher' ); ?></li>
+                            <li><strong><?php esc_html_e( 'Configure OAuth credentials', 'fp-publisher' ); ?></strong> <?php esc_html_e( 'in Social Connections', 'fp-publisher' ); ?></li>
+                            <li><strong><?php esc_html_e( 'Connect your accounts', 'fp-publisher' ); ?></strong> <?php esc_html_e( 'using the OAuth flow', 'fp-publisher' ); ?></li>
+                            <li><strong><?php esc_html_e( 'Create clients', 'fp-publisher' ); ?></strong> <?php esc_html_e( 'and assign social accounts', 'fp-publisher' ); ?></li>
                         </ol>
                         
                         <div class="tts-notice-warning">
-                            <p><strong><?php esc_html_e( 'Important:', 'trello-social-auto-publisher' ); ?></strong> <?php esc_html_e( 'Each social media platform requires you to create a developer application. This is a one-time setup per platform.', 'trello-social-auto-publisher' ); ?></p>
+                            <p><strong><?php esc_html_e( 'Important:', 'fp-publisher' ); ?></strong> <?php esc_html_e( 'Each social media platform requires you to create a developer application. This is a one-time setup per platform.', 'fp-publisher' ); ?></p>
                         </div>
                     </section>
 
                     <section id="facebook">
-                        <h2><?php esc_html_e( '📘 Facebook Setup', 'trello-social-auto-publisher' ); ?></h2>
-                        <h3><?php esc_html_e( 'Step 1: Create Facebook App', 'trello-social-auto-publisher' ); ?></h3>
+                        <h2><?php esc_html_e( '📘 Facebook Setup', 'fp-publisher' ); ?></h2>
+                        <h3><?php esc_html_e( 'Step 1: Create Facebook App', 'fp-publisher' ); ?></h3>
                         <ol>
-                            <li><?php esc_html_e( 'Visit', 'trello-social-auto-publisher' ); ?> <a href="https://developers.facebook.com/apps/" target="_blank">Facebook Developers</a></li>
-                            <li><?php esc_html_e( 'Click "Create App" → "Business" → "Consumer"', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Enter app name and contact email', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Add "Facebook Login" product', 'trello-social-auto-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Visit', 'fp-publisher' ); ?> <a href="https://developers.facebook.com/apps/" target="_blank">Facebook Developers</a></li>
+                            <li><?php esc_html_e( 'Click "Create App" → "Business" → "Consumer"', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Enter app name and contact email', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Add "Facebook Login" product', 'fp-publisher' ); ?></li>
                         </ol>
                         
-                        <h3><?php esc_html_e( 'Step 2: Configure OAuth Settings', 'trello-social-auto-publisher' ); ?></h3>
+                        <h3><?php esc_html_e( 'Step 2: Configure OAuth Settings', 'fp-publisher' ); ?></h3>
                         <ol>
-                            <li><?php esc_html_e( 'Go to Facebook Login → Settings', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Add redirect URI:', 'trello-social-auto-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php?action=tts_oauth_facebook' ) ); ?></code></li>
-                            <li><?php esc_html_e( 'Enable "Use Strict Mode for Redirect URIs"', 'trello-social-auto-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Go to Facebook Login → Settings', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Add redirect URI:', 'fp-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php?action=tts_oauth_facebook' ) ); ?></code></li>
+                            <li><?php esc_html_e( 'Enable "Use Strict Mode for Redirect URIs"', 'fp-publisher' ); ?></li>
                         </ol>
                         
-                        <h3><?php esc_html_e( 'Step 3: Get Credentials', 'trello-social-auto-publisher' ); ?></h3>
+                        <h3><?php esc_html_e( 'Step 3: Get Credentials', 'fp-publisher' ); ?></h3>
                         <ol>
-                            <li><?php esc_html_e( 'Go to Settings → Basic', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Copy App ID and App Secret', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Enter these in Social Connections page', 'trello-social-auto-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Go to Settings → Basic', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Copy App ID and App Secret', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Enter these in Social Connections page', 'fp-publisher' ); ?></li>
                         </ol>
                     </section>
 
                     <section id="instagram">
-                        <h2><?php esc_html_e( '📷 Instagram Setup', 'trello-social-auto-publisher' ); ?></h2>
-                        <p><?php esc_html_e( 'Instagram uses the same Facebook app with additional configuration:', 'trello-social-auto-publisher' ); ?></p>
+                        <h2><?php esc_html_e( '📷 Instagram Setup', 'fp-publisher' ); ?></h2>
+                        <p><?php esc_html_e( 'Instagram uses the same Facebook app with additional configuration:', 'fp-publisher' ); ?></p>
                         <ol>
-                            <li><?php esc_html_e( 'In your Facebook app, add "Instagram Basic Display" product', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Configure redirect URI:', 'trello-social-auto-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php?action=tts_oauth_instagram' ) ); ?></code></li>
-                            <li><?php esc_html_e( 'Add your Instagram account as a test user', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Use the same App ID and App Secret from Facebook', 'trello-social-auto-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'In your Facebook app, add "Instagram Basic Display" product', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Configure redirect URI:', 'fp-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php?action=tts_oauth_instagram' ) ); ?></code></li>
+                            <li><?php esc_html_e( 'Add your Instagram account as a test user', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Use the same App ID and App Secret from Facebook', 'fp-publisher' ); ?></li>
                         </ol>
                     </section>
 
                     <section id="youtube">
-                        <h2><?php esc_html_e( '🎥 YouTube Setup', 'trello-social-auto-publisher' ); ?></h2>
-                        <h3><?php esc_html_e( 'Step 1: Create Google Project', 'trello-social-auto-publisher' ); ?></h3>
+                        <h2><?php esc_html_e( '🎥 YouTube Setup', 'fp-publisher' ); ?></h2>
+                        <h3><?php esc_html_e( 'Step 1: Create Google Project', 'fp-publisher' ); ?></h3>
                         <ol>
-                            <li><?php esc_html_e( 'Visit', 'trello-social-auto-publisher' ); ?> <a href="https://console.developers.google.com/" target="_blank">Google Developers Console</a></li>
-                            <li><?php esc_html_e( 'Create a new project or select existing one', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Enable "YouTube Data API v3"', 'trello-social-auto-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Visit', 'fp-publisher' ); ?> <a href="https://console.developers.google.com/" target="_blank">Google Developers Console</a></li>
+                            <li><?php esc_html_e( 'Create a new project or select existing one', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Enable "YouTube Data API v3"', 'fp-publisher' ); ?></li>
                         </ol>
                         
-                        <h3><?php esc_html_e( 'Step 2: Create OAuth Credentials', 'trello-social-auto-publisher' ); ?></h3>
+                        <h3><?php esc_html_e( 'Step 2: Create OAuth Credentials', 'fp-publisher' ); ?></h3>
                         <ol>
-                            <li><?php esc_html_e( 'Go to Credentials → Create Credentials → OAuth 2.0 Client IDs', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Choose "Web application"', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Add redirect URI:', 'trello-social-auto-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php?action=tts_oauth_youtube' ) ); ?></code></li>
+                            <li><?php esc_html_e( 'Go to Credentials → Create Credentials → OAuth 2.0 Client IDs', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Choose "Web application"', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Add redirect URI:', 'fp-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php?action=tts_oauth_youtube' ) ); ?></code></li>
                         </ol>
                     </section>
 
                     <section id="tiktok">
-                        <h2><?php esc_html_e( '🎵 TikTok Setup', 'trello-social-auto-publisher' ); ?></h2>
+                        <h2><?php esc_html_e( '🎵 TikTok Setup', 'fp-publisher' ); ?></h2>
                         <div class="tts-notice-warning">
-                            <p><strong><?php esc_html_e( 'Note:', 'trello-social-auto-publisher' ); ?></strong> <?php esc_html_e( 'TikTok requires developer account approval, which can take several days.', 'trello-social-auto-publisher' ); ?></p>
+                            <p><strong><?php esc_html_e( 'Note:', 'fp-publisher' ); ?></strong> <?php esc_html_e( 'TikTok requires developer account approval, which can take several days.', 'fp-publisher' ); ?></p>
                         </div>
                         <ol>
-                            <li><?php esc_html_e( 'Visit', 'trello-social-auto-publisher' ); ?> <a href="https://developers.tiktok.com/" target="_blank">TikTok Developers</a></li>
-                            <li><?php esc_html_e( 'Apply for developer access', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Create a new app in the developer portal', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Configure redirect URI:', 'trello-social-auto-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php?action=tts_oauth_tiktok' ) ); ?></code></li>
+                            <li><?php esc_html_e( 'Visit', 'fp-publisher' ); ?> <a href="https://developers.tiktok.com/" target="_blank">TikTok Developers</a></li>
+                            <li><?php esc_html_e( 'Apply for developer access', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Create a new app in the developer portal', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Configure redirect URI:', 'fp-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php?action=tts_oauth_tiktok' ) ); ?></code></li>
                         </ol>
                     </section>
 
                     <section id="troubleshooting">
-                        <h2><?php esc_html_e( '🔧 Troubleshooting Guide', 'trello-social-auto-publisher' ); ?></h2>
+                        <h2><?php esc_html_e( '🔧 Troubleshooting Guide', 'fp-publisher' ); ?></h2>
                         
-                        <h3><?php esc_html_e( 'Common Issues and Solutions', 'trello-social-auto-publisher' ); ?></h3>
+                        <h3><?php esc_html_e( 'Common Issues and Solutions', 'fp-publisher' ); ?></h3>
                         
                         <div class="tts-troubleshoot-item">
-                            <h4><?php esc_html_e( '❌ "OAuth verification failed" Error', 'trello-social-auto-publisher' ); ?></h4>
-                            <p><strong><?php esc_html_e( 'Causes:', 'trello-social-auto-publisher' ); ?></strong></p>
+                            <h4><?php esc_html_e( '❌ "OAuth verification failed" Error', 'fp-publisher' ); ?></h4>
+                            <p><strong><?php esc_html_e( 'Causes:', 'fp-publisher' ); ?></strong></p>
                             <ul>
-                                <li><?php esc_html_e( 'Incorrect redirect URI in app settings', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'App ID/Secret mismatch', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Session issues', 'trello-social-auto-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Incorrect redirect URI in app settings', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'App ID/Secret mismatch', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Session issues', 'fp-publisher' ); ?></li>
                             </ul>
-                            <p><strong><?php esc_html_e( 'Solutions:', 'trello-social-auto-publisher' ); ?></strong></p>
+                            <p><strong><?php esc_html_e( 'Solutions:', 'fp-publisher' ); ?></strong></p>
                             <ol>
-                                <li><?php esc_html_e( 'Verify redirect URI matches exactly:', 'trello-social-auto-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php' ) ); ?></code></li>
-                                <li><?php esc_html_e( 'Double-check App ID and App Secret', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Clear browser cache and cookies', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Try the connection in an incognito/private window', 'trello-social-auto-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Verify redirect URI matches exactly:', 'fp-publisher' ); ?> <code><?php echo esc_url( admin_url( 'admin-post.php' ) ); ?></code></li>
+                                <li><?php esc_html_e( 'Double-check App ID and App Secret', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Clear browser cache and cookies', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Try the connection in an incognito/private window', 'fp-publisher' ); ?></li>
                             </ol>
                         </div>
                         
                         <div class="tts-troubleshoot-item">
-                            <h4><?php esc_html_e( '🔑 "Failed to obtain access token" Error', 'trello-social-auto-publisher' ); ?></h4>
-                            <p><strong><?php esc_html_e( 'Causes:', 'trello-social-auto-publisher' ); ?></strong></p>
+                            <h4><?php esc_html_e( '🔑 "Failed to obtain access token" Error', 'fp-publisher' ); ?></h4>
+                            <p><strong><?php esc_html_e( 'Causes:', 'fp-publisher' ); ?></strong></p>
                             <ul>
-                                <li><?php esc_html_e( 'Invalid app credentials', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'App not approved/active', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Insufficient permissions granted', 'trello-social-auto-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Invalid app credentials', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'App not approved/active', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Insufficient permissions granted', 'fp-publisher' ); ?></li>
                             </ul>
-                            <p><strong><?php esc_html_e( 'Solutions:', 'trello-social-auto-publisher' ); ?></strong></p>
+                            <p><strong><?php esc_html_e( 'Solutions:', 'fp-publisher' ); ?></strong></p>
                             <ol>
-                                <li><?php esc_html_e( 'Verify app is in "Live" mode (not development)', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Check that required permissions are granted during OAuth', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Use the "Test Connection" button to validate credentials', 'trello-social-auto-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Verify app is in "Live" mode (not development)', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Check that required permissions are granted during OAuth', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Use the "Test Connection" button to validate credentials', 'fp-publisher' ); ?></li>
                             </ol>
                         </div>
                         
                         <div class="tts-troubleshoot-item">
-                            <h4><?php esc_html_e( '⚠️ Rate Limiting Issues', 'trello-social-auto-publisher' ); ?></h4>
-                            <p><strong><?php esc_html_e( 'Symptoms:', 'trello-social-auto-publisher' ); ?></strong></p>
+                            <h4><?php esc_html_e( '⚠️ Rate Limiting Issues', 'fp-publisher' ); ?></h4>
+                            <p><strong><?php esc_html_e( 'Symptoms:', 'fp-publisher' ); ?></strong></p>
                             <ul>
-                                <li><?php esc_html_e( 'Posts failing to publish', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( '"Rate limit exceeded" errors in logs', 'trello-social-auto-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Posts failing to publish', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( '"Rate limit exceeded" errors in logs', 'fp-publisher' ); ?></li>
                             </ul>
-                            <p><strong><?php esc_html_e( 'Solutions:', 'trello-social-auto-publisher' ); ?></strong></p>
+                            <p><strong><?php esc_html_e( 'Solutions:', 'fp-publisher' ); ?></strong></p>
                             <ol>
-                                <li><?php esc_html_e( 'Use "Check API Limits" button to monitor usage', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Reduce posting frequency in high-volume periods', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Consider upgrading to business/developer API tiers', 'trello-social-auto-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Use "Check API Limits" button to monitor usage', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Reduce posting frequency in high-volume periods', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Consider upgrading to business/developer API tiers', 'fp-publisher' ); ?></li>
                             </ol>
                         </div>
 
                         <div class="tts-troubleshoot-item">
-                            <h4><?php esc_html_e( '🔧 Performance Issues', 'trello-social-auto-publisher' ); ?></h4>
-                            <p><strong><?php esc_html_e( 'Solutions:', 'trello-social-auto-publisher' ); ?></strong></p>
+                            <h4><?php esc_html_e( '🔧 Performance Issues', 'fp-publisher' ); ?></h4>
+                            <p><strong><?php esc_html_e( 'Solutions:', 'fp-publisher' ); ?></strong></p>
                             <ol>
-                                <li><?php esc_html_e( 'Enable WordPress object caching', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Limit number of concurrent social posts', 'trello-social-auto-publisher' ); ?></li>
-                                <li><?php esc_html_e( 'Monitor system performance in Dashboard', 'trello-social-auto-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Enable WordPress object caching', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Limit number of concurrent social posts', 'fp-publisher' ); ?></li>
+                                <li><?php esc_html_e( 'Monitor system performance in Dashboard', 'fp-publisher' ); ?></li>
                             </ol>
                         </div>
                         
-                        <h3><?php esc_html_e( 'Getting Support', 'trello-social-auto-publisher' ); ?></h3>
-                        <p><?php esc_html_e( 'If you continue experiencing issues:', 'trello-social-auto-publisher' ); ?></p>
+                        <h3><?php esc_html_e( 'Getting Support', 'fp-publisher' ); ?></h3>
+                        <p><?php esc_html_e( 'If you continue experiencing issues:', 'fp-publisher' ); ?></p>
                         <ol>
-                            <li><?php esc_html_e( 'Check the plugin logs for detailed error messages', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Use the "Test Connection" feature to isolate the problem', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Document the exact error message and steps to reproduce', 'trello-social-auto-publisher' ); ?></li>
-                            <li><?php esc_html_e( 'Contact support with your findings', 'trello-social-auto-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Check the plugin logs for detailed error messages', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Use the "Test Connection" feature to isolate the problem', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Document the exact error message and steps to reproduce', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Contact support with your findings', 'fp-publisher' ); ?></li>
                         </ol>
                     </section>
                 </div>
@@ -3198,7 +3198,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         check_ajax_referer( 'tts_test_connection', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( __( 'You do not have sufficient permissions to access this page.', 'trello-social-auto-publisher' ) );
+            wp_die( __( 'You do not have sufficient permissions to access this page.', 'fp-publisher' ) );
         }
         
         $platform = sanitize_key( $_POST['platform'] );
@@ -3221,7 +3221,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         check_ajax_referer( 'tts_check_rate_limits', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( __( 'You do not have sufficient permissions to access this page.', 'trello-social-auto-publisher' ) );
+            wp_die( __( 'You do not have sufficient permissions to access this page.', 'fp-publisher' ) );
         }
         
         $platform = sanitize_key( $_POST['platform'] );
@@ -3241,7 +3241,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         switch ( $platform ) {
             case 'facebook':
                 if ( empty( $settings['app_id'] ) || empty( $settings['app_secret'] ) ) {
-                    return array( 'success' => false, 'message' => __( 'App credentials not configured', 'trello-social-auto-publisher' ) );
+                    return array( 'success' => false, 'message' => __( 'App credentials not configured', 'fp-publisher' ) );
                 }
                 
                 $response = wp_remote_get( 'https://graph.facebook.com/v18.0/oauth/access_token?' . http_build_query( array(
@@ -3251,25 +3251,25 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                 ) ) );
                 
                 if ( is_wp_error( $response ) ) {
-                    return array( 'success' => false, 'message' => __( 'Connection failed: ', 'trello-social-auto-publisher' ) . $response->get_error_message() );
+                    return array( 'success' => false, 'message' => __( 'Connection failed: ', 'fp-publisher' ) . $response->get_error_message() );
                 }
                 
                 $body = json_decode( wp_remote_retrieve_body( $response ), true );
                 if ( isset( $body['access_token'] ) ) {
-                    return array( 'success' => true, 'message' => __( 'Facebook app credentials valid', 'trello-social-auto-publisher' ) );
+                    return array( 'success' => true, 'message' => __( 'Facebook app credentials valid', 'fp-publisher' ) );
                 } else {
-                    return array( 'success' => false, 'message' => __( 'Invalid Facebook app credentials', 'trello-social-auto-publisher' ) );
+                    return array( 'success' => false, 'message' => __( 'Invalid Facebook app credentials', 'fp-publisher' ) );
                 }
                 
             case 'youtube':
                 if ( empty( $settings['client_id'] ) || empty( $settings['client_secret'] ) ) {
-                    return array( 'success' => false, 'message' => __( 'Client credentials not configured', 'trello-social-auto-publisher' ) );
+                    return array( 'success' => false, 'message' => __( 'Client credentials not configured', 'fp-publisher' ) );
                 }
                 
-                return array( 'success' => true, 'message' => __( 'YouTube client credentials format valid', 'trello-social-auto-publisher' ) );
+                return array( 'success' => true, 'message' => __( 'YouTube client credentials format valid', 'fp-publisher' ) );
                 
             default:
-                return array( 'success' => true, 'message' => __( 'Platform configuration appears valid', 'trello-social-auto-publisher' ) );
+                return array( 'success' => true, 'message' => __( 'Platform configuration appears valid', 'fp-publisher' ) );
         }
     }
     
@@ -3445,7 +3445,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         }
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'fp-publisher' ) ) );
         }
         
         $export_options = array(
@@ -3468,7 +3468,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
             file_put_contents( $file_path, json_encode( $result['data'], JSON_PRETTY_PRINT ) );
             
             wp_send_json_success( array( 
-                'message' => __( 'Export completed successfully', 'trello-social-auto-publisher' ),
+                'message' => __( 'Export completed successfully', 'fp-publisher' ),
                 'download_url' => $upload_dir['url'] . '/' . $filename,
                 'file_size' => $result['file_size']
             ) );
@@ -3486,18 +3486,18 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         }
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'fp-publisher' ) ) );
         }
         
         if ( ! isset( $_FILES['import_file'] ) ) {
-            wp_send_json_error( array( 'message' => __( 'No file provided', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'No file provided', 'fp-publisher' ) ) );
         }
         
         $file = $_FILES['import_file'];
         $import_data = json_decode( file_get_contents( $file['tmp_name'] ), true );
         
         if ( json_last_error() !== JSON_ERROR_NONE ) {
-            wp_send_json_error( array( 'message' => __( 'Invalid JSON file', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Invalid JSON file', 'fp-publisher' ) ) );
         }
         
         $import_options = array(
@@ -3511,7 +3511,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         
         if ( $result['success'] ) {
             wp_send_json_success( array( 
-                'message' => __( 'Import completed successfully', 'trello-social-auto-publisher' ),
+                'message' => __( 'Import completed successfully', 'fp-publisher' ),
                 'log' => $result['log']
             ) );
         } else {
@@ -3528,7 +3528,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         }
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'fp-publisher' ) ) );
         }
         
         $tasks = array(
@@ -3543,11 +3543,11 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         
         if ( $result['success'] ) {
             wp_send_json_success( array( 
-                'message' => __( 'System maintenance completed', 'trello-social-auto-publisher' ),
+                'message' => __( 'System maintenance completed', 'fp-publisher' ),
                 'log' => $result['log']
             ) );
         } else {
-            wp_send_json_error( array( 'message' => __( 'Maintenance failed', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Maintenance failed', 'fp-publisher' ) ) );
         }
     }
     
@@ -3560,13 +3560,13 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         }
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'fp-publisher' ) ) );
         }
         
         $report = TTS_Advanced_Utils::generate_system_report();
         
         wp_send_json_success( array( 
-            'message' => __( 'System report generated', 'trello-social-auto-publisher' ),
+            'message' => __( 'System report generated', 'fp-publisher' ),
             'report' => $report
         ) );
     }
@@ -3627,14 +3627,14 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         }
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'fp-publisher' ) ) );
         }
         
         // Perform fresh health check
         $health_data = TTS_Monitoring::perform_health_check();
         
         wp_send_json_success( array( 
-            'message' => __( 'Health check completed', 'trello-social-auto-publisher' ),
+            'message' => __( 'Health check completed', 'fp-publisher' ),
             'health_data' => $health_data
         ) );
     }
@@ -3648,46 +3648,46 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         }
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'fp-publisher' ) ) );
         }
         
         ob_start();
         ?>
         <div class="tts-modal-content">
-            <h2><?php esc_html_e( 'Export Data', 'trello-social-auto-publisher' ); ?></h2>
+            <h2><?php esc_html_e( 'Export Data', 'fp-publisher' ); ?></h2>
             <form id="tts-export-form">
                 <div class="tts-export-options">
                     <label>
                         <input type="checkbox" name="export_settings" checked>
-                        <?php esc_html_e( 'Plugin Settings', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Plugin Settings', 'fp-publisher' ); ?>
                     </label>
                     <label>
                         <input type="checkbox" name="export_social_apps" checked>
-                        <?php esc_html_e( 'Social Media Configurations', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Social Media Configurations', 'fp-publisher' ); ?>
                     </label>
                     <label>
                         <input type="checkbox" name="export_clients" checked>
-                        <?php esc_html_e( 'Clients', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Clients', 'fp-publisher' ); ?>
                     </label>
                     <label>
                         <input type="checkbox" name="export_posts">
-                        <?php esc_html_e( 'Social Posts (last 100)', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Social Posts (last 100)', 'fp-publisher' ); ?>
                     </label>
                     <label>
                         <input type="checkbox" name="export_logs">
-                        <?php esc_html_e( 'Recent Logs (last 30 days)', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Recent Logs (last 30 days)', 'fp-publisher' ); ?>
                     </label>
                     <label>
                         <input type="checkbox" name="export_analytics">
-                        <?php esc_html_e( 'Analytics Data', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Analytics Data', 'fp-publisher' ); ?>
                     </label>
                 </div>
                 <div class="tts-modal-actions">
                     <button type="submit" class="tts-btn primary">
-                        <?php esc_html_e( 'Export', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Export', 'fp-publisher' ); ?>
                     </button>
                     <button type="button" class="tts-btn secondary tts-modal-close">
-                        <?php esc_html_e( 'Cancel', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Cancel', 'fp-publisher' ); ?>
                     </button>
                 </div>
             </form>
@@ -3709,47 +3709,47 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         }
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'fp-publisher' ) ) );
         }
         
         ob_start();
         ?>
         <div class="tts-modal-content">
-            <h2><?php esc_html_e( 'Import Data', 'trello-social-auto-publisher' ); ?></h2>
+            <h2><?php esc_html_e( 'Import Data', 'fp-publisher' ); ?></h2>
             <form id="tts-import-form" enctype="multipart/form-data">
                 <div class="tts-import-file">
                     <label for="import_file">
-                        <?php esc_html_e( 'Select Export File:', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Select Export File:', 'fp-publisher' ); ?>
                     </label>
                     <input type="file" id="import_file" name="import_file" accept=".json" required>
                 </div>
                 
                 <div class="tts-import-options">
-                    <h4><?php esc_html_e( 'Import Options:', 'trello-social-auto-publisher' ); ?></h4>
+                    <h4><?php esc_html_e( 'Import Options:', 'fp-publisher' ); ?></h4>
                     <label>
                         <input type="checkbox" name="overwrite_settings">
-                        <?php esc_html_e( 'Overwrite existing settings', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Overwrite existing settings', 'fp-publisher' ); ?>
                     </label>
                     <label>
                         <input type="checkbox" name="overwrite_social_apps">
-                        <?php esc_html_e( 'Overwrite social media configurations', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Overwrite social media configurations', 'fp-publisher' ); ?>
                     </label>
                     <label>
                         <input type="checkbox" name="import_clients" checked>
-                        <?php esc_html_e( 'Import clients', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Import clients', 'fp-publisher' ); ?>
                     </label>
                     <label>
                         <input type="checkbox" name="import_posts">
-                        <?php esc_html_e( 'Import social posts (as drafts)', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Import social posts (as drafts)', 'fp-publisher' ); ?>
                     </label>
                 </div>
                 
                 <div class="tts-modal-actions">
                     <button type="submit" class="tts-btn primary">
-                        <?php esc_html_e( 'Import', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Import', 'fp-publisher' ); ?>
                     </button>
                     <button type="button" class="tts-btn secondary tts-modal-close">
-                        <?php esc_html_e( 'Cancel', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Cancel', 'fp-publisher' ); ?>
                     </button>
                 </div>
             </form>

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-ai-features-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-ai-features-page.php
@@ -66,7 +66,7 @@ class TTS_AI_Features_Page {
     public function render_page() {
         ?>
         <div class="wrap tts-ai-features-page">
-            <h1><?php esc_html_e( 'AI & Advanced Features', 'trello-social-auto-publisher' ); ?></h1>
+            <h1><?php esc_html_e( 'AI & Advanced Features', 'fp-publisher' ); ?></h1>
             
             <div class="tts-features-grid">
                 
@@ -74,57 +74,57 @@ class TTS_AI_Features_Page {
                 <div class="tts-feature-card">
                     <div class="tts-feature-header">
                         <span class="tts-feature-icon">🤖</span>
-                        <h2><?php esc_html_e( 'AI Content Enhancement', 'trello-social-auto-publisher' ); ?></h2>
+                        <h2><?php esc_html_e( 'AI Content Enhancement', 'fp-publisher' ); ?></h2>
                     </div>
                     <div class="tts-feature-content">
-                        <p><?php esc_html_e( 'Leverage AI to optimize your content for maximum engagement across all social platforms.', 'trello-social-auto-publisher' ); ?></p>
+                        <p><?php esc_html_e( 'Leverage AI to optimize your content for maximum engagement across all social platforms.', 'fp-publisher' ); ?></p>
                         
                         <div class="tts-ai-tools">
                             <div class="tts-tool">
-                                <h4><?php esc_html_e( 'AI Hashtag Generator', 'trello-social-auto-publisher' ); ?></h4>
-                                <textarea id="hashtag-content" placeholder="<?php esc_attr_e( 'Enter your content here...', 'trello-social-auto-publisher' ); ?>"></textarea>
+                                <h4><?php esc_html_e( 'AI Hashtag Generator', 'fp-publisher' ); ?></h4>
+                                <textarea id="hashtag-content" placeholder="<?php esc_attr_e( 'Enter your content here...', 'fp-publisher' ); ?>"></textarea>
                                 <select id="hashtag-platform">
-                                    <option value="general"><?php esc_html_e( 'General', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="instagram"><?php esc_html_e( 'Instagram', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="facebook"><?php esc_html_e( 'Facebook', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="twitter"><?php esc_html_e( 'Twitter', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="linkedin"><?php esc_html_e( 'LinkedIn', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="tiktok"><?php esc_html_e( 'TikTok', 'trello-social-auto-publisher' ); ?></option>
+                                    <option value="general"><?php esc_html_e( 'General', 'fp-publisher' ); ?></option>
+                                    <option value="instagram"><?php esc_html_e( 'Instagram', 'fp-publisher' ); ?></option>
+                                    <option value="facebook"><?php esc_html_e( 'Facebook', 'fp-publisher' ); ?></option>
+                                    <option value="twitter"><?php esc_html_e( 'Twitter', 'fp-publisher' ); ?></option>
+                                    <option value="linkedin"><?php esc_html_e( 'LinkedIn', 'fp-publisher' ); ?></option>
+                                    <option value="tiktok"><?php esc_html_e( 'TikTok', 'fp-publisher' ); ?></option>
                                 </select>
                                 <button type="button" class="button button-primary" id="generate-hashtags">
-                                    <?php esc_html_e( 'Generate Hashtags', 'trello-social-auto-publisher' ); ?>
+                                    <?php esc_html_e( 'Generate Hashtags', 'fp-publisher' ); ?>
                                 </button>
                                 <div id="hashtag-results" class="tts-results"></div>
                             </div>
                             
                             <div class="tts-tool">
-                                <h4><?php esc_html_e( 'Content Performance Predictor', 'trello-social-auto-publisher' ); ?></h4>
-                                <textarea id="predict-content" placeholder="<?php esc_attr_e( 'Enter content to analyze...', 'trello-social-auto-publisher' ); ?>"></textarea>
+                                <h4><?php esc_html_e( 'Content Performance Predictor', 'fp-publisher' ); ?></h4>
+                                <textarea id="predict-content" placeholder="<?php esc_attr_e( 'Enter content to analyze...', 'fp-publisher' ); ?>"></textarea>
                                 <select id="predict-platform">
-                                    <option value="general"><?php esc_html_e( 'General', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="instagram"><?php esc_html_e( 'Instagram', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="facebook"><?php esc_html_e( 'Facebook', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="twitter"><?php esc_html_e( 'Twitter', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="linkedin"><?php esc_html_e( 'LinkedIn', 'trello-social-auto-publisher' ); ?></option>
+                                    <option value="general"><?php esc_html_e( 'General', 'fp-publisher' ); ?></option>
+                                    <option value="instagram"><?php esc_html_e( 'Instagram', 'fp-publisher' ); ?></option>
+                                    <option value="facebook"><?php esc_html_e( 'Facebook', 'fp-publisher' ); ?></option>
+                                    <option value="twitter"><?php esc_html_e( 'Twitter', 'fp-publisher' ); ?></option>
+                                    <option value="linkedin"><?php esc_html_e( 'LinkedIn', 'fp-publisher' ); ?></option>
                                 </select>
                                 <button type="button" class="button button-primary" id="predict-performance">
-                                    <?php esc_html_e( 'Predict Performance', 'trello-social-auto-publisher' ); ?>
+                                    <?php esc_html_e( 'Predict Performance', 'fp-publisher' ); ?>
                                 </button>
                                 <div id="prediction-results" class="tts-results"></div>
                             </div>
                             
                             <div class="tts-tool">
-                                <h4><?php esc_html_e( 'Content Suggestions', 'trello-social-auto-publisher' ); ?></h4>
-                                <input type="text" id="suggestion-topic" placeholder="<?php esc_attr_e( 'Enter topic or keyword...', 'trello-social-auto-publisher' ); ?>">
+                                <h4><?php esc_html_e( 'Content Suggestions', 'fp-publisher' ); ?></h4>
+                                <input type="text" id="suggestion-topic" placeholder="<?php esc_attr_e( 'Enter topic or keyword...', 'fp-publisher' ); ?>">
                                 <select id="suggestion-platform">
-                                    <option value="instagram"><?php esc_html_e( 'Instagram', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="facebook"><?php esc_html_e( 'Facebook', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="twitter"><?php esc_html_e( 'Twitter', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="linkedin"><?php esc_html_e( 'LinkedIn', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="tiktok"><?php esc_html_e( 'TikTok', 'trello-social-auto-publisher' ); ?></option>
+                                    <option value="instagram"><?php esc_html_e( 'Instagram', 'fp-publisher' ); ?></option>
+                                    <option value="facebook"><?php esc_html_e( 'Facebook', 'fp-publisher' ); ?></option>
+                                    <option value="twitter"><?php esc_html_e( 'Twitter', 'fp-publisher' ); ?></option>
+                                    <option value="linkedin"><?php esc_html_e( 'LinkedIn', 'fp-publisher' ); ?></option>
+                                    <option value="tiktok"><?php esc_html_e( 'TikTok', 'fp-publisher' ); ?></option>
                                 </select>
                                 <button type="button" class="button button-primary" id="get-suggestions">
-                                    <?php esc_html_e( 'Get Suggestions', 'trello-social-auto-publisher' ); ?>
+                                    <?php esc_html_e( 'Get Suggestions', 'fp-publisher' ); ?>
                                 </button>
                                 <div id="suggestion-results" class="tts-results"></div>
                             </div>
@@ -136,31 +136,31 @@ class TTS_AI_Features_Page {
                 <div class="tts-feature-card">
                     <div class="tts-feature-header">
                         <span class="tts-feature-icon">📊</span>
-                        <h2><?php esc_html_e( 'Competitor Analysis', 'trello-social-auto-publisher' ); ?></h2>
+                        <h2><?php esc_html_e( 'Competitor Analysis', 'fp-publisher' ); ?></h2>
                     </div>
                     <div class="tts-feature-content">
-                        <p><?php esc_html_e( 'Track and analyze your competitors\' social media performance to stay ahead.', 'trello-social-auto-publisher' ); ?></p>
+                        <p><?php esc_html_e( 'Track and analyze your competitors\' social media performance to stay ahead.', 'fp-publisher' ); ?></p>
                         
                         <div class="tts-competitor-tools">
                             <div class="tts-add-competitor">
-                                <h4><?php esc_html_e( 'Add Competitor', 'trello-social-auto-publisher' ); ?></h4>
-                                <input type="text" id="competitor-name" placeholder="<?php esc_attr_e( 'Competitor name', 'trello-social-auto-publisher' ); ?>">
+                                <h4><?php esc_html_e( 'Add Competitor', 'fp-publisher' ); ?></h4>
+                                <input type="text" id="competitor-name" placeholder="<?php esc_attr_e( 'Competitor name', 'fp-publisher' ); ?>">
                                 <select id="competitor-platform">
-                                    <option value="instagram"><?php esc_html_e( 'Instagram', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="facebook"><?php esc_html_e( 'Facebook', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="twitter"><?php esc_html_e( 'Twitter', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="linkedin"><?php esc_html_e( 'LinkedIn', 'trello-social-auto-publisher' ); ?></option>
-                                    <option value="tiktok"><?php esc_html_e( 'TikTok', 'trello-social-auto-publisher' ); ?></option>
+                                    <option value="instagram"><?php esc_html_e( 'Instagram', 'fp-publisher' ); ?></option>
+                                    <option value="facebook"><?php esc_html_e( 'Facebook', 'fp-publisher' ); ?></option>
+                                    <option value="twitter"><?php esc_html_e( 'Twitter', 'fp-publisher' ); ?></option>
+                                    <option value="linkedin"><?php esc_html_e( 'LinkedIn', 'fp-publisher' ); ?></option>
+                                    <option value="tiktok"><?php esc_html_e( 'TikTok', 'fp-publisher' ); ?></option>
                                 </select>
-                                <input type="text" id="competitor-handle" placeholder="<?php esc_attr_e( '@username or handle', 'trello-social-auto-publisher' ); ?>">
+                                <input type="text" id="competitor-handle" placeholder="<?php esc_attr_e( '@username or handle', 'fp-publisher' ); ?>">
                                 <button type="button" class="button button-primary" id="add-competitor">
-                                    <?php esc_html_e( 'Add Competitor', 'trello-social-auto-publisher' ); ?>
+                                    <?php esc_html_e( 'Add Competitor', 'fp-publisher' ); ?>
                                 </button>
                             </div>
                             
                             <div class="tts-competitor-actions">
                                 <button type="button" class="button" id="generate-competitor-report">
-                                    <?php esc_html_e( 'Generate Report', 'trello-social-auto-publisher' ); ?>
+                                    <?php esc_html_e( 'Generate Report', 'fp-publisher' ); ?>
                                 </button>
                             </div>
                             
@@ -173,29 +173,29 @@ class TTS_AI_Features_Page {
                 <div class="tts-feature-card">
                     <div class="tts-feature-header">
                         <span class="tts-feature-icon">🔄</span>
-                        <h2><?php esc_html_e( 'Workflow & Collaboration', 'trello-social-auto-publisher' ); ?></h2>
+                        <h2><?php esc_html_e( 'Workflow & Collaboration', 'fp-publisher' ); ?></h2>
                     </div>
                     <div class="tts-feature-content">
-                        <p><?php esc_html_e( 'Streamline team collaboration with approval workflows and task management.', 'trello-social-auto-publisher' ); ?></p>
+                        <p><?php esc_html_e( 'Streamline team collaboration with approval workflows and task management.', 'fp-publisher' ); ?></p>
                         
                         <div class="tts-workflow-demo">
                             <div class="tts-workflow-stats">
                                 <div class="stat-item">
                                     <span class="stat-number" id="pending-approvals">0</span>
-                                    <span class="stat-label"><?php esc_html_e( 'Pending Approvals', 'trello-social-auto-publisher' ); ?></span>
+                                    <span class="stat-label"><?php esc_html_e( 'Pending Approvals', 'fp-publisher' ); ?></span>
                                 </div>
                                 <div class="stat-item">
                                     <span class="stat-number" id="approved-content">0</span>
-                                    <span class="stat-label"><?php esc_html_e( 'Approved Content', 'trello-social-auto-publisher' ); ?></span>
+                                    <span class="stat-label"><?php esc_html_e( 'Approved Content', 'fp-publisher' ); ?></span>
                                 </div>
                                 <div class="stat-item">
                                     <span class="stat-number" id="team-members">0</span>
-                                    <span class="stat-label"><?php esc_html_e( 'Team Members', 'trello-social-auto-publisher' ); ?></span>
+                                    <span class="stat-label"><?php esc_html_e( 'Team Members', 'fp-publisher' ); ?></span>
                                 </div>
                             </div>
                             
                             <button type="button" class="button button-primary" id="get-team-dashboard">
-                                <?php esc_html_e( 'View Team Dashboard', 'trello-social-auto-publisher' ); ?>
+                                <?php esc_html_e( 'View Team Dashboard', 'fp-publisher' ); ?>
                             </button>
                             
                             <div id="workflow-results" class="tts-results"></div>
@@ -207,15 +207,15 @@ class TTS_AI_Features_Page {
                 <div class="tts-feature-card">
                     <div class="tts-feature-header">
                         <span class="tts-feature-icon">🎨</span>
-                        <h2><?php esc_html_e( 'Advanced Media Management', 'trello-social-auto-publisher' ); ?></h2>
+                        <h2><?php esc_html_e( 'Advanced Media Management', 'fp-publisher' ); ?></h2>
                     </div>
                     <div class="tts-feature-content">
-                        <p><?php esc_html_e( 'Optimize, resize, and enhance your media for each social platform automatically.', 'trello-social-auto-publisher' ); ?></p>
+                        <p><?php esc_html_e( 'Optimize, resize, and enhance your media for each social platform automatically.', 'fp-publisher' ); ?></p>
                         
                         <div class="tts-media-tools">
                             <div class="tts-media-optimizer">
-                                <h4><?php esc_html_e( 'Platform Optimizer', 'trello-social-auto-publisher' ); ?></h4>
-                                <p><?php esc_html_e( 'Automatically resize images for optimal performance on each platform:', 'trello-social-auto-publisher' ); ?></p>
+                                <h4><?php esc_html_e( 'Platform Optimizer', 'fp-publisher' ); ?></h4>
+                                <p><?php esc_html_e( 'Automatically resize images for optimal performance on each platform:', 'fp-publisher' ); ?></p>
                                 <ul class="tts-platform-sizes">
                                     <li><strong>Instagram:</strong> Square (1080x1080), Portrait (1080x1350), Story (1080x1920)</li>
                                     <li><strong>Facebook:</strong> Shared Image (1200x630), Cover Photo (1640x859)</li>
@@ -225,7 +225,7 @@ class TTS_AI_Features_Page {
                                 </ul>
                                 
                                 <button type="button" class="button button-primary" id="analyze-media-performance">
-                                    <?php esc_html_e( 'Analyze Media Performance', 'trello-social-auto-publisher' ); ?>
+                                    <?php esc_html_e( 'Analyze Media Performance', 'fp-publisher' ); ?>
                                 </button>
                             </div>
                             
@@ -238,14 +238,14 @@ class TTS_AI_Features_Page {
                 <div class="tts-feature-card">
                     <div class="tts-feature-header">
                         <span class="tts-feature-icon">🔗</span>
-                        <h2><?php esc_html_e( 'Integration Hub', 'trello-social-auto-publisher' ); ?></h2>
+                        <h2><?php esc_html_e( 'Integration Hub', 'fp-publisher' ); ?></h2>
                     </div>
                     <div class="tts-feature-content">
-                        <p><?php esc_html_e( 'Connect with your favorite tools and platforms for seamless workflow automation.', 'trello-social-auto-publisher' ); ?></p>
+                        <p><?php esc_html_e( 'Connect with your favorite tools and platforms for seamless workflow automation.', 'fp-publisher' ); ?></p>
                         
                         <div class="tts-integrations-grid">
                             <div class="integration-category">
-                                <h4><?php esc_html_e( 'CRM', 'trello-social-auto-publisher' ); ?></h4>
+                                <h4><?php esc_html_e( 'CRM', 'fp-publisher' ); ?></h4>
                                 <ul>
                                     <li>HubSpot</li>
                                     <li>Salesforce</li>
@@ -254,7 +254,7 @@ class TTS_AI_Features_Page {
                             </div>
                             
                             <div class="integration-category">
-                                <h4><?php esc_html_e( 'E-commerce', 'trello-social-auto-publisher' ); ?></h4>
+                                <h4><?php esc_html_e( 'E-commerce', 'fp-publisher' ); ?></h4>
                                 <ul>
                                     <li>WooCommerce</li>
                                     <li>Shopify</li>
@@ -263,7 +263,7 @@ class TTS_AI_Features_Page {
                             </div>
                             
                             <div class="integration-category">
-                                <h4><?php esc_html_e( 'Email Marketing', 'trello-social-auto-publisher' ); ?></h4>
+                                <h4><?php esc_html_e( 'Email Marketing', 'fp-publisher' ); ?></h4>
                                 <ul>
                                     <li>Mailchimp</li>
                                     <li>ConvertKit</li>
@@ -272,7 +272,7 @@ class TTS_AI_Features_Page {
                             </div>
                             
                             <div class="integration-category">
-                                <h4><?php esc_html_e( 'Design Tools', 'trello-social-auto-publisher' ); ?></h4>
+                                <h4><?php esc_html_e( 'Design Tools', 'fp-publisher' ); ?></h4>
                                 <ul>
                                     <li>Canva</li>
                                     <li>Figma</li>
@@ -282,7 +282,7 @@ class TTS_AI_Features_Page {
                         </div>
                         
                         <button type="button" class="button button-primary" id="view-integrations">
-                            <?php esc_html_e( 'View Available Integrations', 'trello-social-auto-publisher' ); ?>
+                            <?php esc_html_e( 'View Available Integrations', 'fp-publisher' ); ?>
                         </button>
                         
                         <div id="integration-results" class="tts-results"></div>
@@ -294,7 +294,7 @@ class TTS_AI_Features_Page {
             <!-- Loading overlay -->
             <div id="tts-loading-overlay" class="tts-loading-overlay" style="display: none;">
                 <div class="tts-spinner"></div>
-                <p><?php esc_html_e( 'Processing...', 'trello-social-auto-publisher' ); ?></p>
+                <p><?php esc_html_e( 'Processing...', 'fp-publisher' ); ?></p>
             </div>
             
         </div>
@@ -531,7 +531,7 @@ class TTS_AI_Features_Page {
                 const platform = $('#hashtag-platform').val();
                 
                 if (!content.trim()) {
-                    alert('<?php esc_js( __( 'Please enter some content first.', 'trello-social-auto-publisher' ) ); ?>');
+                    alert('<?php esc_js( __( 'Please enter some content first.', 'fp-publisher' ) ); ?>');
                     return;
                 }
                 
@@ -549,7 +549,7 @@ class TTS_AI_Features_Page {
                     success: function(response) {
                         hideLoading();
                         if (response.success) {
-                            let html = '<h5><?php esc_js( __( 'Generated Hashtags:', 'trello-social-auto-publisher' ) ); ?></h5>';
+                            let html = '<h5><?php esc_js( __( 'Generated Hashtags:', 'fp-publisher' ) ); ?></h5>';
                             response.data.hashtags.forEach(function(hashtag) {
                                 html += '<span class="hashtag-tag">' + hashtag + '</span>';
                             });
@@ -560,7 +560,7 @@ class TTS_AI_Features_Page {
                     },
                     error: function() {
                         hideLoading();
-                        $('#hashtag-results').html('<p style="color: red;"><?php esc_js( __( 'Error generating hashtags.', 'trello-social-auto-publisher' ) ); ?></p>');
+                        $('#hashtag-results').html('<p style="color: red;"><?php esc_js( __( 'Error generating hashtags.', 'fp-publisher' ) ); ?></p>');
                     }
                 });
             });
@@ -571,7 +571,7 @@ class TTS_AI_Features_Page {
                 const platform = $('#predict-platform').val();
                 
                 if (!content.trim()) {
-                    alert('<?php esc_js( __( 'Please enter some content first.', 'trello-social-auto-publisher' ) ); ?>');
+                    alert('<?php esc_js( __( 'Please enter some content first.', 'fp-publisher' ) ); ?>');
                     return;
                 }
                 
@@ -590,12 +590,12 @@ class TTS_AI_Features_Page {
                         hideLoading();
                         if (response.success) {
                             const pred = response.data.prediction;
-                            let html = '<h5><?php esc_js( __( 'Performance Prediction:', 'trello-social-auto-publisher' ) ); ?></h5>';
+                            let html = '<h5><?php esc_js( __( 'Performance Prediction:', 'fp-publisher' ) ); ?></h5>';
                             html += '<div class="performance-meter"><div class="performance-fill" style="width: ' + pred.confidence + '%"></div></div>';
-                            html += '<p><strong><?php esc_js( __( 'Confidence:', 'trello-social-auto-publisher' ) ); ?></strong> ' + pred.confidence + '%</p>';
-                            html += '<p><strong><?php esc_js( __( 'Engagement Rate:', 'trello-social-auto-publisher' ) ); ?></strong> ' + pred.engagement_rate + '%</p>';
-                            html += '<p><strong><?php esc_js( __( 'Predicted Likes:', 'trello-social-auto-publisher' ) ); ?></strong> ' + pred.predicted_likes + '</p>';
-                            html += '<p><strong><?php esc_js( __( 'Recommendation:', 'trello-social-auto-publisher' ) ); ?></strong> ' + pred.recommendation + '</p>';
+                            html += '<p><strong><?php esc_js( __( 'Confidence:', 'fp-publisher' ) ); ?></strong> ' + pred.confidence + '%</p>';
+                            html += '<p><strong><?php esc_js( __( 'Engagement Rate:', 'fp-publisher' ) ); ?></strong> ' + pred.engagement_rate + '%</p>';
+                            html += '<p><strong><?php esc_js( __( 'Predicted Likes:', 'fp-publisher' ) ); ?></strong> ' + pred.predicted_likes + '</p>';
+                            html += '<p><strong><?php esc_js( __( 'Recommendation:', 'fp-publisher' ) ); ?></strong> ' + pred.recommendation + '</p>';
                             $('#prediction-results').html(html);
                         } else {
                             $('#prediction-results').html('<p style="color: red;">' + response.data.message + '</p>');
@@ -603,7 +603,7 @@ class TTS_AI_Features_Page {
                     },
                     error: function() {
                         hideLoading();
-                        $('#prediction-results').html('<p style="color: red;"><?php esc_js( __( 'Error predicting performance.', 'trello-social-auto-publisher' ) ); ?></p>');
+                        $('#prediction-results').html('<p style="color: red;"><?php esc_js( __( 'Error predicting performance.', 'fp-publisher' ) ); ?></p>');
                     }
                 });
             });
@@ -627,11 +627,11 @@ class TTS_AI_Features_Page {
                     success: function(response) {
                         hideLoading();
                         if (response.success) {
-                            let html = '<h5><?php esc_js( __( 'Content Suggestions:', 'trello-social-auto-publisher' ) ); ?></h5>';
+                            let html = '<h5><?php esc_js( __( 'Content Suggestions:', 'fp-publisher' ) ); ?></h5>';
                             response.data.suggestions.forEach(function(suggestion) {
                                 html += '<div class="suggestion-item">';
                                 html += '<div class="suggestion-title">' + suggestion.title + '</div>';
-                                html += '<div class="suggestion-meta"><?php esc_js( __( 'Platform:', 'trello-social-auto-publisher' ) ); ?> ' + suggestion.platform + ' | <?php esc_js( __( 'Est. Performance:', 'trello-social-auto-publisher' ) ); ?> ' + suggestion.estimated_performance + '%</div>';
+                                html += '<div class="suggestion-meta"><?php esc_js( __( 'Platform:', 'fp-publisher' ) ); ?> ' + suggestion.platform + ' | <?php esc_js( __( 'Est. Performance:', 'fp-publisher' ) ); ?> ' + suggestion.estimated_performance + '%</div>';
                                 html += '</div>';
                             });
                             $('#suggestion-results').html(html);
@@ -641,7 +641,7 @@ class TTS_AI_Features_Page {
                     },
                     error: function() {
                         hideLoading();
-                        $('#suggestion-results').html('<p style="color: red;"><?php esc_js( __( 'Error getting suggestions.', 'trello-social-auto-publisher' ) ); ?></p>');
+                        $('#suggestion-results').html('<p style="color: red;"><?php esc_js( __( 'Error getting suggestions.', 'fp-publisher' ) ); ?></p>');
                     }
                 });
             });
@@ -653,7 +653,7 @@ class TTS_AI_Features_Page {
                 const handle = $('#competitor-handle').val();
                 
                 if (!name || !handle) {
-                    alert('<?php esc_js( __( 'Please fill in all fields.', 'trello-social-auto-publisher' ) ); ?>');
+                    alert('<?php esc_js( __( 'Please fill in all fields.', 'fp-publisher' ) ); ?>');
                     return;
                 }
                 
@@ -680,7 +680,7 @@ class TTS_AI_Features_Page {
                     },
                     error: function() {
                         hideLoading();
-                        $('#competitor-results').html('<p style="color: red;"><?php esc_js( __( 'Error adding competitor.', 'trello-social-auto-publisher' ) ); ?></p>');
+                        $('#competitor-results').html('<p style="color: red;"><?php esc_js( __( 'Error adding competitor.', 'fp-publisher' ) ); ?></p>');
                     }
                 });
             });
@@ -700,12 +700,12 @@ class TTS_AI_Features_Page {
                         hideLoading();
                         if (response.success) {
                             const report = response.data.report;
-                            let html = '<h5><?php esc_js( __( 'Competitor Analysis Report:', 'trello-social-auto-publisher' ) ); ?></h5>';
-                            html += '<p><strong><?php esc_js( __( 'Total Competitors:', 'trello-social-auto-publisher' ) ); ?></strong> ' + report.summary.total_competitors + '</p>';
-                            html += '<p><strong><?php esc_js( __( 'Average Engagement:', 'trello-social-auto-publisher' ) ); ?></strong> ' + report.summary.avg_engagement_rate + '%</p>';
+                            let html = '<h5><?php esc_js( __( 'Competitor Analysis Report:', 'fp-publisher' ) ); ?></h5>';
+                            html += '<p><strong><?php esc_js( __( 'Total Competitors:', 'fp-publisher' ) ); ?></strong> ' + report.summary.total_competitors + '</p>';
+                            html += '<p><strong><?php esc_js( __( 'Average Engagement:', 'fp-publisher' ) ); ?></strong> ' + report.summary.avg_engagement_rate + '%</p>';
                             
                             if (report.recommendations && report.recommendations.length > 0) {
-                                html += '<h6><?php esc_js( __( 'Recommendations:', 'trello-social-auto-publisher' ) ); ?></h6>';
+                                html += '<h6><?php esc_js( __( 'Recommendations:', 'fp-publisher' ) ); ?></h6>';
                                 report.recommendations.forEach(function(rec) {
                                     html += '<div style="margin: 8px 0;"><strong>' + rec.category + ':</strong> ' + rec.recommendation + '</div>';
                                 });
@@ -718,7 +718,7 @@ class TTS_AI_Features_Page {
                     },
                     error: function() {
                         hideLoading();
-                        $('#competitor-results').html('<p style="color: red;"><?php esc_js( __( 'Error generating report.', 'trello-social-auto-publisher' ) ); ?></p>');
+                        $('#competitor-results').html('<p style="color: red;"><?php esc_js( __( 'Error generating report.', 'fp-publisher' ) ); ?></p>');
                     }
                 });
             });
@@ -744,11 +744,11 @@ class TTS_AI_Features_Page {
                             $('#approved-content').text(stats.approved || 0);
                             $('#team-members').text(dashboard.team_performance ? dashboard.team_performance.length : 0);
                             
-                            let html = '<h5><?php esc_js( __( 'Team Dashboard:', 'trello-social-auto-publisher' ) ); ?></h5>';
-                            html += '<p><strong><?php esc_js( __( 'Pending Approvals:', 'trello-social-auto-publisher' ) ); ?></strong> ' + (stats.pending_approval || 0) + '</p>';
-                            html += '<p><strong><?php esc_js( __( 'Approved Content:', 'trello-social-auto-publisher' ) ); ?></strong> ' + (stats.approved || 0) + '</p>';
-                            html += '<p><strong><?php esc_js( __( 'Rejected Content:', 'trello-social-auto-publisher' ) ); ?></strong> ' + (stats.rejected || 0) + '</p>';
-                            html += '<p><strong><?php esc_js( __( 'Overdue Items:', 'trello-social-auto-publisher' ) ); ?></strong> ' + (stats.overdue || 0) + '</p>';
+                            let html = '<h5><?php esc_js( __( 'Team Dashboard:', 'fp-publisher' ) ); ?></h5>';
+                            html += '<p><strong><?php esc_js( __( 'Pending Approvals:', 'fp-publisher' ) ); ?></strong> ' + (stats.pending_approval || 0) + '</p>';
+                            html += '<p><strong><?php esc_js( __( 'Approved Content:', 'fp-publisher' ) ); ?></strong> ' + (stats.approved || 0) + '</p>';
+                            html += '<p><strong><?php esc_js( __( 'Rejected Content:', 'fp-publisher' ) ); ?></strong> ' + (stats.rejected || 0) + '</p>';
+                            html += '<p><strong><?php esc_js( __( 'Overdue Items:', 'fp-publisher' ) ); ?></strong> ' + (stats.overdue || 0) + '</p>';
                             
                             $('#workflow-results').html(html);
                         } else {
@@ -757,7 +757,7 @@ class TTS_AI_Features_Page {
                     },
                     error: function() {
                         hideLoading();
-                        $('#workflow-results').html('<p style="color: red;"><?php esc_js( __( 'Error loading dashboard.', 'trello-social-auto-publisher' ) ); ?></p>');
+                        $('#workflow-results').html('<p style="color: red;"><?php esc_js( __( 'Error loading dashboard.', 'fp-publisher' ) ); ?></p>');
                     }
                 });
             });
@@ -777,11 +777,11 @@ class TTS_AI_Features_Page {
                         hideLoading();
                         if (response.success) {
                             const analysis = response.data.analysis;
-                            let html = '<h5><?php esc_js( __( 'Media Performance Analysis:', 'trello-social-auto-publisher' ) ); ?></h5>';
-                            html += '<p><strong><?php esc_js( __( 'Posts Analyzed:', 'trello-social-auto-publisher' ) ); ?></strong> ' + analysis.total_posts_analyzed + '</p>';
+                            let html = '<h5><?php esc_js( __( 'Media Performance Analysis:', 'fp-publisher' ) ); ?></h5>';
+                            html += '<p><strong><?php esc_js( __( 'Posts Analyzed:', 'fp-publisher' ) ); ?></strong> ' + analysis.total_posts_analyzed + '</p>';
                             
                             if (analysis.recommendations && analysis.recommendations.length > 0) {
-                                html += '<h6><?php esc_js( __( 'Optimization Recommendations:', 'trello-social-auto-publisher' ) ); ?></h6>';
+                                html += '<h6><?php esc_js( __( 'Optimization Recommendations:', 'fp-publisher' ) ); ?></h6>';
                                 analysis.recommendations.forEach(function(rec) {
                                     html += '<div style="margin: 8px 0;"><strong>' + rec.category + ':</strong> ' + rec.recommendation + ' <span style="color: #666;">(Impact: ' + rec.impact + ', Effort: ' + rec.effort + ')</span></div>';
                                 });
@@ -794,7 +794,7 @@ class TTS_AI_Features_Page {
                     },
                     error: function() {
                         hideLoading();
-                        $('#media-results').html('<p style="color: red;"><?php esc_js( __( 'Error analyzing media.', 'trello-social-auto-publisher' ) ); ?></p>');
+                        $('#media-results').html('<p style="color: red;"><?php esc_js( __( 'Error analyzing media.', 'fp-publisher' ) ); ?></p>');
                     }
                 });
             });
@@ -816,23 +816,23 @@ class TTS_AI_Features_Page {
                             const integrations = response.data.integrations;
                             const connected = response.data.connected;
                             
-                            let html = '<h5><?php esc_js( __( 'Available Integrations:', 'trello-social-auto-publisher' ) ); ?></h5>';
+                            let html = '<h5><?php esc_js( __( 'Available Integrations:', 'fp-publisher' ) ); ?></h5>';
                             
                             if (connected && connected.length > 0) {
-                                html += '<h6><?php esc_js( __( 'Connected:', 'trello-social-auto-publisher' ) ); ?></h6>';
+                                html += '<h6><?php esc_js( __( 'Connected:', 'fp-publisher' ) ); ?></h6>';
                                 connected.forEach(function(conn) {
                                     html += '<div style="color: green; margin: 5px 0;">✓ ' + conn.integration_name + ' (' + conn.integration_type + ')</div>';
                                 });
                             }
                             
-                            html += '<h6><?php esc_js( __( 'Total Available Integrations:', 'trello-social-auto-publisher' ) ); ?></h6>';
+                            html += '<h6><?php esc_js( __( 'Total Available Integrations:', 'fp-publisher' ) ); ?></h6>';
                             
                             let totalCount = 0;
                             Object.keys(integrations).forEach(function(category) {
                                 totalCount += Object.keys(integrations[category]).length;
                             });
                             
-                            html += '<p><?php esc_js( __( 'We support', 'trello-social-auto-publisher' ) ); ?> <strong>' + totalCount + '</strong> <?php esc_js( __( 'different integrations across CRM, E-commerce, Email Marketing, Design Tools, Analytics, and Productivity platforms.', 'trello-social-auto-publisher' ) ); ?></p>';
+                            html += '<p><?php esc_js( __( 'We support', 'fp-publisher' ) ); ?> <strong>' + totalCount + '</strong> <?php esc_js( __( 'different integrations across CRM, E-commerce, Email Marketing, Design Tools, Analytics, and Productivity platforms.', 'fp-publisher' ) ); ?></p>';
                             
                             $('#integration-results').html(html);
                         } else {
@@ -841,7 +841,7 @@ class TTS_AI_Features_Page {
                     },
                     error: function() {
                         hideLoading();
-                        $('#integration-results').html('<p style="color: red;"><?php esc_js( __( 'Error loading integrations.', 'trello-social-auto-publisher' ) ); ?></p>');
+                        $('#integration-results').html('<p style="color: red;"><?php esc_js( __( 'Error loading integrations.', 'fp-publisher' ) ); ?></p>');
                     }
                 });
             });

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-analytics-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-analytics-page.php
@@ -85,7 +85,7 @@ class TTS_Analytics_Page {
         $channels = $this->get_available_channels();
 
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Analytics', 'trello-social-auto-publisher' ) . '</h1>';
+        echo '<h1>' . esc_html__( 'Analytics', 'fp-publisher' ) . '</h1>';
         
         // Summary stats
         $this->render_analytics_summary($data);
@@ -96,9 +96,9 @@ class TTS_Analytics_Page {
         echo '<input type="hidden" name="page" value="tts-analytics" />';
 
         echo '<div class="filter-group">';
-        echo '<label for="channel">' . esc_html__( 'Channel', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<label for="channel">' . esc_html__( 'Channel', 'fp-publisher' ) . '</label>';
         echo '<select name="channel" id="channel">';
-        echo '<option value="">' . esc_html__( 'All Channels', 'trello-social-auto-publisher' ) . '</option>';
+        echo '<option value="">' . esc_html__( 'All Channels', 'fp-publisher' ) . '</option>';
         foreach ( $channels as $ch ) {
             printf( '<option value="%1$s" %2$s>%1$s</option>', esc_attr( $ch ), selected( $ch, $channel, false ) );
         }
@@ -106,20 +106,20 @@ class TTS_Analytics_Page {
         echo '</div>';
 
         echo '<div class="filter-group">';
-        echo '<label for="start">' . esc_html__( 'From', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<label for="start">' . esc_html__( 'From', 'fp-publisher' ) . '</label>';
         printf( '<input type="date" name="start" id="start" value="%s" />', esc_attr( $start ) );
         echo '</div>';
         
         echo '<div class="filter-group">';
-        echo '<label for="end">' . esc_html__( 'To', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<label for="end">' . esc_html__( 'To', 'fp-publisher' ) . '</label>';
         printf( '<input type="date" name="end" id="end" value="%s" />', esc_attr( $end ) );
         echo '</div>';
 
         echo '<div class="filter-actions">';
-        submit_button( __( 'Filter', 'trello-social-auto-publisher' ), 'primary', '', false );
+        submit_button( __( 'Filter', 'fp-publisher' ), 'primary', '', false );
 
         $export_url = add_query_arg( array_merge( $_GET, array( 'export' => 'csv' ) ) );
-        echo ' <a href="' . esc_url( $export_url ) . '" class="button">' . esc_html__( 'Export CSV', 'trello-social-auto-publisher' ) . '</a>';
+        echo ' <a href="' . esc_url( $export_url ) . '" class="button">' . esc_html__( 'Export CSV', 'fp-publisher' ) . '</a>';
         echo '</div>';
 
         echo '</form>';
@@ -165,23 +165,23 @@ class TTS_Analytics_Page {
         echo '<div class="tts-summary-cards">';
         
         echo '<div class="tts-summary-card">';
-        echo '<h3>' . esc_html__('Total Interactions', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Total Interactions', 'fp-publisher') . '</h3>';
         echo '<span class="tts-summary-number">' . number_format($total_interactions) . '</span>';
         echo '</div>';
         
         echo '<div class="tts-summary-card">';
-        echo '<h3>' . esc_html__('Active Channels', 'trello-social-auto-publisher') . '</h3>';
+        echo '<h3>' . esc_html__('Active Channels', 'fp-publisher') . '</h3>';
         echo '<span class="tts-summary-number">' . count($channel_totals) . '</span>';
         echo '</div>';
         
         echo '<div class="tts-summary-card">';
-        echo '<h3>' . esc_html__('Top Channel', 'trello-social-auto-publisher') . '</h3>';
-        echo '<span class="tts-summary-text">' . ($top_channel ? esc_html($top_channel) : esc_html__('N/A', 'trello-social-auto-publisher')) . '</span>';
+        echo '<h3>' . esc_html__('Top Channel', 'fp-publisher') . '</h3>';
+        echo '<span class="tts-summary-text">' . ($top_channel ? esc_html($top_channel) : esc_html__('N/A', 'fp-publisher')) . '</span>';
         echo '</div>';
         
         echo '<div class="tts-summary-card">';
-        echo '<h3>' . esc_html__('Date Range', 'trello-social-auto-publisher') . '</h3>';
-        echo '<span class="tts-summary-text">' . ($date_range_text ? esc_html($date_range_text) : esc_html__('No data', 'trello-social-auto-publisher')) . '</span>';
+        echo '<h3>' . esc_html__('Date Range', 'fp-publisher') . '</h3>';
+        echo '<span class="tts-summary-text">' . ($date_range_text ? esc_html($date_range_text) : esc_html__('No data', 'fp-publisher')) . '</span>';
         echo '</div>';
         
         echo '</div>';

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-calendar-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-calendar-page.php
@@ -82,29 +82,29 @@ class TTS_Calendar_Page {
         $next_month     = date( 'Y-m', strtotime( '+1 month', $timestamp ) );
 
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Calendario', 'trello-social-auto-publisher' ) . '</h1>';
+        echo '<h1>' . esc_html__( 'Calendario', 'fp-publisher' ) . '</h1>';
         
         // Add navigation and summary info
         echo '<div class="tts-calendar-header">';
         echo '<div class="tts-calendar-nav">';
-        echo '<a href="#" data-month="' . esc_attr( $prev_month ) . '" class="button">&laquo; ' . esc_html__('Previous', 'trello-social-auto-publisher') . '</a> ';
+        echo '<a href="#" data-month="' . esc_attr( $prev_month ) . '" class="button">&laquo; ' . esc_html__('Previous', 'fp-publisher') . '</a> ';
         echo '<span class="tts-current-month">' . esc_html( date_i18n( 'F Y', $timestamp ) ) . '</span> ';
-        echo '<a href="#" data-month="' . esc_attr( $next_month ) . '" class="button">' . esc_html__('Next', 'trello-social-auto-publisher') . ' &raquo;</a>';
+        echo '<a href="#" data-month="' . esc_attr( $next_month ) . '" class="button">' . esc_html__('Next', 'fp-publisher') . ' &raquo;</a>';
         echo '</div>';
         
         echo '<div class="tts-calendar-summary">';
-        echo '<span class="tts-posts-count">' . sprintf(esc_html__('%d posts scheduled this month', 'trello-social-auto-publisher'), count($posts)) . '</span>';
+        echo '<span class="tts-posts-count">' . sprintf(esc_html__('%d posts scheduled this month', 'fp-publisher'), count($posts)) . '</span>';
         echo '</div>';
         echo '</div>';
 
         $weekdays = array(
-            __( 'Lun', 'trello-social-auto-publisher' ),
-            __( 'Mar', 'trello-social-auto-publisher' ),
-            __( 'Mer', 'trello-social-auto-publisher' ),
-            __( 'Gio', 'trello-social-auto-publisher' ),
-            __( 'Ven', 'trello-social-auto-publisher' ),
-            __( 'Sab', 'trello-social-auto-publisher' ),
-            __( 'Dom', 'trello-social-auto-publisher' ),
+            __( 'Lun', 'fp-publisher' ),
+            __( 'Mar', 'fp-publisher' ),
+            __( 'Mer', 'fp-publisher' ),
+            __( 'Gio', 'fp-publisher' ),
+            __( 'Ven', 'fp-publisher' ),
+            __( 'Sab', 'fp-publisher' ),
+            __( 'Dom', 'fp-publisher' ),
         );
 
         echo '<table class="widefat fixed tts-calendar">';
@@ -140,7 +140,7 @@ class TTS_Calendar_Page {
                         echo ' <span class="entry-time">(' . esc_html($time_display) . ')</span>';
                     }
                     echo '</div>';
-                    echo '<div class="entry-actions"><a href="' . esc_url( $edit_link ) . '" class="button-small">' . esc_html__( 'Modifica', 'trello-social-auto-publisher' ) . '</a></div>';
+                    echo '<div class="entry-actions"><a href="' . esc_url( $edit_link ) . '" class="button-small">' . esc_html__( 'Modifica', 'fp-publisher' ) . '</a></div>';
                     echo '</div>';
                 }
                 echo '</div>';

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-dashboard-widget.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-dashboard-widget.php
@@ -29,7 +29,7 @@ class TTS_Frequency_Dashboard_Widget {
         if ( current_user_can( 'manage_options' ) ) {
             wp_add_dashboard_widget(
                 'tts_frequency_status_widget',
-                __( 'Publishing Frequency Status', 'trello-social-auto-publisher' ),
+                __( 'Publishing Frequency Status', 'fp-publisher' ),
                 array( $this, 'render_widget' ),
                 array( $this, 'render_widget_config' )
             );
@@ -57,9 +57,9 @@ class TTS_Frequency_Dashboard_Widget {
         ?>
         <div class="tts-frequency-widget">
             <?php if ( empty( $clients ) ) : ?>
-                <p><?php esc_html_e( 'No clients with frequency settings found.', 'trello-social-auto-publisher' ); ?></p>
+                <p><?php esc_html_e( 'No clients with frequency settings found.', 'fp-publisher' ); ?></p>
                 <p><a href="<?php echo admin_url( 'edit.php?post_type=tts_client' ); ?>" class="button">
-                    <?php esc_html_e( 'Configure Clients', 'trello-social-auto-publisher' ); ?>
+                    <?php esc_html_e( 'Configure Clients', 'fp-publisher' ); ?>
                 </a></p>
             <?php else : ?>
                 <div class="tts-widget-summary">
@@ -100,15 +100,15 @@ class TTS_Frequency_Dashboard_Widget {
                     <div class="tts-summary-stats">
                         <div class="tts-stat urgent">
                             <span class="count"><?php echo esc_html( $urgent_count ); ?></span>
-                            <span class="label"><?php esc_html_e( 'Urgent', 'trello-social-auto-publisher' ); ?></span>
+                            <span class="label"><?php esc_html_e( 'Urgent', 'fp-publisher' ); ?></span>
                         </div>
                         <div class="tts-stat warning">
                             <span class="count"><?php echo esc_html( $warning_count ); ?></span>
-                            <span class="label"><?php esc_html_e( 'Warning', 'trello-social-auto-publisher' ); ?></span>
+                            <span class="label"><?php esc_html_e( 'Warning', 'fp-publisher' ); ?></span>
                         </div>
                         <div class="tts-stat completed">
                             <span class="count"><?php echo esc_html( $completed_count ); ?></span>
-                            <span class="label"><?php esc_html_e( 'On Track', 'trello-social-auto-publisher' ); ?></span>
+                            <span class="label"><?php esc_html_e( 'On Track', 'fp-publisher' ); ?></span>
                         </div>
                     </div>
                 </div>
@@ -132,10 +132,10 @@ class TTS_Frequency_Dashboard_Widget {
 
                 <div class="tts-widget-actions">
                     <a href="<?php echo admin_url( 'admin.php?page=fp-publisher-frequency-status' ); ?>" class="button button-primary">
-                        <?php esc_html_e( 'View Full Status', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'View Full Status', 'fp-publisher' ); ?>
                     </a>
                     <button type="button" class="button button-secondary" id="tts-widget-refresh">
-                        <?php esc_html_e( 'Refresh', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Refresh', 'fp-publisher' ); ?>
                     </button>
                 </div>
             <?php endif; ?>
@@ -289,7 +289,7 @@ class TTS_Frequency_Dashboard_Widget {
                         <strong><?php echo esc_html( ucfirst( $channel ) ); ?>:</strong>
                         <?php echo esc_html( $data['published'] ); ?>/<?php echo esc_html( $data['target'] ); ?>
                         <?php if ( $data['remaining'] > 0 ) : ?>
-                            (<?php echo esc_html( $data['remaining'] ); ?> <?php esc_html_e( 'left', 'trello-social-auto-publisher' ); ?>)
+                            (<?php echo esc_html( $data['remaining'] ); ?> <?php esc_html_e( 'left', 'fp-publisher' ); ?>)
                         <?php endif; ?>
                     </span>
                 <?php endforeach; ?>
@@ -312,7 +312,7 @@ class TTS_Frequency_Dashboard_Widget {
         check_ajax_referer( 'tts_frequency_widget', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( __( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( __( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         // Trigger a quick frequency check

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-status-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-status-page.php
@@ -60,8 +60,8 @@ class TTS_Frequency_Status_Page {
                 'ajaxUrl' => admin_url( 'admin-ajax.php' ),
                 'nonce'   => wp_create_nonce( 'tts_frequency_status' ),
                 'strings' => array(
-                    'refreshing' => __( 'Refreshing...', 'trello-social-auto-publisher' ),
-                    'error'      => __( 'Error refreshing status', 'trello-social-auto-publisher' ),
+                    'refreshing' => __( 'Refreshing...', 'fp-publisher' ),
+                    'error'      => __( 'Error refreshing status', 'fp-publisher' ),
                 )
             )
         );
@@ -82,20 +82,20 @@ class TTS_Frequency_Status_Page {
 
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e( 'Publishing Frequency Status', 'trello-social-auto-publisher' ); ?></h1>
+            <h1><?php esc_html_e( 'Publishing Frequency Status', 'fp-publisher' ); ?></h1>
             
             <div class="tts-frequency-header">
-                <p><?php esc_html_e( 'Monitor publishing frequency compliance for all clients. This page shows progress towards publishing goals and alerts for upcoming content needs.', 'trello-social-auto-publisher' ); ?></p>
+                <p><?php esc_html_e( 'Monitor publishing frequency compliance for all clients. This page shows progress towards publishing goals and alerts for upcoming content needs.', 'fp-publisher' ); ?></p>
                 
                 <div class="tts-frequency-actions">
                     <button type="button" id="tts-refresh-status" class="button button-secondary">
-                        <?php esc_html_e( 'Refresh Status', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Refresh Status', 'fp-publisher' ); ?>
                     </button>
                     <button type="button" id="tts-check-now" class="button button-primary">
-                        <?php esc_html_e( 'Check All Clients Now', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Check All Clients Now', 'fp-publisher' ); ?>
                     </button>
                     <button type="button" id="tts-test-alerts" class="button button-secondary">
-                        <?php esc_html_e( 'Test Alert System', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Test Alert System', 'fp-publisher' ); ?>
                     </button>
                 </div>
             </div>
@@ -105,13 +105,13 @@ class TTS_Frequency_Status_Page {
             </div>
 
             <div class="tts-frequency-legend">
-                <h3><?php esc_html_e( 'Status Legend', 'trello-social-auto-publisher' ); ?></h3>
+                <h3><?php esc_html_e( 'Status Legend', 'fp-publisher' ); ?></h3>
                 <div class="tts-legend-items">
-                    <span class="tts-status-badge status-completed"><?php esc_html_e( 'Completed', 'trello-social-auto-publisher' ); ?></span>
-                    <span class="tts-status-badge status-on_track"><?php esc_html_e( 'On Track', 'trello-social-auto-publisher' ); ?></span>
-                    <span class="tts-status-badge status-warning"><?php esc_html_e( 'Warning (≤5 days)', 'trello-social-auto-publisher' ); ?></span>
-                    <span class="tts-status-badge status-urgent"><?php esc_html_e( 'Urgent (≤2 days)', 'trello-social-auto-publisher' ); ?></span>
-                    <span class="tts-status-badge status-overdue"><?php esc_html_e( 'Overdue', 'trello-social-auto-publisher' ); ?></span>
+                    <span class="tts-status-badge status-completed"><?php esc_html_e( 'Completed', 'fp-publisher' ); ?></span>
+                    <span class="tts-status-badge status-on_track"><?php esc_html_e( 'On Track', 'fp-publisher' ); ?></span>
+                    <span class="tts-status-badge status-warning"><?php esc_html_e( 'Warning (≤5 days)', 'fp-publisher' ); ?></span>
+                    <span class="tts-status-badge status-urgent"><?php esc_html_e( 'Urgent (≤2 days)', 'fp-publisher' ); ?></span>
+                    <span class="tts-status-badge status-overdue"><?php esc_html_e( 'Overdue', 'fp-publisher' ); ?></span>
                 </div>
             </div>
         </div>
@@ -126,7 +126,7 @@ class TTS_Frequency_Status_Page {
      */
     private function render_status_tables( $clients, $monitor ) {
         if ( empty( $clients ) ) {
-            echo '<div class="notice notice-info"><p>' . esc_html__( 'No clients found.', 'trello-social-auto-publisher' ) . '</p></div>';
+            echo '<div class="notice notice-info"><p>' . esc_html__( 'No clients found.', 'fp-publisher' ) . '</p></div>';
             return;
         }
 
@@ -156,13 +156,13 @@ class TTS_Frequency_Status_Page {
                 <table class="wp-list-table widefat fixed striped">
                     <thead>
                         <tr>
-                            <th><?php esc_html_e( 'Channel', 'trello-social-auto-publisher' ); ?></th>
-                            <th><?php esc_html_e( 'Target', 'trello-social-auto-publisher' ); ?></th>
-                            <th><?php esc_html_e( 'Published', 'trello-social-auto-publisher' ); ?></th>
-                            <th><?php esc_html_e( 'Remaining', 'trello-social-auto-publisher' ); ?></th>
-                            <th><?php esc_html_e( 'Days Left', 'trello-social-auto-publisher' ); ?></th>
-                            <th><?php esc_html_e( 'Progress', 'trello-social-auto-publisher' ); ?></th>
-                            <th><?php esc_html_e( 'Status', 'trello-social-auto-publisher' ); ?></th>
+                            <th><?php esc_html_e( 'Channel', 'fp-publisher' ); ?></th>
+                            <th><?php esc_html_e( 'Target', 'fp-publisher' ); ?></th>
+                            <th><?php esc_html_e( 'Published', 'fp-publisher' ); ?></th>
+                            <th><?php esc_html_e( 'Remaining', 'fp-publisher' ); ?></th>
+                            <th><?php esc_html_e( 'Days Left', 'fp-publisher' ); ?></th>
+                            <th><?php esc_html_e( 'Progress', 'fp-publisher' ); ?></th>
+                            <th><?php esc_html_e( 'Status', 'fp-publisher' ); ?></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -204,11 +204,11 @@ class TTS_Frequency_Status_Page {
      */
     private function get_status_label( $status ) {
         $labels = array(
-            'completed' => __( 'Completed', 'trello-social-auto-publisher' ),
-            'on_track'  => __( 'On Track', 'trello-social-auto-publisher' ),
-            'warning'   => __( 'Warning', 'trello-social-auto-publisher' ),
-            'urgent'    => __( 'Urgent', 'trello-social-auto-publisher' ),
-            'overdue'   => __( 'Overdue', 'trello-social-auto-publisher' ),
+            'completed' => __( 'Completed', 'fp-publisher' ),
+            'on_track'  => __( 'On Track', 'fp-publisher' ),
+            'warning'   => __( 'Warning', 'fp-publisher' ),
+            'urgent'    => __( 'Urgent', 'fp-publisher' ),
+            'overdue'   => __( 'Overdue', 'fp-publisher' ),
         );
 
         return isset( $labels[ $status ] ) ? $labels[ $status ] : ucfirst( $status );
@@ -221,7 +221,7 @@ class TTS_Frequency_Status_Page {
         check_ajax_referer( 'tts_frequency_status', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( __( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( __( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $monitor = new TTS_Frequency_Monitor();
@@ -247,13 +247,13 @@ class TTS_Frequency_Status_Page {
         check_ajax_referer( 'tts_frequency_status', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( __( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( __( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $monitor = new TTS_Frequency_Monitor();
         $monitor->check_all_clients();
 
-        wp_send_json_success( array( 'message' => __( 'Frequency check completed', 'trello-social-auto-publisher' ) ) );
+        wp_send_json_success( array( 'message' => __( 'Frequency check completed', 'fp-publisher' ) ) );
     }
 
     /**
@@ -263,24 +263,24 @@ class TTS_Frequency_Status_Page {
         check_ajax_referer( 'tts_frequency_status', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( __( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( __( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $notifier = new TTS_Notifier();
         
         // Send test notifications
-        $test_message = __( 'TEST ALERT: Publishing frequency monitoring system is working correctly. This is a test message.', 'trello-social-auto-publisher' );
+        $test_message = __( 'TEST ALERT: Publishing frequency monitoring system is working correctly. This is a test message.', 'fp-publisher' );
         
         $notifier->notify_slack( $test_message );
         $notifier->notify_email( 
-            __( 'Test Alert - Publishing Frequency System', 'trello-social-auto-publisher' ), 
+            __( 'Test Alert - Publishing Frequency System', 'fp-publisher' ), 
             $test_message 
         );
 
         // Log the test
         tts_log_event( 0, 'frequency_monitor', 'test', $test_message, array() );
 
-        wp_send_json_success( array( 'message' => __( 'Test alerts sent successfully', 'trello-social-auto-publisher' ) ) );
+        wp_send_json_success( array( 'message' => __( 'Test alerts sent successfully', 'fp-publisher' ) ) );
     }
 }
 

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-health-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-health-page.php
@@ -48,17 +48,17 @@ class TTS_Health_Page {
      */
     public function render_page() {
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Stato Sistema', 'trello-social-auto-publisher' ) . '</h1>';
+        echo '<h1>' . esc_html__( 'Stato Sistema', 'fp-publisher' ) . '</h1>';
 
         // Overall health status
         echo '<div class="tts-health-overview">';
-        echo '<h2>' . esc_html__( 'Stato Generale', 'trello-social-auto-publisher' ) . '</h2>';
+        echo '<h2>' . esc_html__( 'Stato Generale', 'fp-publisher' ) . '</h2>';
         $this->render_general_health();
         echo '</div>';
 
         // Token checks.
         echo '<div class="tts-health-section">';
-        echo '<h2>' . esc_html__( 'Token', 'trello-social-auto-publisher' ) . '</h2>';
+        echo '<h2>' . esc_html__( 'Token', 'fp-publisher' ) . '</h2>';
         $clients = get_posts(
             array(
                 'post_type'      => 'tts_client',
@@ -75,46 +75,46 @@ class TTS_Health_Page {
                 echo '<div class="tts-health-card">';
                 echo '<h3>' . esc_html( $title ) . '</h3>';
                 if ( is_wp_error( $result ) || ! $result ) {
-                    $message = is_wp_error( $result ) ? $result->get_error_message() : __( 'Errore', 'trello-social-auto-publisher' );
+                    $message = is_wp_error( $result ) ? $result->get_error_message() : __( 'Errore', 'fp-publisher' );
                     echo '<div class="tts-status-error"><span class="dashicons dashicons-warning"></span>' . esc_html( $message ) . '</div>';
                 } else {
-                    echo '<div class="tts-status-ok"><span class="dashicons dashicons-yes"></span>' . esc_html__( 'Token valido', 'trello-social-auto-publisher' ) . '</div>';
+                    echo '<div class="tts-status-ok"><span class="dashicons dashicons-yes"></span>' . esc_html__( 'Token valido', 'fp-publisher' ) . '</div>';
                 }
                 echo '</div>';
             }
             echo '</div>';
         } else {
-            echo '<p>' . esc_html__( 'Nessun client configurato.', 'trello-social-auto-publisher' ) . '</p>';
+            echo '<p>' . esc_html__( 'Nessun client configurato.', 'fp-publisher' ) . '</p>';
         }
         echo '</div>';
 
         // System checks
         echo '<div class="tts-health-section">';
-        echo '<h2>' . esc_html__( 'Controlli Sistema', 'trello-social-auto-publisher' ) . '</h2>';
+        echo '<h2>' . esc_html__( 'Controlli Sistema', 'fp-publisher' ) . '</h2>';
         echo '<div class="tts-health-grid">';
         
         // Trello webhook check.
         echo '<div class="tts-health-card">';
-        echo '<h3>' . esc_html__( 'Webhook Trello', 'trello-social-auto-publisher' ) . '</h3>';
+        echo '<h3>' . esc_html__( 'Webhook Trello', 'fp-publisher' ) . '</h3>';
         $webhook = TTS_Webhook::check_connection();
         if ( is_wp_error( $webhook ) || ! $webhook ) {
-            $message = is_wp_error( $webhook ) ? $webhook->get_error_message() : __( 'Errore', 'trello-social-auto-publisher' );
+            $message = is_wp_error( $webhook ) ? $webhook->get_error_message() : __( 'Errore', 'fp-publisher' );
             echo '<div class="tts-status-error"><span class="dashicons dashicons-warning"></span>' . esc_html( $message ) . '</div>';
         } else {
-            echo '<div class="tts-status-ok"><span class="dashicons dashicons-yes"></span>' . esc_html__( 'Connessione attiva', 'trello-social-auto-publisher' ) . '</div>';
+            echo '<div class="tts-status-ok"><span class="dashicons dashicons-yes"></span>' . esc_html__( 'Connessione attiva', 'fp-publisher' ) . '</div>';
         }
         echo '</div>';
 
         // Action Scheduler queue check.
         echo '<div class="tts-health-card">';
-        echo '<h3>' . esc_html__( 'Action Scheduler', 'trello-social-auto-publisher' ) . '</h3>';
+        echo '<h3>' . esc_html__( 'Action Scheduler', 'fp-publisher' ) . '</h3>';
         if ( is_callable( array( 'TTS_Scheduler', 'check_queue' ) ) ) {
             $queue = TTS_Scheduler::check_queue();
         } else {
-            $queue = new WP_Error( 'missing_method', __( 'Metodo check_queue non disponibile.', 'trello-social-auto-publisher' ) );
+            $queue = new WP_Error( 'missing_method', __( 'Metodo check_queue non disponibile.', 'fp-publisher' ) );
         }
         if ( is_wp_error( $queue ) || ! $queue ) {
-            $message = is_wp_error( $queue ) ? $queue->get_error_message() : __( 'Errore', 'trello-social-auto-publisher' );
+            $message = is_wp_error( $queue ) ? $queue->get_error_message() : __( 'Errore', 'fp-publisher' );
             echo '<div class="tts-status-error"><span class="dashicons dashicons-warning"></span>' . esc_html( $message ) . '</div>';
         } else {
             echo '<div class="tts-status-ok"><span class="dashicons dashicons-yes"></span>' . esc_html( $queue ) . '</div>';
@@ -123,7 +123,7 @@ class TTS_Health_Page {
 
         // WordPress requirements
         echo '<div class="tts-health-card">';
-        echo '<h3>' . esc_html__( 'Requisiti WordPress', 'trello-social-auto-publisher' ) . '</h3>';
+        echo '<h3>' . esc_html__( 'Requisiti WordPress', 'fp-publisher' ) . '</h3>';
         $this->render_wp_requirements();
         echo '</div>';
 
@@ -168,9 +168,9 @@ class TTS_Health_Page {
         echo '</div>';
         echo '<div class="tts-health-description">';
         if ($issues === 0) {
-            echo '<div class="tts-status-ok"><span class="dashicons dashicons-yes"></span>' . esc_html__('Tutti i sistemi funzionano correttamente', 'trello-social-auto-publisher') . '</div>';
+            echo '<div class="tts-status-ok"><span class="dashicons dashicons-yes"></span>' . esc_html__('Tutti i sistemi funzionano correttamente', 'fp-publisher') . '</div>';
         } else {
-            echo '<div class="tts-status-warning"><span class="dashicons dashicons-warning"></span>' . sprintf(esc_html__('%d problemi rilevati su %d controlli', 'trello-social-auto-publisher'), $issues, $total_checks) . '</div>';
+            echo '<div class="tts-status-warning"><span class="dashicons dashicons-warning"></span>' . sprintf(esc_html__('%d problemi rilevati su %d controlli', 'fp-publisher'), $issues, $total_checks) . '</div>';
         }
         echo '</div>';
         echo '</div>';
@@ -182,21 +182,21 @@ class TTS_Health_Page {
     private function render_wp_requirements() {
         $requirements = array(
             array(
-                'name' => __('WordPress Version', 'trello-social-auto-publisher'),
+                'name' => __('WordPress Version', 'fp-publisher'),
                 'current' => get_bloginfo('version'),
                 'required' => '5.0',
                 'check' => version_compare(get_bloginfo('version'), '5.0', '>=')
             ),
             array(
-                'name' => __('PHP Version', 'trello-social-auto-publisher'),
+                'name' => __('PHP Version', 'fp-publisher'),
                 'current' => PHP_VERSION,
                 'required' => '7.4',
                 'check' => version_compare(PHP_VERSION, '7.4', '>=')
             ),
             array(
-                'name' => __('cURL Extension', 'trello-social-auto-publisher'),
-                'current' => extension_loaded('curl') ? __('Enabled', 'trello-social-auto-publisher') : __('Disabled', 'trello-social-auto-publisher'),
-                'required' => __('Required', 'trello-social-auto-publisher'),
+                'name' => __('cURL Extension', 'fp-publisher'),
+                'current' => extension_loaded('curl') ? __('Enabled', 'fp-publisher') : __('Disabled', 'fp-publisher'),
+                'required' => __('Required', 'fp-publisher'),
                 'check' => extension_loaded('curl')
             )
         );

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-log-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-log-page.php
@@ -34,7 +34,7 @@ class TTS_Log_Page {
         $table->prepare_items();
 
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Log', 'trello-social-auto-publisher' ) . '</h1>';
+        echo '<h1>' . esc_html__( 'Log', 'fp-publisher' ) . '</h1>';
         echo '<form method="get">';
         echo '<input type="hidden" name="page" value="fp-publisher-log" />';
         $table->display();
@@ -55,13 +55,13 @@ class TTS_Log_Table extends WP_List_Table {
      */
     public function get_columns() {
         return array(
-            'id'         => __( 'ID', 'trello-social-auto-publisher' ),
-            'post_id'    => __( 'Post ID', 'trello-social-auto-publisher' ),
-            'channel'    => __( 'Channel', 'trello-social-auto-publisher' ),
-            'status'     => __( 'Status', 'trello-social-auto-publisher' ),
-            'message'    => __( 'Message', 'trello-social-auto-publisher' ),
-            'metrics'    => __( 'Metrics', 'trello-social-auto-publisher' ),
-            'created_at' => __( 'Date', 'trello-social-auto-publisher' ),
+            'id'         => __( 'ID', 'fp-publisher' ),
+            'post_id'    => __( 'Post ID', 'fp-publisher' ),
+            'channel'    => __( 'Channel', 'fp-publisher' ),
+            'status'     => __( 'Status', 'fp-publisher' ),
+            'message'    => __( 'Message', 'fp-publisher' ),
+            'metrics'    => __( 'Metrics', 'fp-publisher' ),
+            'created_at' => __( 'Date', 'fp-publisher' ),
         );
     }
 
@@ -132,7 +132,7 @@ class TTS_Log_Table extends WP_List_Table {
         );
 
         $actions = array(
-            'delete' => sprintf( '<a href="%s">%s</a>', esc_url( $delete_url ), __( 'Delete', 'trello-social-auto-publisher' ) ),
+            'delete' => sprintf( '<a href="%s">%s</a>', esc_url( $delete_url ), __( 'Delete', 'fp-publisher' ) ),
         );
 
         return sprintf( '%1$s %2$s', esc_html( $item['message'] ), $this->row_actions( $actions ) );
@@ -179,20 +179,20 @@ class TTS_Log_Table extends WP_List_Table {
 
         echo '<div class="alignleft actions">';
         echo '<select name="channel">';
-        echo '<option value="">' . esc_html__( 'All Channels', 'trello-social-auto-publisher' ) . '</option>';
+        echo '<option value="">' . esc_html__( 'All Channels', 'fp-publisher' ) . '</option>';
         foreach ( $channels as $ch ) {
             printf( '<option value="%1$s" %2$s>%1$s</option>', esc_attr( $ch ), selected( $ch, $current_channel, false ) );
         }
         echo '</select>';
 
         echo '<select name="status">';
-        echo '<option value="">' . esc_html__( 'All Statuses', 'trello-social-auto-publisher' ) . '</option>';
+        echo '<option value="">' . esc_html__( 'All Statuses', 'fp-publisher' ) . '</option>';
         foreach ( $statuses as $st ) {
             printf( '<option value="%1$s" %2$s>%1$s</option>', esc_attr( $st ), selected( $st, $current_status, false ) );
         }
         echo '</select>';
 
-        submit_button( __( 'Filter', 'trello-social-auto-publisher' ), '', 'filter_action', false );
+        submit_button( __( 'Filter', 'fp-publisher' ), '', 'filter_action', false );
         echo '</div>';
     }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-advanced-media.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-advanced-media.php
@@ -110,7 +110,7 @@ class TTS_Advanced_Media {
         check_ajax_referer( 'tts_media_nonce', 'nonce' );
 
         if ( ! current_user_can( 'upload_files' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $attachment_id = intval( $_POST['attachment_id'] ?? 0 );
@@ -118,7 +118,7 @@ class TTS_Advanced_Media {
         $format = sanitize_text_field( wp_unslash( $_POST['format'] ?? '' ) );
 
         if ( empty( $attachment_id ) || empty( $platform ) || empty( $format ) ) {
-            wp_send_json_error( array( 'message' => __( 'Attachment ID, platform, and format are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Attachment ID, platform, and format are required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -126,11 +126,11 @@ class TTS_Advanced_Media {
             
             wp_send_json_success( array(
                 'resized_url' => $resized_url,
-                'message' => __( 'Image resized successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Image resized successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Media Resize Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to resize image. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to resize image. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -206,7 +206,7 @@ class TTS_Advanced_Media {
         check_ajax_referer( 'tts_media_nonce', 'nonce' );
 
         if ( ! current_user_can( 'upload_files' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $attachment_id = intval( $_POST['attachment_id'] ?? 0 );
@@ -214,7 +214,7 @@ class TTS_Advanced_Media {
         $quality = sanitize_text_field( wp_unslash( $_POST['quality'] ?? 'medium' ) );
 
         if ( empty( $attachment_id ) || empty( $platform ) ) {
-            wp_send_json_error( array( 'message' => __( 'Attachment ID and platform are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Attachment ID and platform are required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -222,11 +222,11 @@ class TTS_Advanced_Media {
             
             wp_send_json_success( array(
                 'optimized_info' => $optimized_info,
-                'message' => __( 'Video optimized successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Video optimized successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Video Optimization Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to optimize video. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to optimize video. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -391,7 +391,7 @@ class TTS_Advanced_Media {
         check_ajax_referer( 'tts_media_nonce', 'nonce' );
 
         if ( ! current_user_can( 'upload_files' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $attachment_id = intval( $_POST['attachment_id'] ?? 0 );
@@ -401,7 +401,7 @@ class TTS_Advanced_Media {
         $watermark_opacity = intval( $_POST['watermark_opacity'] ?? 50 );
 
         if ( empty( $attachment_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Attachment ID is required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Attachment ID is required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -409,11 +409,11 @@ class TTS_Advanced_Media {
             
             wp_send_json_success( array(
                 'watermarked_url' => $watermarked_url,
-                'message' => __( 'Watermark added successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Watermark added successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Watermark Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to add watermark. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to add watermark. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -619,7 +619,7 @@ class TTS_Advanced_Media {
         check_ajax_referer( 'tts_media_nonce', 'nonce' );
 
         if ( ! current_user_can( 'upload_files' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $attachment_ids = array_map( 'intval', $_POST['attachment_ids'] ?? array() );
@@ -627,12 +627,12 @@ class TTS_Advanced_Media {
         $settings = array_map( 'sanitize_text_field', wp_unslash( $_POST['settings'] ?? array() ) );
 
         if ( empty( $attachment_ids ) || empty( $operation ) ) {
-            wp_send_json_error( array( 'message' => __( 'Attachment IDs and operation are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Attachment IDs and operation are required.', 'fp-publisher' ) ) );
         }
 
         // Limit batch size for performance
         if ( count( $attachment_ids ) > 20 ) {
-            wp_send_json_error( array( 'message' => __( 'Maximum 20 files can be processed at once.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Maximum 20 files can be processed at once.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -640,11 +640,11 @@ class TTS_Advanced_Media {
             
             wp_send_json_success( array(
                 'results' => $results,
-                'message' => __( 'Batch processing completed successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Batch processing completed successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Batch Media Processing Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to process media files. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to process media files. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -733,7 +733,7 @@ class TTS_Advanced_Media {
         check_ajax_referer( 'tts_media_nonce', 'nonce' );
 
         if ( ! current_user_can( 'upload_files' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $search_term = sanitize_text_field( wp_unslash( $_POST['search_term'] ?? '' ) );
@@ -741,7 +741,7 @@ class TTS_Advanced_Media {
         $per_page = intval( $_POST['per_page'] ?? 20 );
 
         if ( empty( $search_term ) ) {
-            wp_send_json_error( array( 'message' => __( 'Search term is required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Search term is required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -749,11 +749,11 @@ class TTS_Advanced_Media {
             
             wp_send_json_success( array(
                 'photos' => $photos,
-                'message' => __( 'Stock photos retrieved successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Stock photos retrieved successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Stock Photos Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to retrieve stock photos. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to retrieve stock photos. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -797,14 +797,14 @@ class TTS_Advanced_Media {
         check_ajax_referer( 'tts_media_nonce', 'nonce' );
 
         if ( ! current_user_can( 'upload_files' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $attachment_id = intval( $_POST['attachment_id'] ?? 0 );
         $platforms = array_map( 'sanitize_text_field', wp_unslash( $_POST['platforms'] ?? array() ) );
 
         if ( empty( $attachment_id ) || empty( $platforms ) ) {
-            wp_send_json_error( array( 'message' => __( 'Attachment ID and platforms are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Attachment ID and platforms are required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -812,11 +812,11 @@ class TTS_Advanced_Media {
             
             wp_send_json_success( array(
                 'variations' => $variations,
-                'message' => __( 'Media variations created successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Media variations created successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Media Variations Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to create variations. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to create variations. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -864,14 +864,14 @@ class TTS_Advanced_Media {
         check_ajax_referer( 'tts_media_nonce', 'nonce' );
 
         if ( ! current_user_can( 'upload_files' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $attachment_id = intval( $_POST['attachment_id'] ?? 0 );
         $quality = sanitize_text_field( wp_unslash( $_POST['quality'] ?? 'medium' ) );
 
         if ( empty( $attachment_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Attachment ID is required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Attachment ID is required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -879,11 +879,11 @@ class TTS_Advanced_Media {
             
             wp_send_json_success( array(
                 'compression_info' => $compression_info,
-                'message' => __( 'Media compressed successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Media compressed successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Media Compression Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to compress media. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to compress media. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -974,7 +974,7 @@ class TTS_Advanced_Media {
         check_ajax_referer( 'tts_media_nonce', 'nonce' );
 
         if ( ! current_user_can( 'read' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         try {
@@ -982,11 +982,11 @@ class TTS_Advanced_Media {
             
             wp_send_json_success( array(
                 'analysis' => $analysis,
-                'message' => __( 'Media performance analyzed successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Media performance analyzed successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Media Performance Analysis Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to analyze performance. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to analyze performance. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -1095,7 +1095,7 @@ class TTS_Advanced_Media {
     public function add_media_fields( $form_fields, $post ) {
         // Add platform optimization status
         $form_fields['tts_platform_optimized'] = array(
-            'label' => __( 'Platform Optimized', 'trello-social-auto-publisher' ),
+            'label' => __( 'Platform Optimized', 'fp-publisher' ),
             'input' => 'html',
             'html' => '<select name="attachments[' . $post->ID . '][tts_platform_optimized]">
                         <option value="">Not optimized</option>
@@ -1111,10 +1111,10 @@ class TTS_Advanced_Media {
         
         // Add usage rights
         $form_fields['tts_usage_rights'] = array(
-            'label' => __( 'Usage Rights', 'trello-social-auto-publisher' ),
+            'label' => __( 'Usage Rights', 'fp-publisher' ),
             'input' => 'text',
             'value' => get_post_meta( $post->ID, '_tts_usage_rights', true ),
-            'helps' => __( 'Specify usage rights and licensing information', 'trello-social-auto-publisher' )
+            'helps' => __( 'Specify usage rights and licensing information', 'fp-publisher' )
         );
         
         return $form_fields;

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-ai-content.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-ai-content.php
@@ -33,14 +33,14 @@ class TTS_AI_Content {
         check_ajax_referer( 'tts_ai_nonce', 'nonce' );
 
         if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $content = sanitize_textarea_field( wp_unslash( $_POST['content'] ?? '' ) );
         $platform = sanitize_text_field( wp_unslash( $_POST['platform'] ?? 'general' ) );
 
         if ( empty( $content ) ) {
-            wp_send_json_error( array( 'message' => __( 'Content is required for hashtag generation.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Content is required for hashtag generation.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -48,11 +48,11 @@ class TTS_AI_Content {
             
             wp_send_json_success( array(
                 'hashtags' => $hashtags,
-                'message' => __( 'Hashtags generated successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Hashtags generated successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS AI Hashtag Generation Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to generate hashtags. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to generate hashtags. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -179,14 +179,14 @@ class TTS_AI_Content {
         check_ajax_referer( 'tts_ai_nonce', 'nonce' );
 
         if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $content = sanitize_textarea_field( wp_unslash( $_POST['content'] ?? '' ) );
         $platform = sanitize_text_field( wp_unslash( $_POST['platform'] ?? 'general' ) );
 
         if ( empty( $content ) ) {
-            wp_send_json_error( array( 'message' => __( 'Content is required for analysis.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Content is required for analysis.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -194,11 +194,11 @@ class TTS_AI_Content {
             
             wp_send_json_success( array(
                 'analysis' => $analysis,
-                'message' => __( 'Content analyzed successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Content analyzed successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS AI Content Analysis Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to analyze content. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to analyze content. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -237,7 +237,7 @@ class TTS_AI_Content {
             $analysis['score'] += 30;
         } else {
             $analysis['suggestions'][] = sprintf(
-                __( 'Optimal content length for %s is %d-%d characters. Current: %d', 'trello-social-auto-publisher' ),
+                __( 'Optimal content length for %s is %d-%d characters. Current: %d', 'fp-publisher' ),
                 $platform,
                 $platform_limits['min'],
                 $platform_limits['max'],
@@ -252,7 +252,7 @@ class TTS_AI_Content {
         if ( $hashtag_count > 0 ) {
             $analysis['score'] += 20;
         } else {
-            $analysis['suggestions'][] = __( 'Add relevant hashtags to increase discoverability', 'trello-social-auto-publisher' );
+            $analysis['suggestions'][] = __( 'Add relevant hashtags to increase discoverability', 'fp-publisher' );
         }
 
         // Check for engagement triggers
@@ -280,7 +280,7 @@ class TTS_AI_Content {
             $analysis['score'] += 10;
         } else {
             $analysis['readability'] = 40;
-            $analysis['suggestions'][] = __( 'Consider using shorter sentences for better readability', 'trello-social-auto-publisher' );
+            $analysis['suggestions'][] = __( 'Consider using shorter sentences for better readability', 'fp-publisher' );
         }
 
         // Store metrics
@@ -304,14 +304,14 @@ class TTS_AI_Content {
         check_ajax_referer( 'tts_ai_nonce', 'nonce' );
 
         if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $content = sanitize_textarea_field( wp_unslash( $_POST['content'] ?? '' ) );
         $platform = sanitize_text_field( wp_unslash( $_POST['platform'] ?? 'general' ) );
 
         if ( empty( $content ) ) {
-            wp_send_json_error( array( 'message' => __( 'Content is required for performance prediction.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Content is required for performance prediction.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -319,11 +319,11 @@ class TTS_AI_Content {
             
             wp_send_json_success( array(
                 'prediction' => $prediction,
-                'message' => __( 'Performance predicted successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Performance predicted successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS AI Performance Prediction Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to predict performance. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to predict performance. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -467,13 +467,13 @@ class TTS_AI_Content {
      */
     private function get_performance_recommendation( $score ) {
         if ( $score >= 80 ) {
-            return __( 'Excellent! This content has high engagement potential.', 'trello-social-auto-publisher' );
+            return __( 'Excellent! This content has high engagement potential.', 'fp-publisher' );
         } elseif ( $score >= 60 ) {
-            return __( 'Good content with solid engagement potential. Consider minor optimizations.', 'trello-social-auto-publisher' );
+            return __( 'Good content with solid engagement potential. Consider minor optimizations.', 'fp-publisher' );
         } elseif ( $score >= 40 ) {
-            return __( 'Average content. Consider adding hashtags, questions, or calls-to-action.', 'trello-social-auto-publisher' );
+            return __( 'Average content. Consider adding hashtags, questions, or calls-to-action.', 'fp-publisher' );
         } else {
-            return __( 'This content may underperform. Consider significant revisions for better engagement.', 'trello-social-auto-publisher' );
+            return __( 'This content may underperform. Consider significant revisions for better engagement.', 'fp-publisher' );
         }
     }
 
@@ -484,13 +484,13 @@ class TTS_AI_Content {
         check_ajax_referer( 'tts_ai_nonce', 'nonce' );
 
         if ( ! current_user_can( 'upload_files' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $image_url = esc_url_raw( wp_unslash( $_POST['image_url'] ?? '' ) );
 
         if ( empty( $image_url ) ) {
-            wp_send_json_error( array( 'message' => __( 'Image URL is required for auto-tagging.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Image URL is required for auto-tagging.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -498,11 +498,11 @@ class TTS_AI_Content {
             
             wp_send_json_success( array(
                 'tags' => $tags,
-                'message' => __( 'Image analyzed successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Image analyzed successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS AI Image Analysis Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to analyze image. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to analyze image. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -580,7 +580,7 @@ class TTS_AI_Content {
         check_ajax_referer( 'tts_ai_nonce', 'nonce' );
 
         if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $platform = sanitize_text_field( wp_unslash( $_POST['platform'] ?? 'general' ) );
@@ -591,11 +591,11 @@ class TTS_AI_Content {
             
             wp_send_json_success( array(
                 'suggestions' => $suggestions,
-                'message' => __( 'Content suggestions generated successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Content suggestions generated successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS AI Content Suggestions Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to generate suggestions. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to generate suggestions. Please try again.', 'fp-publisher' ) ) );
         }
     }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
@@ -91,12 +91,12 @@ class TTS_Analytics {
      */
     public static function fetch_facebook_metrics( $post_id, $credentials ) {
         if ( empty( $credentials ) ) {
-            return new WP_Error( 'fb_no_token', __( 'Facebook token missing', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'fb_no_token', __( 'Facebook token missing', 'fp-publisher' ) );
         }
 
         $remote_id = get_post_meta( $post_id, '_tts_facebook_id', true );
         if ( empty( $remote_id ) ) {
-            return new WP_Error( 'fb_no_id', __( 'Missing Facebook post ID', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'fb_no_id', __( 'Missing Facebook post ID', 'fp-publisher' ) );
         }
 
         $endpoint = sprintf( 'https://graph.facebook.com/%s?fields=engagement&access_token=%s', rawurlencode( $remote_id ), rawurlencode( $credentials ) );
@@ -122,12 +122,12 @@ class TTS_Analytics {
      */
     public static function fetch_instagram_metrics( $post_id, $credentials ) {
         if ( empty( $credentials ) ) {
-            return new WP_Error( 'ig_no_token', __( 'Instagram token missing', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'ig_no_token', __( 'Instagram token missing', 'fp-publisher' ) );
         }
 
         $remote_id = get_post_meta( $post_id, '_tts_instagram_id', true );
         if ( empty( $remote_id ) ) {
-            return new WP_Error( 'ig_no_id', __( 'Missing Instagram media ID', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'ig_no_id', __( 'Missing Instagram media ID', 'fp-publisher' ) );
         }
 
         $endpoint = sprintf( 'https://graph.facebook.com/%s?fields=like_count,comments_count&access_token=%s', rawurlencode( $remote_id ), rawurlencode( $credentials ) );
@@ -153,12 +153,12 @@ class TTS_Analytics {
      */
     public static function fetch_youtube_metrics( $post_id, $credentials ) {
         if ( empty( $credentials ) ) {
-            return new WP_Error( 'yt_no_token', __( 'YouTube token missing', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'yt_no_token', __( 'YouTube token missing', 'fp-publisher' ) );
         }
 
         $remote_id = get_post_meta( $post_id, '_tts_youtube_id', true );
         if ( empty( $remote_id ) ) {
-            return new WP_Error( 'yt_no_id', __( 'Missing YouTube video ID', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'yt_no_id', __( 'Missing YouTube video ID', 'fp-publisher' ) );
         }
 
         $endpoint = add_query_arg(
@@ -194,12 +194,12 @@ class TTS_Analytics {
      */
     public static function fetch_tiktok_metrics( $post_id, $credentials ) {
         if ( empty( $credentials ) ) {
-            return new WP_Error( 'tt_no_token', __( 'TikTok token missing', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'tt_no_token', __( 'TikTok token missing', 'fp-publisher' ) );
         }
 
         $remote_id = get_post_meta( $post_id, '_tts_tiktok_id', true );
         if ( empty( $remote_id ) ) {
-            return new WP_Error( 'tt_no_id', __( 'Missing TikTok video ID', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'tt_no_id', __( 'Missing TikTok video ID', 'fp-publisher' ) );
         }
 
         $endpoint = sprintf( 'https://open.tiktokapis.com/v2/video/%s/metrics?access_token=%s', rawurlencode( $remote_id ), rawurlencode( $credentials ) );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-backup.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-backup.php
@@ -38,7 +38,7 @@ class TTS_Backup {
         check_ajax_referer( 'tts_backup_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $backup_type = sanitize_text_field( $_POST['backup_type'] ?? 'full' );
@@ -89,7 +89,7 @@ class TTS_Backup {
             // Save backup to file
             $backup_json = wp_json_encode( $backup_data, JSON_PRETTY_PRINT );
             if ( false === file_put_contents( $backup_path, $backup_json ) ) {
-                throw new Exception( __( 'Failed to save backup file', 'trello-social-auto-publisher' ) );
+                throw new Exception( __( 'Failed to save backup file', 'fp-publisher' ) );
             }
             
             // Compress backup
@@ -103,7 +103,7 @@ class TTS_Backup {
             
             return array(
                 'success' => true,
-                'message' => __( 'Backup created successfully', 'trello-social-auto-publisher' ),
+                'message' => __( 'Backup created successfully', 'fp-publisher' ),
                 'filename' => basename( $compressed_path ),
                 'size' => $this->format_file_size( filesize( $compressed_path ) ),
                 'timestamp' => current_time( 'mysql' )
@@ -114,7 +114,7 @@ class TTS_Backup {
             
             return array(
                 'success' => false,
-                'message' => __( 'Backup creation failed: ', 'trello-social-auto-publisher' ) . $e->getMessage()
+                'message' => __( 'Backup creation failed: ', 'fp-publisher' ) . $e->getMessage()
             );
         }
     }
@@ -237,7 +237,7 @@ class TTS_Backup {
         check_ajax_referer( 'tts_backup_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $backup_filename = sanitize_file_name( $_POST['backup_filename'] ?? '' );
@@ -259,7 +259,7 @@ class TTS_Backup {
             $backup_path = $this->get_backup_directory() . $filename;
             
             if ( ! file_exists( $backup_path ) ) {
-                throw new Exception( __( 'Backup file not found', 'trello-social-auto-publisher' ) );
+                throw new Exception( __( 'Backup file not found', 'fp-publisher' ) );
             }
             
             // Decompress backup
@@ -268,17 +268,17 @@ class TTS_Backup {
             // Load backup data
             $backup_content = file_get_contents( $decompressed_path );
             if ( false === $backup_content ) {
-                throw new Exception( __( 'Failed to read backup file', 'trello-social-auto-publisher' ) );
+                throw new Exception( __( 'Failed to read backup file', 'fp-publisher' ) );
             }
             
             $backup_data = json_decode( $backup_content, true );
             
             if ( json_last_error() !== JSON_ERROR_NONE ) {
-                throw new Exception( __( 'Backup file contains invalid JSON', 'trello-social-auto-publisher' ) );
+                throw new Exception( __( 'Backup file contains invalid JSON', 'fp-publisher' ) );
             }
             
             if ( ! $backup_data ) {
-                throw new Exception( __( 'Invalid backup file format', 'trello-social-auto-publisher' ) );
+                throw new Exception( __( 'Invalid backup file format', 'fp-publisher' ) );
             }
             
             // Perform restore based on type
@@ -301,7 +301,7 @@ class TTS_Backup {
             
             return array(
                 'success' => true,
-                'message' => __( 'Backup restored successfully', 'trello-social-auto-publisher' )
+                'message' => __( 'Backup restored successfully', 'fp-publisher' )
             );
             
         } catch ( Exception $e ) {
@@ -309,7 +309,7 @@ class TTS_Backup {
             
             return array(
                 'success' => false,
-                'message' => __( 'Backup restore failed: ', 'trello-social-auto-publisher' ) . $e->getMessage()
+                'message' => __( 'Backup restore failed: ', 'fp-publisher' ) . $e->getMessage()
             );
         }
     }
@@ -367,7 +367,7 @@ class TTS_Backup {
         check_ajax_referer( 'tts_backup_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $backups = $this->list_backups();
@@ -415,7 +415,7 @@ class TTS_Backup {
         check_ajax_referer( 'tts_backup_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $filename = sanitize_file_name( $_POST['filename'] ?? '' );
@@ -433,13 +433,13 @@ class TTS_Backup {
         if ( file_exists( $backup_path ) && unlink( $backup_path ) ) {
             return array(
                 'success' => true,
-                'message' => __( 'Backup deleted successfully', 'trello-social-auto-publisher' )
+                'message' => __( 'Backup deleted successfully', 'fp-publisher' )
             );
         }
         
         return array(
             'success' => false,
-            'message' => __( 'Failed to delete backup', 'trello-social-auto-publisher' )
+            'message' => __( 'Failed to delete backup', 'fp-publisher' )
         );
     }
 
@@ -450,7 +450,7 @@ class TTS_Backup {
         check_ajax_referer( 'tts_backup_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $filename = sanitize_file_name( $_GET['filename'] ?? '' );
@@ -464,7 +464,7 @@ class TTS_Backup {
         $backup_path = $this->get_backup_directory() . $filename;
         
         if ( ! file_exists( $backup_path ) ) {
-            wp_die( esc_html__( 'Backup file not found', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Backup file not found', 'fp-publisher' ) );
         }
         
         header( 'Content-Type: application/octet-stream' );
@@ -521,7 +521,7 @@ class TTS_Backup {
         if ( false === $fp_out || false === $fp_in ) {
             if ( $fp_in ) fclose( $fp_in );
             if ( $fp_out ) gzclose( $fp_out );
-            throw new Exception( __( 'Failed to compress backup file', 'trello-social-auto-publisher' ) );
+            throw new Exception( __( 'Failed to compress backup file', 'fp-publisher' ) );
         }
         
         while ( ! feof( $fp_in ) ) {
@@ -546,7 +546,7 @@ class TTS_Backup {
         if ( false === $fp_out || false === $fp_in ) {
             if ( $fp_out ) fclose( $fp_out );
             if ( $fp_in ) gzclose( $fp_in );
-            throw new Exception( __( 'Failed to decompress backup file', 'trello-social-auto-publisher' ) );
+            throw new Exception( __( 'Failed to decompress backup file', 'fp-publisher' ) );
         }
         
         while ( ! gzeof( $fp_in ) ) {

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cache-manager.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cache-manager.php
@@ -864,7 +864,7 @@ class TTS_Cache_Manager {
         check_ajax_referer( 'tts_cache_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $group = sanitize_text_field( $_POST['group'] ?? '' );
@@ -873,7 +873,7 @@ class TTS_Cache_Manager {
         $cleared = $this->clear_cache( $group ?: null, $pattern ?: null );
         
         wp_send_json_success( array(
-            'message' => sprintf( __( 'Cleared %d cache entries', 'trello-social-auto-publisher' ), $cleared ),
+            'message' => sprintf( __( 'Cleared %d cache entries', 'fp-publisher' ), $cleared ),
             'cleared' => $cleared
         ));
     }
@@ -882,7 +882,7 @@ class TTS_Cache_Manager {
         check_ajax_referer( 'tts_cache_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $stats = $this->get_cache_stats();
@@ -893,13 +893,13 @@ class TTS_Cache_Manager {
         check_ajax_referer( 'tts_cache_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $results = $this->optimize_cache();
         
         wp_send_json_success( array(
-            'message' => __( 'Cache optimization completed', 'trello-social-auto-publisher' ),
+            'message' => __( 'Cache optimization completed', 'fp-publisher' ),
             'results' => $results
         ));
     }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
@@ -57,7 +57,7 @@ class TTS_Client {
     public function add_credentials_metabox() {
         add_meta_box(
             'tts_client_credentials',
-            __( 'Client Credentials', 'trello-social-auto-publisher' ),
+            __( 'Client Credentials', 'fp-publisher' ),
             array( $this, 'render_credentials_metabox' ),
             'tts_client'
         );
@@ -98,13 +98,13 @@ class TTS_Client {
             $publish_freq = array();
         }
 
-        echo '<p><label for="tts_trello_key">' . esc_html__( 'Trello API Key', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_trello_key">' . esc_html__( 'Trello API Key', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="tts_trello_key" name="tts_trello_key" value="' . esc_attr( $trello_key ) . '" class="widefat" /></p>';
 
-        echo '<p><label for="tts_trello_token">' . esc_html__( 'Trello API Token', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_trello_token">' . esc_html__( 'Trello API Token', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="tts_trello_token" name="tts_trello_token" value="' . esc_attr( $trello_token ) . '" class="widefat" /></p>';
 
-        echo '<p><label for="tts_trello_secret">' . esc_html__( 'Trello API Secret', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_trello_secret">' . esc_html__( 'Trello API Secret', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="tts_trello_secret" name="tts_trello_secret" value="' . esc_attr( $trello_secret ) . '" class="widefat" /></p>';
 
         ?>
@@ -114,60 +114,60 @@ class TTS_Client {
             foreach ( $board_ids as $board ) :
                 ?>
                 <p class="tts-trello-board-row">
-                    <input type="text" name="tts_trello_boards[<?php echo $index; ?>]" value="<?php echo esc_attr( $board ); ?>" placeholder="<?php esc_attr_e( 'Trello Board ID', 'trello-social-auto-publisher' ); ?>" />
+                    <input type="text" name="tts_trello_boards[<?php echo $index; ?>]" value="<?php echo esc_attr( $board ); ?>" placeholder="<?php esc_attr_e( 'Trello Board ID', 'fp-publisher' ); ?>" />
                 </p>
                 <?php
                 $index++;
             endforeach;
             ?>
             <p class="tts-trello-board-row">
-                <input type="text" name="tts_trello_boards[<?php echo $index; ?>]" placeholder="<?php esc_attr_e( 'Trello Board ID', 'trello-social-auto-publisher' ); ?>" />
+                <input type="text" name="tts_trello_boards[<?php echo $index; ?>]" placeholder="<?php esc_attr_e( 'Trello Board ID', 'fp-publisher' ); ?>" />
             </p>
         </div>
-        <p><button type="button" class="button" id="add-tts-trello-board"><?php esc_html_e( 'Add Board', 'trello-social-auto-publisher' ); ?></button></p>
+        <p><button type="button" class="button" id="add-tts-trello-board"><?php esc_html_e( 'Add Board', 'fp-publisher' ); ?></button></p>
         <script type="text/javascript">
         jQuery(document).ready(function($){
             $('#add-tts-trello-board').on('click', function(e){
                 e.preventDefault();
                 var index = $('#tts_trello_boards .tts-trello-board-row').length;
                 var safeIndex = String(parseInt(index, 10));
-                var row = '<p class="tts-trello-board-row"><input type="text" name="tts_trello_boards[' + safeIndex + ']" placeholder="<?php echo esc_js( __( 'Trello Board ID', 'trello-social-auto-publisher' ) ); ?>" /></p>';
+                var row = '<p class="tts-trello-board-row"><input type="text" name="tts_trello_boards[' + safeIndex + ']" placeholder="<?php echo esc_js( __( 'Trello Board ID', 'fp-publisher' ) ); ?>" /></p>';
                 $('#tts_trello_boards').append(row);
             });
         });
         </script>
         <?php
 
-        echo '<p><label for="tts_trello_published_list">' . esc_html__( 'Trello Published List ID', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_trello_published_list">' . esc_html__( 'Trello Published List ID', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="tts_trello_published_list" name="tts_trello_published_list" value="' . esc_attr( $published_list ) . '" class="widefat" /></p>';
 
-        echo '<p><label for="tts_fb_token">' . esc_html__( 'Facebook Access Token', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_fb_token">' . esc_html__( 'Facebook Access Token', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="tts_fb_token" name="tts_fb_token" value="' . esc_attr( $fb_token ) . '" class="widefat" /></p>';
-        echo '<p><label for="tts_default_hashtags_facebook">' . esc_html__( 'Facebook Default Hashtags', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_default_hashtags_facebook">' . esc_html__( 'Facebook Default Hashtags', 'fp-publisher' ) . '</label>';
         echo '<textarea id="tts_default_hashtags_facebook" name="tts_default_hashtags_facebook" class="widefat" rows="3">' . esc_textarea( $fb_hashtags ) . '</textarea></p>';
 
-        echo '<p><label for="tts_ig_token">' . esc_html__( 'Instagram Access Token', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_ig_token">' . esc_html__( 'Instagram Access Token', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="tts_ig_token" name="tts_ig_token" value="' . esc_attr( $ig_token ) . '" class="widefat" /></p>';
-        echo '<p><label for="tts_default_hashtags_instagram">' . esc_html__( 'Instagram Default Hashtags', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_default_hashtags_instagram">' . esc_html__( 'Instagram Default Hashtags', 'fp-publisher' ) . '</label>';
         echo '<textarea id="tts_default_hashtags_instagram" name="tts_default_hashtags_instagram" class="widefat" rows="3">' . esc_textarea( $ig_hashtags ) . '</textarea></p>';
 
-        echo '<p><label for="tts_yt_token">' . esc_html__( 'YouTube Access Token', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_yt_token">' . esc_html__( 'YouTube Access Token', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="tts_yt_token" name="tts_yt_token" value="' . esc_attr( $yt_token ) . '" class="widefat" /></p>';
-        echo '<p><label for="tts_default_hashtags_youtube">' . esc_html__( 'YouTube Default Hashtags', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_default_hashtags_youtube">' . esc_html__( 'YouTube Default Hashtags', 'fp-publisher' ) . '</label>';
         echo '<textarea id="tts_default_hashtags_youtube" name="tts_default_hashtags_youtube" class="widefat" rows="3">' . esc_textarea( $yt_hashtags ) . '</textarea></p>';
 
-        echo '<p><label for="tts_tt_token">' . esc_html__( 'TikTok Access Token', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_tt_token">' . esc_html__( 'TikTok Access Token', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="tts_tt_token" name="tts_tt_token" value="' . esc_attr( $tt_token ) . '" class="widefat" /></p>';
-        echo '<p><label for="tts_default_hashtags_tiktok">' . esc_html__( 'TikTok Default Hashtags', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="tts_default_hashtags_tiktok">' . esc_html__( 'TikTok Default Hashtags', 'fp-publisher' ) . '</label>';
         echo '<textarea id="tts_default_hashtags_tiktok" name="tts_default_hashtags_tiktok" class="widefat" rows="3">' . esc_textarea( $tt_hashtags ) . '</textarea></p>';
 
-        echo '<h3>' . esc_html__( 'Blog Publishing Settings', 'trello-social-auto-publisher' ) . '</h3>';
-        echo '<p><label for="tts_blog_settings">' . esc_html__( 'Blog Settings', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<h3>' . esc_html__( 'Blog Publishing Settings', 'fp-publisher' ) . '</h3>';
+        echo '<p><label for="tts_blog_settings">' . esc_html__( 'Blog Settings', 'fp-publisher' ) . '</label>';
         echo '<textarea id="tts_blog_settings" name="tts_blog_settings" class="widefat" rows="4" placeholder="post_type:post|post_status:draft|author_id:1|category_id:1|language:it|keywords:keyword1:url1|keyword2:url2">' . esc_textarea( $blog_settings ) . '</textarea>';
-        echo '<small>' . esc_html__( 'Format: post_type:post|post_status:draft|author_id:1|category_id:1|language:it|keywords:keyword1:url1|keyword2:url2', 'trello-social-auto-publisher' ) . '</small></p>';
+        echo '<small>' . esc_html__( 'Format: post_type:post|post_status:draft|author_id:1|category_id:1|language:it|keywords:keyword1:url1|keyword2:url2', 'fp-publisher' ) . '</small></p>';
 
-        echo '<h3>' . esc_html__( 'Trello List Mapping', 'trello-social-auto-publisher' ) . '</h3>';
-        echo '<p>' . esc_html__( 'Map Trello lists to social channels. Supported channels: facebook, instagram, youtube, tiktok, blog', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<h3>' . esc_html__( 'Trello List Mapping', 'fp-publisher' ) . '</h3>';
+        echo '<p>' . esc_html__( 'Map Trello lists to social channels. Supported channels: facebook, instagram, youtube, tiktok, blog', 'fp-publisher' ) . '</p>';
 
         ?>
         <div id="tts_trello_map">
@@ -178,19 +178,19 @@ class TTS_Client {
                 $social  = isset( $row['canale_social'] ) ? esc_attr( $row['canale_social'] ) : '';
                 ?>
                 <p class="tts-trello-map-row">
-                    <input type="text" name="tts_trello_map[<?php echo $index; ?>][idList]" value="<?php echo $id_list; ?>" placeholder="<?php esc_attr_e( 'Trello List ID', 'trello-social-auto-publisher' ); ?>" />
-                    <input type="text" name="tts_trello_map[<?php echo $index; ?>][canale_social]" value="<?php echo $social; ?>" placeholder="<?php esc_attr_e( 'Canale Social', 'trello-social-auto-publisher' ); ?>" />
+                    <input type="text" name="tts_trello_map[<?php echo $index; ?>][idList]" value="<?php echo $id_list; ?>" placeholder="<?php esc_attr_e( 'Trello List ID', 'fp-publisher' ); ?>" />
+                    <input type="text" name="tts_trello_map[<?php echo $index; ?>][canale_social]" value="<?php echo $social; ?>" placeholder="<?php esc_attr_e( 'Canale Social', 'fp-publisher' ); ?>" />
                 </p>
                 <?php
                 $index++;
             endforeach;
             ?>
             <p class="tts-trello-map-row">
-                <input type="text" name="tts_trello_map[<?php echo $index; ?>][idList]" placeholder="<?php esc_attr_e( 'Trello List ID', 'trello-social-auto-publisher' ); ?>" />
-                <input type="text" name="tts_trello_map[<?php echo $index; ?>][canale_social]" placeholder="<?php esc_attr_e( 'Canale Social', 'trello-social-auto-publisher' ); ?>" />
+                <input type="text" name="tts_trello_map[<?php echo $index; ?>][idList]" placeholder="<?php esc_attr_e( 'Trello List ID', 'fp-publisher' ); ?>" />
+                <input type="text" name="tts_trello_map[<?php echo $index; ?>][canale_social]" placeholder="<?php esc_attr_e( 'Canale Social', 'fp-publisher' ); ?>" />
             </p>
         </div>
-        <p><button type="button" class="button" id="add-tts-trello-map"><?php esc_html_e( 'Add Mapping', 'trello-social-auto-publisher' ); ?></button></p>
+        <p><button type="button" class="button" id="add-tts-trello-map"><?php esc_html_e( 'Add Mapping', 'fp-publisher' ); ?></button></p>
         <script type="text/javascript">
         jQuery(document).ready(function($){
             $('#add-tts-trello-map').on('click', function(e){
@@ -198,16 +198,16 @@ class TTS_Client {
                 var index = $('#tts_trello_map .tts-trello-map-row').length;
                 var safeIndex = String(parseInt(index, 10));
                 var row = '<p class="tts-trello-map-row">' +
-                    '<input type="text" name="tts_trello_map[' + safeIndex + '][idList]" placeholder="<?php echo esc_js( __( 'Trello List ID', 'trello-social-auto-publisher' ) ); ?>" />' +
-                    '<input type="text" name="tts_trello_map[' + safeIndex + '][canale_social]" placeholder="<?php echo esc_js( __( 'Canale Social', 'trello-social-auto-publisher' ) ); ?>" />' +
+                    '<input type="text" name="tts_trello_map[' + safeIndex + '][idList]" placeholder="<?php echo esc_js( __( 'Trello List ID', 'fp-publisher' ) ); ?>" />' +
+                    '<input type="text" name="tts_trello_map[' + safeIndex + '][canale_social]" placeholder="<?php echo esc_js( __( 'Canale Social', 'fp-publisher' ) ); ?>" />' +
                 '</p>';
                 $('#tts_trello_map').append(row);
             });
         });
         </script>
         
-        <h3><?php esc_html_e( 'Publishing Frequency Settings', 'trello-social-auto-publisher' ); ?></h3>
-        <p><?php esc_html_e( 'Configure how often content should be published for this client on each channel.', 'trello-social-auto-publisher' ); ?></p>
+        <h3><?php esc_html_e( 'Publishing Frequency Settings', 'fp-publisher' ); ?></h3>
+        <p><?php esc_html_e( 'Configure how often content should be published for this client on each channel.', 'fp-publisher' ); ?></p>
         
         <?php
         $channels = array(
@@ -219,9 +219,9 @@ class TTS_Client {
         );
         
         $periods = array(
-            'daily' => __( 'Daily', 'trello-social-auto-publisher' ),
-            'weekly' => __( 'Weekly', 'trello-social-auto-publisher' ),
-            'monthly' => __( 'Monthly', 'trello-social-auto-publisher' )
+            'daily' => __( 'Daily', 'fp-publisher' ),
+            'weekly' => __( 'Weekly', 'fp-publisher' ),
+            'monthly' => __( 'Monthly', 'fp-publisher' )
         );
         ?>
         
@@ -247,19 +247,19 @@ class TTS_Client {
                         <?php endforeach; ?>
                     </select>
                     <small style="color: #666; margin-left: 10px;">
-                        <?php esc_html_e( 'Leave count empty or 0 to disable frequency tracking for this channel', 'trello-social-auto-publisher' ); ?>
+                        <?php esc_html_e( 'Leave count empty or 0 to disable frequency tracking for this channel', 'fp-publisher' ); ?>
                     </small>
                 </p>
             <?php endforeach; ?>
         </div>
         
-        <h4><?php esc_html_e( 'Alert Settings', 'trello-social-auto-publisher' ); ?></h4>
+        <h4><?php esc_html_e( 'Alert Settings', 'fp-publisher' ); ?></h4>
         <?php
         $alert_days = get_post_meta( $post->ID, '_tts_alert_days_ahead', true );
         $alert_days = $alert_days ? $alert_days : 3;
         ?>
         <p>
-            <label for="tts_alert_days_ahead"><?php esc_html_e( 'Days ahead to alert for content needs:', 'trello-social-auto-publisher' ); ?></label>
+            <label for="tts_alert_days_ahead"><?php esc_html_e( 'Days ahead to alert for content needs:', 'fp-publisher' ); ?></label>
             <input type="number" 
                    id="tts_alert_days_ahead" 
                    name="tts_alert_days_ahead" 
@@ -268,7 +268,7 @@ class TTS_Client {
                    max="30" 
                    style="width: 60px;" />
             <small style="color: #666; margin-left: 10px;">
-                <?php esc_html_e( 'Send alerts this many days before content is needed', 'trello-social-auto-publisher' ); ?>
+                <?php esc_html_e( 'Send alerts this many days before content is needed', 'fp-publisher' ); ?>
             </small>
         </p>
         <?php
@@ -415,29 +415,29 @@ class TTS_Client {
         $client_id = absint( $client_id );
 
         if ( ! $client_id ) {
-            return new WP_Error( 'invalid_client', __( 'ID client non valido.', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'invalid_client', __( 'ID client non valido.', 'fp-publisher' ) );
         }
 
         if ( 'tts_client' !== get_post_type( $client_id ) ) {
-            return new WP_Error( 'invalid_client', __( 'Il post indicato non è un client valido.', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'invalid_client', __( 'Il post indicato non è un client valido.', 'fp-publisher' ) );
         }
 
         $channels = array(
             'facebook'  => array(
                 'meta'  => '_tts_fb_token',
-                'label' => __( 'Facebook', 'trello-social-auto-publisher' ),
+                'label' => __( 'Facebook', 'fp-publisher' ),
             ),
             'instagram' => array(
                 'meta'  => '_tts_ig_token',
-                'label' => __( 'Instagram', 'trello-social-auto-publisher' ),
+                'label' => __( 'Instagram', 'fp-publisher' ),
             ),
             'youtube'   => array(
                 'meta'  => '_tts_yt_token',
-                'label' => __( 'YouTube', 'trello-social-auto-publisher' ),
+                'label' => __( 'YouTube', 'fp-publisher' ),
             ),
             'tiktok'    => array(
                 'meta'  => '_tts_tt_token',
-                'label' => __( 'TikTok', 'trello-social-auto-publisher' ),
+                'label' => __( 'TikTok', 'fp-publisher' ),
             ),
         );
 
@@ -482,11 +482,11 @@ class TTS_Client {
             if ( ! empty( $missing_tokens ) ) {
                 $messages[] = sprintf(
                     /* translators: %s: comma separated list of channels. */
-                    __( 'Token mancanti per: %s.', 'trello-social-auto-publisher' ),
+                    __( 'Token mancanti per: %s.', 'fp-publisher' ),
                     implode( ', ', $missing_tokens )
                 );
             } else {
-                $messages[] = __( 'Nessun token configurato per questo client.', 'trello-social-auto-publisher' );
+                $messages[] = __( 'Nessun token configurato per questo client.', 'fp-publisher' );
             }
 
             return new WP_Error( 'missing_tokens', implode( ' ', $messages ) );
@@ -495,13 +495,13 @@ class TTS_Client {
         if ( ! empty( $missing_tokens ) ) {
             $messages[] = sprintf(
                 /* translators: %s: comma separated list of channels. */
-                __( 'Token mancanti per: %s.', 'trello-social-auto-publisher' ),
+                __( 'Token mancanti per: %s.', 'fp-publisher' ),
                 implode( ', ', $missing_tokens )
             );
         }
 
         if ( empty( $messages ) ) {
-            $messages[] = __( 'Impossibile verificare i token del client.', 'trello-social-auto-publisher' );
+            $messages[] = __( 'Impossibile verificare i token del client.', 'fp-publisher' );
         }
 
         return new WP_Error( 'invalid_tokens', implode( ' ', $messages ) );
@@ -555,7 +555,7 @@ class TTS_Client {
             return new WP_Error(
                 'fb_request_failed',
                 sprintf(
-                    __( 'Facebook: %s', 'trello-social-auto-publisher' ),
+                    __( 'Facebook: %s', 'fp-publisher' ),
                     $response->get_error_message()
                 )
             );
@@ -565,12 +565,12 @@ class TTS_Client {
         $body = json_decode( wp_remote_retrieve_body( $response ), true );
 
         if ( 200 !== $code || empty( $body['id'] ) ) {
-            $message = isset( $body['error']['message'] ) ? $body['error']['message'] : __( 'token non valido.', 'trello-social-auto-publisher' );
+            $message = isset( $body['error']['message'] ) ? $body['error']['message'] : __( 'token non valido.', 'fp-publisher' );
 
             return new WP_Error(
                 'fb_invalid_token',
                 sprintf(
-                    __( 'Facebook: %s', 'trello-social-auto-publisher' ),
+                    __( 'Facebook: %s', 'fp-publisher' ),
                     $message
                 )
             );
@@ -605,7 +605,7 @@ class TTS_Client {
             return new WP_Error(
                 'ig_request_failed',
                 sprintf(
-                    __( 'Instagram: %s', 'trello-social-auto-publisher' ),
+                    __( 'Instagram: %s', 'fp-publisher' ),
                     $response->get_error_message()
                 )
             );
@@ -615,12 +615,12 @@ class TTS_Client {
         $body = json_decode( wp_remote_retrieve_body( $response ), true );
 
         if ( 200 !== $code || empty( $body['id'] ) ) {
-            $message = isset( $body['error']['message'] ) ? $body['error']['message'] : __( 'token non valido.', 'trello-social-auto-publisher' );
+            $message = isset( $body['error']['message'] ) ? $body['error']['message'] : __( 'token non valido.', 'fp-publisher' );
 
             return new WP_Error(
                 'ig_invalid_token',
                 sprintf(
-                    __( 'Instagram: %s', 'trello-social-auto-publisher' ),
+                    __( 'Instagram: %s', 'fp-publisher' ),
                     $message
                 )
             );
@@ -654,7 +654,7 @@ class TTS_Client {
             return new WP_Error(
                 'yt_request_failed',
                 sprintf(
-                    __( 'YouTube: %s', 'trello-social-auto-publisher' ),
+                    __( 'YouTube: %s', 'fp-publisher' ),
                     $response->get_error_message()
                 )
             );
@@ -670,13 +670,13 @@ class TTS_Client {
             } elseif ( isset( $body['error'] ) ) {
                 $message = $body['error'];
             } else {
-                $message = __( 'token non valido.', 'trello-social-auto-publisher' );
+                $message = __( 'token non valido.', 'fp-publisher' );
             }
 
             return new WP_Error(
                 'yt_invalid_token',
                 sprintf(
-                    __( 'YouTube: %s', 'trello-social-auto-publisher' ),
+                    __( 'YouTube: %s', 'fp-publisher' ),
                     $message
                 )
             );
@@ -693,7 +693,7 @@ class TTS_Client {
      */
     protected static function validate_tiktok_token( $token ) {
         if ( empty( $token ) ) {
-            return new WP_Error( 'tt_invalid_token', __( 'TikTok: token non valido.', 'trello-social-auto-publisher' ) );
+            return new WP_Error( 'tt_invalid_token', __( 'TikTok: token non valido.', 'fp-publisher' ) );
         }
 
         // No lightweight public endpoint is available for validation without additional credentials.
@@ -718,14 +718,14 @@ class TTS_Client {
         $client  = isset( $_GET['client_id'] ) ? absint( $_GET['client_id'] ) : 0;
 
         if ( empty( $code ) || $state !== $expect ) {
-            wp_die( esc_html__( 'OAuth verification failed.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'OAuth verification failed.', 'fp-publisher' ) );
         }
 
         // Exchange code for token
         $token = $this->exchange_code_for_token( $channel, $code );
         
         if ( ! $token ) {
-            wp_die( esc_html__( 'Failed to obtain access token.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Failed to obtain access token.', 'fp-publisher' ) );
         }
 
         if ( $client ) {

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-competitor-analysis.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-competitor-analysis.php
@@ -45,7 +45,7 @@ class TTS_Competitor_Analysis {
         check_ajax_referer( 'tts_competitor_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $competitor_name = sanitize_text_field( wp_unslash( $_POST['competitor_name'] ?? '' ) );
@@ -53,7 +53,7 @@ class TTS_Competitor_Analysis {
         $handle = sanitize_text_field( wp_unslash( $_POST['handle'] ?? '' ) );
 
         if ( empty( $competitor_name ) || empty( $platform ) || empty( $handle ) ) {
-            wp_send_json_error( array( 'message' => __( 'All fields are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'All fields are required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -61,11 +61,11 @@ class TTS_Competitor_Analysis {
             
             wp_send_json_success( array(
                 'competitor_id' => $competitor_id,
-                'message' => __( 'Competitor added successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Competitor added successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Competitor Add Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to add competitor. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to add competitor. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -142,24 +142,24 @@ class TTS_Competitor_Analysis {
         check_ajax_referer( 'tts_competitor_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $competitor_id = intval( $_POST['competitor_id'] ?? 0 );
 
         if ( empty( $competitor_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Invalid competitor ID.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Invalid competitor ID.', 'fp-publisher' ) ) );
         }
 
         try {
             $this->remove_competitor( $competitor_id );
             
             wp_send_json_success( array(
-                'message' => __( 'Competitor removed successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Competitor removed successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Competitor Remove Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to remove competitor. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to remove competitor. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -191,13 +191,13 @@ class TTS_Competitor_Analysis {
         check_ajax_referer( 'tts_competitor_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $competitor_id = intval( $_POST['competitor_id'] ?? 0 );
 
         if ( empty( $competitor_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Invalid competitor ID.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Invalid competitor ID.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -205,11 +205,11 @@ class TTS_Competitor_Analysis {
             
             wp_send_json_success( array(
                 'analysis' => $analysis,
-                'message' => __( 'Competitor analyzed successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Competitor analyzed successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Competitor Analysis Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to analyze competitor. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to analyze competitor. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -545,7 +545,7 @@ class TTS_Competitor_Analysis {
         check_ajax_referer( 'tts_competitor_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         try {
@@ -553,11 +553,11 @@ class TTS_Competitor_Analysis {
             
             wp_send_json_success( array(
                 'report' => $report,
-                'message' => __( 'Competitor report generated successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Competitor report generated successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Competitor Report Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to generate report. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to generate report. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -745,13 +745,13 @@ class TTS_Competitor_Analysis {
         check_ajax_referer( 'tts_competitor_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $competitor_id = intval( $_POST['competitor_id'] ?? 0 );
 
         if ( empty( $competitor_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Invalid competitor ID.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Invalid competitor ID.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -759,11 +759,11 @@ class TTS_Competitor_Analysis {
             
             wp_send_json_success( array(
                 'posts' => $posts,
-                'message' => __( 'Competitor posts tracked successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Competitor posts tracked successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Competitor Posts Tracking Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to track competitor posts. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to track competitor posts. Please try again.', 'fp-publisher' ) ) );
         }
     }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -155,7 +155,7 @@ class TTS_CPT {
     public function add_schedule_metabox() {
         add_meta_box(
             'tts_programmazione',
-            __( 'Programmazione', 'trello-social-auto-publisher' ),
+            __( 'Programmazione', 'fp-publisher' ),
             array( $this, 'render_schedule_metabox' ),
             'tts_social_post',
             'side'
@@ -168,7 +168,7 @@ class TTS_CPT {
     public function add_preview_metabox() {
         add_meta_box(
             'tts_anteprima',
-            __( 'Preview', 'trello-social-auto-publisher' ),
+            __( 'Preview', 'fp-publisher' ),
             array( $this, 'render_preview_metabox' ),
             'tts_social_post',
             'normal'
@@ -181,7 +181,7 @@ class TTS_CPT {
     public function add_channel_metabox() {
         add_meta_box(
             'tts_social_channel',
-            __( 'Channels', 'trello-social-auto-publisher' ),
+            __( 'Channels', 'fp-publisher' ),
             array( $this, 'render_channel_metabox' ),
             'tts_social_post',
             'side'
@@ -194,7 +194,7 @@ class TTS_CPT {
     public function add_media_metabox() {
         add_meta_box(
             'tts_manual_media',
-            __( 'Media', 'trello-social-auto-publisher' ),
+            __( 'Media', 'fp-publisher' ),
             array( $this, 'render_media_metabox' ),
             'tts_social_post',
             'side'
@@ -207,7 +207,7 @@ class TTS_CPT {
     public function add_messages_metabox() {
         add_meta_box(
             'tts_messages',
-            __( 'Messaggi per canale', 'trello-social-auto-publisher' ),
+            __( 'Messaggi per canale', 'fp-publisher' ),
             array( $this, 'render_messages_metabox' ),
             'tts_social_post',
             'normal'
@@ -220,7 +220,7 @@ class TTS_CPT {
     public function add_location_metabox() {
         add_meta_box(
             'tts_location',
-            __( 'Localizzazione', 'trello-social-auto-publisher' ),
+            __( 'Localizzazione', 'fp-publisher' ),
             array( $this, 'render_location_metabox' ),
             'tts_social_post',
             'side'
@@ -233,7 +233,7 @@ class TTS_CPT {
     public function add_approval_metabox() {
         add_meta_box(
             'tts_approval_status',
-            __( 'Stato di approvazione', 'trello-social-auto-publisher' ),
+            __( 'Stato di approvazione', 'fp-publisher' ),
             array( $this, 'render_approval_metabox' ),
             'tts_social_post',
             'side'
@@ -250,7 +250,7 @@ class TTS_CPT {
         $value     = get_post_meta( $post->ID, '_tts_publish_at', true );
         $formatted = $value ? date( 'Y-m-d\\TH:i', strtotime( $value ) ) : '';
 
-        echo '<label for="_tts_publish_at">' . esc_html__( 'Data di pubblicazione', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<label for="_tts_publish_at">' . esc_html__( 'Data di pubblicazione', 'fp-publisher' ) . '</label>';
         echo '<input type="datetime-local" id="_tts_publish_at" name="_tts_publish_at" value="' . esc_attr( $formatted ) . '" class="widefat" />';
 
         $channels = get_post_meta( $post->ID, '_tts_social_channel', true );
@@ -258,7 +258,7 @@ class TTS_CPT {
         if ( $channel && class_exists( 'TTS_Timing' ) ) {
             $suggested = TTS_Timing::suggest_time( $channel );
             if ( $suggested ) {
-                echo '<p class="description">' . sprintf( esc_html__( 'Orario suggerito: %s', 'trello-social-auto-publisher' ), esc_html( $suggested ) ) . '</p>';
+                echo '<p class="description">' . sprintf( esc_html__( 'Orario suggerito: %s', 'fp-publisher' ), esc_html( $suggested ) ) . '</p>';
             }
         }
     }
@@ -307,7 +307,7 @@ class TTS_CPT {
 
         foreach ( $channels as $key => $label ) {
             $offset  = isset( $options[ $key . '_offset' ] ) ? intval( $options[ $key . '_offset' ] ) : 0;
-            $display = sprintf( __( '%1$s (%2$d min)', 'trello-social-auto-publisher' ), $label, $offset );
+            $display = sprintf( __( '%1$s (%2$d min)', 'fp-publisher' ), $label, $offset );
             printf(
                 '<p><label><input type="checkbox" name="_tts_social_channel[]" value="%1$s" %2$s /> %3$s</label></p>',
                 esc_attr( $key ),
@@ -337,16 +337,16 @@ class TTS_CPT {
         echo '<input type="hidden" id="tts_attachment_ids" name="_tts_attachment_ids" value="' . esc_attr( implode( ',', $attachments ) ) . '" />';
         $value = get_post_meta( $post->ID, '_tts_manual_media', true );
         echo '<input type="hidden" id="tts_manual_media" name="_tts_manual_media" value="' . esc_attr( $value ) . '" />';
-        echo '<button type="button" class="button tts-select-media">' . esc_html__( 'Seleziona/Carica file', 'trello-social-auto-publisher' ) . '</button>';
+        echo '<button type="button" class="button tts-select-media">' . esc_html__( 'Seleziona/Carica file', 'fp-publisher' ) . '</button>';
 
         $story_enabled = (bool) get_post_meta( $post->ID, '_tts_publish_story', true );
         $story_media   = (int) get_post_meta( $post->ID, '_tts_story_media', true );
         $story_thumb   = $story_media ? wp_get_attachment_image( $story_media, array( 80, 80 ) ) : '';
-        echo '<p><label><input type="checkbox" id="tts_publish_story" name="_tts_publish_story" value="1" ' . checked( $story_enabled, true, false ) . ' /> ' . esc_html__( 'Pubblica come Story', 'trello-social-auto-publisher' ) . '</label></p>';
+        echo '<p><label><input type="checkbox" id="tts_publish_story" name="_tts_publish_story" value="1" ' . checked( $story_enabled, true, false ) . ' /> ' . esc_html__( 'Pubblica come Story', 'fp-publisher' ) . '</label></p>';
         echo '<div id="tts_story_media_wrapper"' . ( $story_enabled ? '' : ' style="display:none;"' ) . '>';
         echo '<div id="tts_story_media_preview">' . $story_thumb . '</div>';
         echo '<input type="hidden" id="tts_story_media" name="_tts_story_media" value="' . esc_attr( $story_media ) . '" />';
-        echo '<button type="button" class="button tts-select-story-media">' . esc_html__( 'Seleziona media Story', 'trello-social-auto-publisher' ) . '</button>';
+        echo '<button type="button" class="button tts-select-story-media">' . esc_html__( 'Seleziona media Story', 'fp-publisher' ) . '</button>';
         echo '</div>';
     }
 
@@ -371,7 +371,7 @@ class TTS_CPT {
 
             if ( 'instagram' === $key ) {
                 $comment = get_post_meta( $post->ID, '_tts_instagram_first_comment', true );
-                echo '<p><label for="tts_instagram_first_comment">' . esc_html__( 'Commento iniziale Instagram', 'trello-social-auto-publisher' ) . '</label>';
+                echo '<p><label for="tts_instagram_first_comment">' . esc_html__( 'Commento iniziale Instagram', 'fp-publisher' ) . '</label>';
                 echo '<textarea id="tts_instagram_first_comment" name="_tts_instagram_first_comment" rows="3" class="widefat">' . esc_textarea( $comment ) . '</textarea></p>';
             }
         }
@@ -395,9 +395,9 @@ class TTS_CPT {
             $lng = $options['default_lng'];
         }
 
-        echo '<p><label for="_tts_lat">' . esc_html__( 'Latitude', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="_tts_lat">' . esc_html__( 'Latitude', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="_tts_lat" name="_tts_lat" value="' . esc_attr( $lat ) . '" class="widefat" /></p>';
-        echo '<p><label for="_tts_lng">' . esc_html__( 'Longitude', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<p><label for="_tts_lng">' . esc_html__( 'Longitude', 'fp-publisher' ) . '</label>';
         echo '<input type="text" id="_tts_lng" name="_tts_lng" value="' . esc_attr( $lng ) . '" class="widefat" /></p>';
     }
 
@@ -567,7 +567,7 @@ class TTS_CPT {
         wp_nonce_field( 'tts_approval_metabox', 'tts_approval_nonce' );
         $approved = (bool) get_post_meta( $post->ID, '_tts_approved', true );
         echo '<label><input type="checkbox" name="_tts_approved" value="1" ' . checked( $approved, true, false ) . ' /> ';
-        echo esc_html__( 'Approvato', 'trello-social-auto-publisher' ) . '</label>';
+        echo esc_html__( 'Approvato', 'fp-publisher' ) . '</label>';
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
@@ -56,7 +56,7 @@ class TTS_Error_Recovery {
     public function add_custom_cron_schedules( $schedules ) {
         $schedules['every_15_minutes'] = array(
             'interval' => 15 * 60,
-            'display' => __( 'Every 15 minutes', 'trello-social-auto-publisher' )
+            'display' => __( 'Every 15 minutes', 'fp-publisher' )
         );
         return $schedules;
     }
@@ -838,7 +838,7 @@ class TTS_Error_Recovery {
         check_ajax_referer( 'tts_error_recovery_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $operation_id = sanitize_text_field( $_POST['operation_id'] ?? '' );
@@ -880,7 +880,7 @@ class TTS_Error_Recovery {
         check_ajax_referer( 'tts_error_recovery_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $days = intval( $_POST['days'] ?? 7 );
@@ -896,13 +896,13 @@ class TTS_Error_Recovery {
         check_ajax_referer( 'tts_error_recovery_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         delete_option( $this->retry_queue_option );
         
         wp_send_json_success( array(
-            'message' => __( 'Retry queue cleared successfully', 'trello-social-auto-publisher' )
+            'message' => __( 'Retry queue cleared successfully', 'fp-publisher' )
         ));
     }
 
@@ -913,7 +913,7 @@ class TTS_Error_Recovery {
         check_ajax_referer( 'tts_error_recovery_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $queue = get_option( $this->retry_queue_option, array() );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-frequency-monitor.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-frequency-monitor.php
@@ -99,7 +99,7 @@ class TTS_Frequency_Monitor {
                         'type' => 'overdue',
                         'channel' => $channel,
                         'message' => sprintf(
-                            __( 'OVERDUE: %1$s needs %2$d more %3$s posts for the current %4$s period (target: %5$d)', 'trello-social-auto-publisher' ),
+                            __( 'OVERDUE: %1$s needs %2$d more %3$s posts for the current %4$s period (target: %5$d)', 'fp-publisher' ),
                             $client_title,
                             $remaining_needed,
                             ucfirst( $channel ),
@@ -113,7 +113,7 @@ class TTS_Frequency_Monitor {
                         'type' => 'upcoming',
                         'channel' => $channel,
                         'message' => sprintf(
-                            __( 'CONTENT NEEDED: %1$s needs %2$d more %3$s posts in the next %4$d days (target: %5$d per %6$s)', 'trello-social-auto-publisher' ),
+                            __( 'CONTENT NEEDED: %1$s needs %2$d more %3$s posts in the next %4$d days (target: %5$d per %6$s)', 'fp-publisher' ),
                             $client_title,
                             $remaining_needed,
                             ucfirst( $channel ),
@@ -294,8 +294,8 @@ class TTS_Frequency_Monitor {
             $notifier->notify_slack( $message );
             
             $subject = $alert['type'] === 'overdue' 
-                ? __( 'Publishing Schedule Overdue', 'trello-social-auto-publisher' )
-                : __( 'Content Needed Soon', 'trello-social-auto-publisher' );
+                ? __( 'Publishing Schedule Overdue', 'fp-publisher' )
+                : __( 'Content Needed Soon', 'fp-publisher' );
                 
             $notifier->notify_email( $subject, $message );
         }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-integration-hub.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-integration-hub.php
@@ -218,18 +218,18 @@ class TTS_Integration_Hub {
         check_ajax_referer( 'tts_integration_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         try {
             wp_send_json_success( array(
                 'integrations' => $this->available_integrations,
                 'connected' => $this->get_connected_integrations(),
-                'message' => __( 'Available integrations retrieved successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Available integrations retrieved successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Get Integrations Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to retrieve integrations. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to retrieve integrations. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -240,7 +240,7 @@ class TTS_Integration_Hub {
         check_ajax_referer( 'tts_integration_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $integration_type = sanitize_text_field( wp_unslash( $_POST['integration_type'] ?? '' ) );
@@ -249,7 +249,7 @@ class TTS_Integration_Hub {
         $settings = array_map( 'sanitize_text_field', wp_unslash( $_POST['settings'] ?? array() ) );
 
         if ( empty( $integration_type ) || empty( $integration_name ) ) {
-            wp_send_json_error( array( 'message' => __( 'Integration type and name are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Integration type and name are required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -257,11 +257,11 @@ class TTS_Integration_Hub {
             
             wp_send_json_success( array(
                 'integration_id' => $integration_id,
-                'message' => __( 'Integration connected successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Integration connected successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Integration Connection Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to connect integration. Please check your credentials and try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to connect integration. Please check your credentials and try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -619,24 +619,24 @@ class TTS_Integration_Hub {
         check_ajax_referer( 'tts_integration_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $integration_id = intval( $_POST['integration_id'] ?? 0 );
 
         if ( empty( $integration_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Integration ID is required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Integration ID is required.', 'fp-publisher' ) ) );
         }
 
         try {
             $this->disconnect_integration( $integration_id );
             
             wp_send_json_success( array(
-                'message' => __( 'Integration disconnected successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Integration disconnected successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Integration Disconnection Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to disconnect integration. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to disconnect integration. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -670,13 +670,13 @@ class TTS_Integration_Hub {
         check_ajax_referer( 'tts_integration_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $integration_id = intval( $_POST['integration_id'] ?? 0 );
 
         if ( empty( $integration_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Integration ID is required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Integration ID is required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -684,11 +684,11 @@ class TTS_Integration_Hub {
             
             wp_send_json_success( array(
                 'test_result' => $test_result,
-                'message' => __( 'Integration tested successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Integration tested successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Integration Test Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to test integration. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to test integration. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -728,14 +728,14 @@ class TTS_Integration_Hub {
         check_ajax_referer( 'tts_integration_nonce', 'nonce' );
 
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $integration_id = intval( $_POST['integration_id'] ?? 0 );
         $data_type = sanitize_text_field( wp_unslash( $_POST['data_type'] ?? 'all' ) );
 
         if ( empty( $integration_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Integration ID is required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Integration ID is required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -743,11 +743,11 @@ class TTS_Integration_Hub {
             
             wp_send_json_success( array(
                 'sync_result' => $sync_result,
-                'message' => __( 'Integration data synced successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Integration data synced successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Integration Sync Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to sync integration data. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to sync integration data. Please try again.', 'fp-publisher' ) ) );
         }
     }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-link-checker.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-link-checker.php
@@ -58,13 +58,13 @@ class TTS_Link_Checker {
                         $post_id,
                         'link_checker',
                         'error',
-                        sprintf( __( 'URL check failed for %s', 'trello-social-auto-publisher' ), $url ),
+                        sprintf( __( 'URL check failed for %s', 'fp-publisher' ), $url ),
                         $error_message
                     );
 
-                    $notify_msg = sprintf( __( 'Invalid URL %1$s in post "%2$s"', 'trello-social-auto-publisher' ), $url, get_the_title( $post_id ) );
+                    $notify_msg = sprintf( __( 'Invalid URL %1$s in post "%2$s"', 'fp-publisher' ), $url, get_the_title( $post_id ) );
                     $notifier->notify_slack( $notify_msg );
-                    $notifier->notify_email( __( 'Invalid URL detected', 'trello-social-auto-publisher' ), $notify_msg );
+                    $notifier->notify_email( __( 'Invalid URL detected', 'fp-publisher' ), $notify_msg );
                 }
             }
         }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-notifier.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-notifier.php
@@ -28,11 +28,11 @@ class TTS_Notifier {
      */
     public static function notify_post_approved( $post_id ) {
         $title   = get_the_title( $post_id );
-        $message = sprintf( __( 'Post "%s" approvato', 'trello-social-auto-publisher' ), $title );
+        $message = sprintf( __( 'Post "%s" approvato', 'fp-publisher' ), $title );
 
         $notifier = new self();
         $notifier->notify_slack( $message );
-        $notifier->notify_email( __( 'Post approvato', 'trello-social-auto-publisher' ), $message );
+        $notifier->notify_email( __( 'Post approvato', 'fp-publisher' ), $message );
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rate-limiter.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rate-limiter.php
@@ -465,7 +465,7 @@ class TTS_Rate_Limiter {
         check_ajax_referer( 'tts_rate_limit_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $platforms = array( 'facebook', 'instagram', 'youtube', 'tiktok' );
@@ -485,7 +485,7 @@ class TTS_Rate_Limiter {
         check_ajax_referer( 'tts_rate_limit_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $platform = sanitize_text_field( $_POST['platform'] ?? '' );
@@ -516,7 +516,7 @@ class TTS_Rate_Limiter {
         
         return array(
             'success' => true,
-            'message' => sprintf( __( 'Rate limits reset for %s', 'trello-social-auto-publisher' ), $platform )
+            'message' => sprintf( __( 'Rate limits reset for %s', 'fp-publisher' ), $platform )
         );
     }
 
@@ -527,7 +527,7 @@ class TTS_Rate_Limiter {
         check_ajax_referer( 'tts_rate_limit_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $analytics = $this->get_rate_limit_analytics();

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
@@ -87,7 +87,7 @@ class TTS_REST {
         $id   = intval( $request['id'] );
         $post = get_post( $id );
         if ( ! $post ) {
-            return new WP_Error( 'invalid_post', __( 'Invalid post ID.', 'trello-social-auto-publisher' ), array( 'status' => 404 ) );
+            return new WP_Error( 'invalid_post', __( 'Invalid post ID.', 'fp-publisher' ), array( 'status' => 404 ) );
         }
 
         $post_status      = get_post_status( $id );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -138,11 +138,11 @@ class TTS_Scheduler {
 
         $client_id = intval( get_post_meta( $post_id, '_tts_client_id', true ) );
         if ( ! $client_id ) {
-            tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing client ID', 'trello-social-auto-publisher' ), '' );
+            tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing client ID', 'fp-publisher' ), '' );
             return;
         }
 
-        tts_log_event( $post_id, 'scheduler', 'start', __( 'Publishing social post', 'trello-social-auto-publisher' ), '' );
+        tts_log_event( $post_id, 'scheduler', 'start', __( 'Publishing social post', 'fp-publisher' ), '' );
 
         $tokens = array(
             'facebook'  => get_post_meta( $client_id, '_tts_fb_token', true ),
@@ -200,7 +200,7 @@ class TTS_Scheduler {
         }
 
         if ( empty( $channels ) ) {
-            tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing social channel', 'trello-social-auto-publisher' ), '' );
+            tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing social channel', 'fp-publisher' ), '' );
             return;
         }
 
@@ -301,18 +301,18 @@ class TTS_Scheduler {
                     }
                 }
             } else {
-                tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing Story media', 'trello-social-auto-publisher' ), '' );
+                tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing Story media', 'fp-publisher' ), '' );
                 $error = true;
             }
         }
 
         if ( $error ) {
             if ( $attempt >= $max_attempts ) {
-                tts_log_event( $post_id, 'scheduler', 'error', __( 'Maximum retry attempts reached', 'trello-social-auto-publisher' ), '' );
+                tts_log_event( $post_id, 'scheduler', 'error', __( 'Maximum retry attempts reached', 'fp-publisher' ), '' );
                 $log_url = admin_url( 'admin.php?page=fp-publisher-log&post_id=' . $post_id );
-                $message = sprintf( __( 'Publishing failed for post %1$s. Log: %2$s', 'trello-social-auto-publisher' ), get_the_title( $post_id ), $log_url );
+                $message = sprintf( __( 'Publishing failed for post %1$s. Log: %2$s', 'fp-publisher' ), get_the_title( $post_id ), $log_url );
                 $notifier->notify_slack( $message );
-                $notifier->notify_email( __( 'Social publishing failed', 'trello-social-auto-publisher' ), $message );
+                $notifier->notify_email( __( 'Social publishing failed', 'fp-publisher' ), $message );
                 return;
             }
 
@@ -323,7 +323,7 @@ class TTS_Scheduler {
             $timestamp = time() + $delay * MINUTE_IN_SECONDS;
             as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( $post_id ) );
 
-            tts_log_event( $post_id, 'scheduler', 'retry', sprintf( __( 'Retry #%1$d scheduled in %2$d minutes', 'trello-social-auto-publisher' ), $attempt, $delay ), '' );
+            tts_log_event( $post_id, 'scheduler', 'retry', sprintf( __( 'Retry #%1$d scheduled in %2$d minutes', 'fp-publisher' ), $attempt, $delay ), '' );
             return;
         }
 
@@ -410,12 +410,12 @@ class TTS_Scheduler {
             }
         }
 
-        tts_log_event( $post_id, 'scheduler', 'complete', __( 'Publish process completed', 'trello-social-auto-publisher' ), $log );
+        tts_log_event( $post_id, 'scheduler', 'complete', __( 'Publish process completed', 'fp-publisher' ), $log );
 
         $log_url = admin_url( 'admin.php?page=fp-publisher-log&post_id=' . $post_id );
-        $message = sprintf( __( 'Publishing completed for post %1$s. Log: %2$s', 'trello-social-auto-publisher' ), get_the_title( $post_id ), $log_url );
+        $message = sprintf( __( 'Publishing completed for post %1$s. Log: %2$s', 'fp-publisher' ), get_the_title( $post_id ), $log_url );
         $notifier->notify_slack( $message );
-        $notifier->notify_email( __( 'Social publishing completed', 'trello-social-auto-publisher' ), $message );
+        $notifier->notify_email( __( 'Social publishing completed', 'fp-publisher' ), $message );
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-security-audit.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-security-audit.php
@@ -631,7 +631,7 @@ class TTS_Security_Audit {
         check_ajax_referer( 'tts_security_audit_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $page = max( 1, intval( $_POST['page'] ?? 1 ) );
@@ -665,7 +665,7 @@ class TTS_Security_Audit {
         check_ajax_referer( 'tts_security_audit_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         $days = max( 1, min( 90, intval( $_POST['days'] ?? 7 ) ) );
@@ -681,7 +681,7 @@ class TTS_Security_Audit {
         check_ajax_referer( 'tts_security_audit_nonce', 'nonce' );
         
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
         global $wpdb;
@@ -698,7 +698,7 @@ class TTS_Security_Audit {
         );
         
         wp_send_json_success( array(
-            'message' => sprintf( __( 'Deleted %d old audit log entries', 'trello-social-auto-publisher' ), $deleted ),
+            'message' => sprintf( __( 'Deleted %d old audit log entries', 'fp-publisher' ), $deleted ),
             'deleted_count' => $deleted
         ));
     }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -47,14 +47,14 @@ class TTS_Settings {
         // Trello API credentials.
         add_settings_section(
             'tts_trello_api',
-            __( 'Trello API Credentials', 'trello-social-auto-publisher' ),
+            __( 'Trello API Credentials', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
 
         add_settings_field(
             'trello_api_key',
-            __( 'API Key', 'trello-social-auto-publisher' ),
+            __( 'API Key', 'fp-publisher' ),
             array( $this, 'render_trello_api_key_field' ),
             'tts_settings',
             'tts_trello_api'
@@ -62,7 +62,7 @@ class TTS_Settings {
 
         add_settings_field(
             'trello_api_token',
-            __( 'API Token', 'trello-social-auto-publisher' ),
+            __( 'API Token', 'fp-publisher' ),
             array( $this, 'render_trello_api_token_field' ),
             'tts_settings',
             'tts_trello_api'
@@ -71,14 +71,14 @@ class TTS_Settings {
         // Column mapping.
         add_settings_section(
             'tts_column_mapping',
-            __( 'Trello Column Mapping', 'trello-social-auto-publisher' ),
+            __( 'Trello Column Mapping', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
 
         add_settings_field(
             'column_mapping',
-            __( 'Column Mapping (JSON)', 'trello-social-auto-publisher' ),
+            __( 'Column Mapping (JSON)', 'fp-publisher' ),
             array( $this, 'render_column_mapping_field' ),
             'tts_settings',
             'tts_column_mapping'
@@ -87,14 +87,14 @@ class TTS_Settings {
         // Social access token.
         add_settings_section(
             'tts_social_token',
-            __( 'Social Access Token', 'trello-social-auto-publisher' ),
+            __( 'Social Access Token', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
 
         add_settings_field(
             'social_access_token',
-            __( 'Access Token', 'trello-social-auto-publisher' ),
+            __( 'Access Token', 'fp-publisher' ),
             array( $this, 'render_social_access_token_field' ),
             'tts_settings',
             'tts_social_token'
@@ -103,7 +103,7 @@ class TTS_Settings {
         // Scheduling options.
         add_settings_section(
             'tts_scheduling_options',
-            __( 'Scheduling Options', 'trello-social-auto-publisher' ),
+            __( 'Scheduling Options', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
@@ -111,7 +111,7 @@ class TTS_Settings {
         foreach ( $channels as $channel ) {
             add_settings_field(
                 $channel . '_offset',
-                sprintf( __( '%s Offset (minutes)', 'trello-social-auto-publisher' ), ucfirst( $channel ) ),
+                sprintf( __( '%s Offset (minutes)', 'fp-publisher' ), ucfirst( $channel ) ),
                 array( $this, 'render_offset_field' ),
                 'tts_settings',
                 'tts_scheduling_options',
@@ -124,14 +124,14 @@ class TTS_Settings {
         // Default location options.
         add_settings_section(
             'tts_location_options',
-            __( 'Default Location', 'trello-social-auto-publisher' ),
+            __( 'Default Location', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
 
         add_settings_field(
             'default_lat',
-            __( 'Default Latitude', 'trello-social-auto-publisher' ),
+            __( 'Default Latitude', 'fp-publisher' ),
             array( $this, 'render_default_lat_field' ),
             'tts_settings',
             'tts_location_options'
@@ -139,7 +139,7 @@ class TTS_Settings {
 
         add_settings_field(
             'default_lng',
-            __( 'Default Longitude', 'trello-social-auto-publisher' ),
+            __( 'Default Longitude', 'fp-publisher' ),
             array( $this, 'render_default_lng_field' ),
             'tts_settings',
             'tts_location_options'
@@ -148,7 +148,7 @@ class TTS_Settings {
         // Image size options.
         add_settings_section(
             'tts_image_sizes',
-            __( 'Image Sizes', 'trello-social-auto-publisher' ),
+            __( 'Image Sizes', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
@@ -156,7 +156,7 @@ class TTS_Settings {
         foreach ( $channels as $channel ) {
             add_settings_field(
                 $channel . '_size',
-                sprintf( __( '%s Size (WxH)', 'trello-social-auto-publisher' ), ucfirst( $channel ) ),
+                sprintf( __( '%s Size (WxH)', 'fp-publisher' ), ucfirst( $channel ) ),
                 array( $this, 'render_image_size_field' ),
                 'tts_settings',
                 'tts_image_sizes',
@@ -169,7 +169,7 @@ class TTS_Settings {
         // UTM options.
         add_settings_section(
             'tts_utm_options',
-            __( 'UTM Options', 'trello-social-auto-publisher' ),
+            __( 'UTM Options', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
@@ -179,7 +179,7 @@ class TTS_Settings {
             foreach ( $params as $param ) {
                 add_settings_field(
                     $channel . '_' . $param,
-                    sprintf( __( '%s UTM %s', 'trello-social-auto-publisher' ), ucfirst( $channel ), ucfirst( str_replace( 'utm_', '', $param ) ) ),
+                    sprintf( __( '%s UTM %s', 'fp-publisher' ), ucfirst( $channel ), ucfirst( str_replace( 'utm_', '', $param ) ) ),
                     array( $this, 'render_utm_field' ),
                     'tts_settings',
                     'tts_utm_options',
@@ -194,14 +194,14 @@ class TTS_Settings {
         // Template options.
         add_settings_section(
             'tts_template_options',
-            __( 'Template Options', 'trello-social-auto-publisher' ),
+            __( 'Template Options', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
 
         add_settings_field(
             'facebook_template',
-            __( 'Facebook Template', 'trello-social-auto-publisher' ),
+            __( 'Facebook Template', 'fp-publisher' ),
             array( $this, 'render_facebook_template_field' ),
             'tts_settings',
             'tts_template_options'
@@ -209,7 +209,7 @@ class TTS_Settings {
 
         add_settings_field(
             'instagram_template',
-            __( 'Instagram Template', 'trello-social-auto-publisher' ),
+            __( 'Instagram Template', 'fp-publisher' ),
             array( $this, 'render_instagram_template_field' ),
             'tts_settings',
             'tts_template_options'
@@ -217,7 +217,7 @@ class TTS_Settings {
 
         add_settings_field(
             'youtube_template',
-            __( 'YouTube Template', 'trello-social-auto-publisher' ),
+            __( 'YouTube Template', 'fp-publisher' ),
             array( $this, 'render_youtube_template_field' ),
             'tts_settings',
             'tts_template_options'
@@ -225,7 +225,7 @@ class TTS_Settings {
 
         add_settings_field(
             'tiktok_template',
-            __( 'TikTok Template', 'trello-social-auto-publisher' ),
+            __( 'TikTok Template', 'fp-publisher' ),
             array( $this, 'render_tiktok_template_field' ),
             'tts_settings',
             'tts_template_options'
@@ -233,7 +233,7 @@ class TTS_Settings {
 
         add_settings_field(
             'labels_as_hashtags',
-            __( 'Labels as Hashtags', 'trello-social-auto-publisher' ),
+            __( 'Labels as Hashtags', 'fp-publisher' ),
             array( $this, 'render_labels_as_hashtags_field' ),
             'tts_settings',
             'tts_template_options'
@@ -242,14 +242,14 @@ class TTS_Settings {
         // URL shortener options.
         add_settings_section(
             'tts_url_shortener',
-            __( 'URL Shortener', 'trello-social-auto-publisher' ),
+            __( 'URL Shortener', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
 
         add_settings_field(
             'url_shortener',
-            __( 'URL Shortener', 'trello-social-auto-publisher' ),
+            __( 'URL Shortener', 'fp-publisher' ),
             array( $this, 'render_url_shortener_field' ),
             'tts_settings',
             'tts_url_shortener'
@@ -257,7 +257,7 @@ class TTS_Settings {
 
         add_settings_field(
             'bitly_token',
-            __( 'Bitly Token', 'trello-social-auto-publisher' ),
+            __( 'Bitly Token', 'fp-publisher' ),
             array( $this, 'render_bitly_token_field' ),
             'tts_settings',
             'tts_url_shortener'
@@ -266,14 +266,14 @@ class TTS_Settings {
         // Notification options.
         add_settings_section(
             'tts_notification_options',
-            __( 'Notification Options', 'trello-social-auto-publisher' ),
+            __( 'Notification Options', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
 
         add_settings_field(
             'slack_webhook',
-            __( 'Slack Webhook', 'trello-social-auto-publisher' ),
+            __( 'Slack Webhook', 'fp-publisher' ),
             array( $this, 'render_slack_webhook_field' ),
             'tts_settings',
             'tts_notification_options'
@@ -281,7 +281,7 @@ class TTS_Settings {
 
         add_settings_field(
             'notification_emails',
-            __( 'Notification Emails', 'trello-social-auto-publisher' ),
+            __( 'Notification Emails', 'fp-publisher' ),
             array( $this, 'render_notification_emails_field' ),
             'tts_settings',
             'tts_notification_options'
@@ -290,14 +290,14 @@ class TTS_Settings {
         // Logging options.
         add_settings_section(
             'tts_logging_options',
-            __( 'Logging Options', 'trello-social-auto-publisher' ),
+            __( 'Logging Options', 'fp-publisher' ),
             '__return_false',
             'tts_settings'
         );
 
         add_settings_field(
             'log_retention_days',
-            __( 'Log Retention (days)', 'trello-social-auto-publisher' ),
+            __( 'Log Retention (days)', 'fp-publisher' ),
             array( $this, 'render_log_retention_days_field' ),
             'tts_settings',
             'tts_logging_options'
@@ -310,7 +310,7 @@ class TTS_Settings {
     public function render_settings_page() {
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e( 'Trello Social Settings', 'trello-social-auto-publisher' ); ?></h1>
+            <h1><?php esc_html_e( 'Trello Social Settings', 'fp-publisher' ); ?></h1>
             <form action="options.php" method="post">
                 <?php
                 settings_fields( 'tts_settings_group' );
@@ -428,7 +428,7 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['facebook_template'] ) ? esc_attr( $options['facebook_template'] ) : '';
         echo '<input type="text" name="tts_settings[facebook_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url} {due}" />';
-        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'fp-publisher' ) . '</p>';
     }
 
     /**
@@ -438,7 +438,7 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['instagram_template'] ) ? esc_attr( $options['instagram_template'] ) : '';
         echo '<input type="text" name="tts_settings[instagram_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url} {due}" />';
-        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'fp-publisher' ) . '</p>';
     }
 
     /**
@@ -448,7 +448,7 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['youtube_template'] ) ? esc_attr( $options['youtube_template'] ) : '';
         echo '<input type="text" name="tts_settings[youtube_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url} {due}" />';
-        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'fp-publisher' ) . '</p>';
     }
 
     /**
@@ -458,7 +458,7 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['tiktok_template'] ) ? esc_attr( $options['tiktok_template'] ) : '';
         echo '<input type="text" name="tts_settings[tiktok_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url} {due}" />';
-        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'fp-publisher' ) . '</p>';
     }
 
     /**
@@ -467,7 +467,7 @@ class TTS_Settings {
     public function render_labels_as_hashtags_field() {
         $options = get_option( 'tts_settings', array() );
         $checked = ! empty( $options['labels_as_hashtags'] );
-        echo '<label><input type="checkbox" name="tts_settings[labels_as_hashtags]" value="1"' . checked( $checked, true, false ) . ' /> ' . esc_html__( 'Append Trello labels as hashtags', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<label><input type="checkbox" name="tts_settings[labels_as_hashtags]" value="1"' . checked( $checked, true, false ) . ' /> ' . esc_html__( 'Append Trello labels as hashtags', 'fp-publisher' ) . '</label>';
     }
 
     /**
@@ -478,9 +478,9 @@ class TTS_Settings {
         $value   = isset( $options['url_shortener'] ) ? $options['url_shortener'] : 'none';
 
         $choices = array(
-            'none'  => __( 'None', 'trello-social-auto-publisher' ),
-            'wp'    => __( 'WordPress', 'trello-social-auto-publisher' ),
-            'bitly' => __( 'Bitly', 'trello-social-auto-publisher' ),
+            'none'  => __( 'None', 'fp-publisher' ),
+            'wp'    => __( 'WordPress', 'fp-publisher' ),
+            'bitly' => __( 'Bitly', 'fp-publisher' ),
         );
 
         echo '<select name="tts_settings[url_shortener]">';
@@ -497,7 +497,7 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['bitly_token'] ) ? esc_attr( $options['bitly_token'] ) : '';
         echo '<input type="text" name="tts_settings[bitly_token]" value="' . $value . '" class="regular-text" />';
-        echo '<p class="description">' . esc_html__( 'Required for Bitly shortening.', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<p class="description">' . esc_html__( 'Required for Bitly shortening.', 'fp-publisher' ) . '</p>';
     }
 
     /**
@@ -516,7 +516,7 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['notification_emails'] ) ? esc_attr( $options['notification_emails'] ) : '';
         echo '<input type="text" name="tts_settings[notification_emails]" value="' . $value . '" class="regular-text" />';
-        echo '<p class="description">' . esc_html__( 'Comma-separated list of email addresses.', 'trello-social-auto-publisher' ) . '</p>';
+        echo '<p class="description">' . esc_html__( 'Comma-separated list of email addresses.', 'fp-publisher' ) . '</p>';
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-token-refresh.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-token-refresh.php
@@ -71,7 +71,7 @@ class TTS_Token_Refresh {
                 $app_secret = isset( $channel_config['app_secret'] ) ? $channel_config['app_secret'] : '';
 
                 if ( empty( $app_id ) || empty( $app_secret ) ) {
-                    $error_message = __( 'Facebook app credentials are missing; cannot refresh token.', 'trello-social-auto-publisher' );
+                    $error_message = __( 'Facebook app credentials are missing; cannot refresh token.', 'fp-publisher' );
                     $error_data    = array(
                         'client_id'       => $client_id,
                         'missing_app_id'  => empty( $app_id ),
@@ -122,7 +122,7 @@ class TTS_Token_Refresh {
             $response = wp_remote_get( $url );
             if ( is_wp_error( $response ) ) {
                 $message = sprintf(
-                    __( '%1$s token refresh request failed: %2$s', 'trello-social-auto-publisher' ),
+                    __( '%1$s token refresh request failed: %2$s', 'fp-publisher' ),
                     ucfirst( $channel ),
                     $response->get_error_message()
                 );
@@ -149,7 +149,7 @@ class TTS_Token_Refresh {
                 $error = new WP_Error(
                     'tts_' . $channel . '_http_status_error',
                     sprintf(
-                        __( '%1$s token refresh returned unexpected HTTP status: %2$d.', 'trello-social-auto-publisher' ),
+                        __( '%1$s token refresh returned unexpected HTTP status: %2$d.', 'fp-publisher' ),
                         ucfirst( $channel ),
                         $response_code
                     ),
@@ -169,7 +169,7 @@ class TTS_Token_Refresh {
             if ( null === $body && JSON_ERROR_NONE !== json_last_error() ) {
                 $error = new WP_Error(
                     'tts_' . $channel . '_invalid_response',
-                    sprintf( __( '%s token refresh returned an invalid response.', 'trello-social-auto-publisher' ), ucfirst( $channel ) ),
+                    sprintf( __( '%s token refresh returned an invalid response.', 'fp-publisher' ), ucfirst( $channel ) ),
                     array(
                         'client_id' => $client_id,
                         'body'      => $body_raw,
@@ -185,7 +185,7 @@ class TTS_Token_Refresh {
             if ( ! is_array( $body ) ) {
                 $error = new WP_Error(
                     'tts_' . $channel . '_unexpected_response_format',
-                    sprintf( __( '%s token refresh response could not be parsed.', 'trello-social-auto-publisher' ), ucfirst( $channel ) ),
+                    sprintf( __( '%s token refresh response could not be parsed.', 'fp-publisher' ), ucfirst( $channel ) ),
                     array(
                         'client_id' => $client_id,
                         'body'      => $body_raw,
@@ -202,7 +202,7 @@ class TTS_Token_Refresh {
                 $error_details = is_scalar( $body['error'] ) ? $body['error'] : wp_json_encode( $body['error'] );
                 $error         = new WP_Error(
                     'tts_' . $channel . '_api_error',
-                    sprintf( __( '%1$s token refresh error: %2$s', 'trello-social-auto-publisher' ), ucfirst( $channel ), $error_details ),
+                    sprintf( __( '%1$s token refresh error: %2$s', 'fp-publisher' ), ucfirst( $channel ), $error_details ),
                     array(
                         'client_id' => $client_id,
                         'response'  => $body,
@@ -218,7 +218,7 @@ class TTS_Token_Refresh {
             if ( empty( $body['access_token'] ) ) {
                 $error = new WP_Error(
                     'tts_' . $channel . '_missing_access_token',
-                    sprintf( __( '%s token refresh response did not include a new access token.', 'trello-social-auto-publisher' ), ucfirst( $channel ) ),
+                    sprintf( __( '%s token refresh response did not include a new access token.', 'fp-publisher' ), ucfirst( $channel ) ),
                     array(
                         'client_id' => $client_id,
                         'response'  => $body,
@@ -244,7 +244,7 @@ class TTS_Token_Refresh {
         if ( ! empty( $errors ) ) {
             return new WP_Error(
                 'tts_token_refresh_failed',
-                __( 'One or more token refresh operations failed.', 'trello-social-auto-publisher' ),
+                __( 'One or more token refresh operations failed.', 'fp-publisher' ),
                 $errors
             );
         }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-validation.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-validation.php
@@ -30,17 +30,17 @@ class TTS_Validation {
      */
     public static function validate_trello_credentials( $key, $token ) {
         if ( empty( $key ) || empty( $token ) ) {
-            self::add_error( __( 'Trello API key and token are required.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'Trello API key and token are required.', 'fp-publisher' ) );
             return false;
         }
         
         if ( strlen( $key ) !== 32 ) {
-            self::add_error( __( 'Invalid Trello API key format.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'Invalid Trello API key format.', 'fp-publisher' ) );
             return false;
         }
         
         if ( strlen( $token ) !== 64 ) {
-            self::add_error( __( 'Invalid Trello token format.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'Invalid Trello token format.', 'fp-publisher' ) );
             return false;
         }
         
@@ -55,14 +55,14 @@ class TTS_Validation {
      */
     public static function validate_social_channels( $channels ) {
         if ( empty( $channels ) || ! is_array( $channels ) ) {
-            self::add_error( __( 'At least one social media channel must be selected.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'At least one social media channel must be selected.', 'fp-publisher' ) );
             return false;
         }
         
         $allowed_channels = array( 'facebook', 'instagram', 'youtube', 'tiktok' );
         foreach ( $channels as $channel ) {
             if ( ! in_array( $channel, $allowed_channels, true ) ) {
-                self::add_error( sprintf( __( 'Invalid social media channel: %s', 'trello-social-auto-publisher' ), esc_html( $channel ) ) );
+                self::add_error( sprintf( __( 'Invalid social media channel: %s', 'fp-publisher' ), esc_html( $channel ) ) );
                 return false;
             }
         }
@@ -83,19 +83,19 @@ class TTS_Validation {
         
         $timestamp = strtotime( $datetime );
         if ( false === $timestamp ) {
-            self::add_error( __( 'Invalid date and time format.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'Invalid date and time format.', 'fp-publisher' ) );
             return false;
         }
         
         // Check if the date is in the past
         if ( $timestamp < current_time( 'timestamp' ) ) {
-            self::add_error( __( 'Publish date cannot be in the past.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'Publish date cannot be in the past.', 'fp-publisher' ) );
             return false;
         }
         
         // Check if the date is too far in the future (max 1 year)
         if ( $timestamp > current_time( 'timestamp' ) + YEAR_IN_SECONDS ) {
-            self::add_error( __( 'Publish date cannot be more than 1 year in the future.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'Publish date cannot be more than 1 year in the future.', 'fp-publisher' ) );
             return false;
         }
         
@@ -156,7 +156,7 @@ class TTS_Validation {
      */
     public static function validate_media_upload( $file ) {
         if ( empty( $file['tmp_name'] ) ) {
-            self::add_error( __( 'No file uploaded.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'No file uploaded.', 'fp-publisher' ) );
             return false;
         }
         
@@ -164,14 +164,14 @@ class TTS_Validation {
         $file_type = wp_check_filetype( $file['name'] );
         
         if ( ! in_array( $file_type['type'], $allowed_types, true ) ) {
-            self::add_error( __( 'Unsupported file type. Please upload JPG, PNG, GIF, MP4, or AVI files.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'Unsupported file type. Please upload JPG, PNG, GIF, MP4, or AVI files.', 'fp-publisher' ) );
             return false;
         }
         
         // Check file size (max 100MB)
         $max_size = 100 * 1024 * 1024; // 100MB
         if ( $file['size'] > $max_size ) {
-            self::add_error( __( 'File size too large. Maximum allowed size is 100MB.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'File size too large. Maximum allowed size is 100MB.', 'fp-publisher' ) );
             return false;
         }
         
@@ -221,25 +221,25 @@ class TTS_Validation {
         $allowed_actions = array( 'approve', 'delete', 'schedule' );
         
         if ( ! in_array( $action, $allowed_actions, true ) ) {
-            self::add_error( __( 'Invalid bulk action specified.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'Invalid bulk action specified.', 'fp-publisher' ) );
             return false;
         }
         
         if ( empty( $post_ids ) || ! is_array( $post_ids ) ) {
-            self::add_error( __( 'No posts selected for bulk action.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'No posts selected for bulk action.', 'fp-publisher' ) );
             return false;
         }
         
         // Limit bulk actions to prevent performance issues
         if ( count( $post_ids ) > 100 ) {
-            self::add_error( __( 'Too many posts selected. Maximum 100 posts allowed for bulk actions.', 'trello-social-auto-publisher' ) );
+            self::add_error( __( 'Too many posts selected. Maximum 100 posts allowed for bulk actions.', 'fp-publisher' ) );
             return false;
         }
         
         // Validate all post IDs are numeric
         foreach ( $post_ids as $post_id ) {
             if ( ! is_numeric( $post_id ) || $post_id <= 0 ) {
-                self::add_error( __( 'Invalid post ID in selection.', 'trello-social-auto-publisher' ) );
+                self::add_error( __( 'Invalid post ID in selection.', 'fp-publisher' ) );
                 return false;
             }
         }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
@@ -43,7 +43,7 @@ class TTS_Webhook {
         );
 
         if ( empty( $clients ) ) {
-            $cached_result = new WP_Error( 'tts_webhook_no_clients', __( 'Nessun client Trello configurato.', 'trello-social-auto-publisher' ) );
+            $cached_result = new WP_Error( 'tts_webhook_no_clients', __( 'Nessun client Trello configurato.', 'fp-publisher' ) );
             return $cached_result;
         }
 
@@ -52,7 +52,7 @@ class TTS_Webhook {
         foreach ( $clients as $client_id ) {
             $title = get_the_title( $client_id );
             if ( '' === $title ) {
-                $title = sprintf( __( 'Client #%d', 'trello-social-auto-publisher' ), (int) $client_id );
+                $title = sprintf( __( 'Client #%d', 'fp-publisher' ), (int) $client_id );
             }
 
             $key   = trim( (string) get_post_meta( $client_id, '_tts_trello_key', true ) );
@@ -61,7 +61,7 @@ class TTS_Webhook {
             if ( empty( $key ) || empty( $token ) ) {
                 $errors[] = sprintf(
                     /* translators: %s: client name. */
-                    __( '%s: credenziali Trello mancanti.', 'trello-social-auto-publisher' ),
+                    __( '%s: credenziali Trello mancanti.', 'fp-publisher' ),
                     $title
                 );
                 continue;
@@ -85,7 +85,7 @@ class TTS_Webhook {
             if ( is_wp_error( $response ) ) {
                 $errors[] = sprintf(
                     /* translators: 1: client name. 2: error message. */
-                    __( '%1$s: %2$s', 'trello-social-auto-publisher' ),
+                    __( '%1$s: %2$s', 'fp-publisher' ),
                     $title,
                     $response->get_error_message()
                 );
@@ -124,11 +124,11 @@ class TTS_Webhook {
 
             if ( empty( $body_message ) ) {
                 if ( 429 === $code ) {
-                    $body_message = __( 'Limite di richieste Trello raggiunto. Riprovare più tardi.', 'trello-social-auto-publisher' );
+                    $body_message = __( 'Limite di richieste Trello raggiunto. Riprovare più tardi.', 'fp-publisher' );
                 } elseif ( 401 === $code || 403 === $code ) {
-                    $body_message = __( 'Credenziali Trello non valide o insufficienti.', 'trello-social-auto-publisher' );
+                    $body_message = __( 'Credenziali Trello non valide o insufficienti.', 'fp-publisher' );
                 } else {
-                    $body_message = __( 'Risposta inattesa dal servizio Trello.', 'trello-social-auto-publisher' );
+                    $body_message = __( 'Risposta inattesa dal servizio Trello.', 'fp-publisher' );
                 }
             }
 
@@ -142,7 +142,7 @@ class TTS_Webhook {
 
             $errors[] = sprintf(
                 /* translators: 1: client name. 2: error message. 3: HTTP status code. */
-                __( '%1$s: %2$s (HTTP %3$d)', 'trello-social-auto-publisher' ),
+                __( '%1$s: %2$s (HTTP %3$d)', 'fp-publisher' ),
                 $title,
                 $body_message,
                 $code
@@ -150,7 +150,7 @@ class TTS_Webhook {
         }
 
         if ( empty( $errors ) ) {
-            $errors[] = __( 'Impossibile verificare la connessione al webhook Trello.', 'trello-social-auto-publisher' );
+            $errors[] = __( 'Impossibile verificare la connessione al webhook Trello.', 'fp-publisher' );
         }
 
         $cached_result = new WP_Error( 'tts_webhook_connection_failed', implode( ' ', array_unique( $errors ) ) );
@@ -276,7 +276,7 @@ class TTS_Webhook {
         }
 
         if ( ! $client_id ) {
-            return new WP_Error( 'client_not_found', __( 'Client not found.', 'trello-social-auto-publisher' ), array( 'status' => 404 ) );
+            return new WP_Error( 'client_not_found', __( 'Client not found.', 'fp-publisher' ), array( 'status' => 404 ) );
         }
 
         // Load Trello credentials for the resolved client.
@@ -285,7 +285,7 @@ class TTS_Webhook {
 
         $provided_token = $request->get_param( 'token' );
         if ( empty( $client_token ) || $provided_token !== $client_token ) {
-            return new WP_Error( 'invalid_token', __( 'Invalid token.', 'trello-social-auto-publisher' ), array( 'status' => 403 ) );
+            return new WP_Error( 'invalid_token', __( 'Invalid token.', 'fp-publisher' ), array( 'status' => 403 ) );
         }
 
         $signature_header = $request->get_header( 'x-trello-webhook' );
@@ -293,28 +293,28 @@ class TTS_Webhook {
         $content          = $request->get_body();
 
         if ( empty( $client_secret ) ) {
-            return new WP_Error( 'missing_secret', __( 'Client secret not configured.', 'trello-social-auto-publisher' ), array( 'status' => 403 ) );
+            return new WP_Error( 'missing_secret', __( 'Client secret not configured.', 'fp-publisher' ), array( 'status' => 403 ) );
         }
 
         if ( $signature_header ) {
             $callback_url = rest_url( 'tts/v1/trello-webhook' );
             $expected     = base64_encode( hash_hmac( 'sha1', $content . $callback_url, $client_secret, true ) );
             if ( ! hash_equals( $signature_header, $expected ) ) {
-                return new WP_Error( 'invalid_signature', __( 'Invalid signature.', 'trello-social-auto-publisher' ), array( 'status' => 403 ) );
+                return new WP_Error( 'invalid_signature', __( 'Invalid signature.', 'fp-publisher' ), array( 'status' => 403 ) );
             }
         } elseif ( $hmac_param ) {
             $expected = hash_hmac( 'sha256', $content, $client_secret );
             if ( ! hash_equals( $hmac_param, $expected ) ) {
-                return new WP_Error( 'invalid_signature', __( 'Invalid signature.', 'trello-social-auto-publisher' ), array( 'status' => 403 ) );
+                return new WP_Error( 'invalid_signature', __( 'Invalid signature.', 'fp-publisher' ), array( 'status' => 403 ) );
             }
         } else {
-            return new WP_Error( 'invalid_signature', __( 'Missing signature.', 'trello-social-auto-publisher' ), array( 'status' => 403 ) );
+            return new WP_Error( 'invalid_signature', __( 'Missing signature.', 'fp-publisher' ), array( 'status' => 403 ) );
         }
 
         $mapping_json = get_post_meta( $client_id, '_tts_column_mapping', true );
         $mapping = ! empty( $mapping_json ) ? json_decode( $mapping_json, true ) : array();
         if ( empty( $result['idList'] ) || ! is_array( $mapping ) || ! array_key_exists( $result['idList'], $mapping ) ) {
-            return rest_ensure_response( array( 'message' => __( 'Unmapped list.', 'trello-social-auto-publisher' ) ) );
+            return rest_ensure_response( array( 'message' => __( 'Unmapped list.', 'fp-publisher' ) ) );
         }
         $existing_post = get_posts(
             array(
@@ -333,7 +333,7 @@ class TTS_Webhook {
 
         if ( ! empty( $existing_post ) ) {
             tts_log_event( $existing_post[0], 'webhook', 'skip', 'Trello card already processed', '' );
-            return rest_ensure_response( array( 'message' => __( 'Card already processed.', 'trello-social-auto-publisher' ) ) );
+            return rest_ensure_response( array( 'message' => __( 'Card already processed.', 'fp-publisher' ) ) );
         }
 
         $post_id = wp_insert_post(
@@ -377,9 +377,9 @@ class TTS_Webhook {
                     }
 
                     update_post_meta( $post_id, '_tts_manual_media', (int) $media_id );
-                    tts_log_event( $post_id, 'webhook', 'success', __( 'Manual media imported', 'trello-social-auto-publisher' ), $manual_url );
+                    tts_log_event( $post_id, 'webhook', 'success', __( 'Manual media imported', 'fp-publisher' ), $manual_url );
                 } else {
-                    tts_log_event( $post_id, 'webhook', 'warning', __( 'No attachments provided', 'trello-social-auto-publisher' ), '' );
+                    tts_log_event( $post_id, 'webhook', 'warning', __( 'No attachments provided', 'fp-publisher' ), '' );
                     return rest_ensure_response( $result );
                 }
             }
@@ -394,7 +394,7 @@ class TTS_Webhook {
                         $post_id,
                         'webhook',
                         'scheduled',
-                        sprintf( __( 'Publish scheduled for %s', 'trello-social-auto-publisher' ), $publish_at ),
+                        sprintf( __( 'Publish scheduled for %s', 'fp-publisher' ), $publish_at ),
                         ''
                     );
                 }
@@ -418,13 +418,13 @@ class TTS_Webhook {
                         )
                     );
                     if ( is_wp_error( $response ) ) {
-                        tts_log_event( $post_id, 'webhook', 'error', __( 'Failed to retrieve attachment.', 'trello-social-auto-publisher' ), $attachment['url'] );
+                        tts_log_event( $post_id, 'webhook', 'error', __( 'Failed to retrieve attachment.', 'fp-publisher' ), $attachment['url'] );
                         continue;
                     }
 
                     $code = wp_remote_retrieve_response_code( $response );
                     if ( 200 !== (int) $code ) {
-                        tts_log_event( $post_id, 'webhook', 'error', sprintf( __( 'Unexpected HTTP response code: %d', 'trello-social-auto-publisher' ), $code ), $attachment['url'] );
+                        tts_log_event( $post_id, 'webhook', 'error', sprintf( __( 'Unexpected HTTP response code: %d', 'fp-publisher' ), $code ), $attachment['url'] );
                         continue;
                     }
 
@@ -432,7 +432,7 @@ class TTS_Webhook {
                     $filetype     = wp_check_filetype( basename( wp_parse_url( $attachment['url'], PHP_URL_PATH ) ) );
 
                     if ( empty( $content_type ) || empty( $filetype['type'] ) || ( 0 !== strpos( $content_type, 'image/' ) && 0 !== strpos( $content_type, 'video/' ) ) ) {
-                        tts_log_event( $post_id, 'webhook', 'error', sprintf( __( 'Unsupported MIME type: %s', 'trello-social-auto-publisher' ), $content_type ), $attachment['url'] );
+                        tts_log_event( $post_id, 'webhook', 'error', sprintf( __( 'Unsupported MIME type: %s', 'fp-publisher' ), $content_type ), $attachment['url'] );
                         continue;
                     }
 
@@ -483,7 +483,7 @@ class TTS_Webhook {
         $boards = get_post_meta( $client_id, '_tts_trello_boards', true );
 
         if ( empty( $key ) || empty( $token ) || empty( $boards ) || ! is_array( $boards ) ) {
-            return new WP_Error( 'missing_data', __( 'Missing Trello credentials or boards.', 'trello-social-auto-publisher' ), array( 'status' => 400 ) );
+            return new WP_Error( 'missing_data', __( 'Missing Trello credentials or boards.', 'fp-publisher' ), array( 'status' => 400 ) );
         }
 
         $callback = rest_url( 'tts/v1/trello-webhook' );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-workflow-system.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-workflow-system.php
@@ -131,7 +131,7 @@ class TTS_Workflow_System {
         check_ajax_referer( 'tts_workflow_nonce', 'nonce' );
 
         if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $post_id = intval( $_POST['post_id'] ?? 0 );
@@ -141,7 +141,7 @@ class TTS_Workflow_System {
         $notes = sanitize_textarea_field( wp_unslash( $_POST['notes'] ?? '' ) );
 
         if ( empty( $post_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -149,11 +149,11 @@ class TTS_Workflow_System {
             
             wp_send_json_success( array(
                 'workflow_id' => $workflow_id,
-                'message' => __( 'Content submitted for approval successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Content submitted for approval successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Workflow Submission Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to submit for approval. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to submit for approval. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -245,25 +245,25 @@ class TTS_Workflow_System {
         check_ajax_referer( 'tts_workflow_nonce', 'nonce' );
 
         if ( ! current_user_can( 'publish_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $workflow_id = intval( $_POST['workflow_id'] ?? 0 );
         $comments = sanitize_textarea_field( wp_unslash( $_POST['comments'] ?? '' ) );
 
         if ( empty( $workflow_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Invalid workflow ID.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Invalid workflow ID.', 'fp-publisher' ) ) );
         }
 
         try {
             $this->approve_content( $workflow_id, $comments );
             
             wp_send_json_success( array(
-                'message' => __( 'Content approved successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Content approved successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Workflow Approval Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to approve content. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to approve content. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -329,25 +329,25 @@ class TTS_Workflow_System {
         check_ajax_referer( 'tts_workflow_nonce', 'nonce' );
 
         if ( ! current_user_can( 'publish_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $workflow_id = intval( $_POST['workflow_id'] ?? 0 );
         $reason = sanitize_textarea_field( wp_unslash( $_POST['reason'] ?? '' ) );
 
         if ( empty( $workflow_id ) || empty( $reason ) ) {
-            wp_send_json_error( array( 'message' => __( 'Workflow ID and rejection reason are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Workflow ID and rejection reason are required.', 'fp-publisher' ) ) );
         }
 
         try {
             $this->reject_content( $workflow_id, $reason );
             
             wp_send_json_success( array(
-                'message' => __( 'Content rejected successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Content rejected successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Workflow Rejection Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to reject content. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to reject content. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -412,7 +412,7 @@ class TTS_Workflow_System {
         check_ajax_referer( 'tts_workflow_nonce', 'nonce' );
 
         if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $workflow_id = intval( $_POST['workflow_id'] ?? 0 );
@@ -420,7 +420,7 @@ class TTS_Workflow_System {
         $comment_type = sanitize_text_field( wp_unslash( $_POST['comment_type'] ?? 'general' ) );
 
         if ( empty( $workflow_id ) || empty( $comment ) ) {
-            wp_send_json_error( array( 'message' => __( 'Workflow ID and comment are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Workflow ID and comment are required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -428,11 +428,11 @@ class TTS_Workflow_System {
             
             wp_send_json_success( array(
                 'comment_id' => $comment_id,
-                'message' => __( 'Comment added successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Comment added successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Workflow Comment Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to add comment. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to add comment. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -475,7 +475,7 @@ class TTS_Workflow_System {
         check_ajax_referer( 'tts_workflow_nonce', 'nonce' );
 
         if ( ! current_user_can( 'edit_others_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $post_id = intval( $_POST['post_id'] ?? 0 );
@@ -485,7 +485,7 @@ class TTS_Workflow_System {
         $instructions = sanitize_textarea_field( wp_unslash( $_POST['instructions'] ?? '' ) );
 
         if ( empty( $post_id ) || empty( $assigned_to ) ) {
-            wp_send_json_error( array( 'message' => __( 'Post ID and assignee are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Post ID and assignee are required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -493,11 +493,11 @@ class TTS_Workflow_System {
             
             wp_send_json_success( array(
                 'assignment_id' => $assignment_id,
-                'message' => __( 'Task assigned successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Task assigned successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Task Assignment Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to assign task. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to assign task. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -571,13 +571,13 @@ class TTS_Workflow_System {
         check_ajax_referer( 'tts_workflow_nonce', 'nonce' );
 
         if ( ! current_user_can( 'read' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $post_id = intval( $_POST['post_id'] ?? 0 );
 
         if ( empty( $post_id ) ) {
-            wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -585,11 +585,11 @@ class TTS_Workflow_System {
             
             wp_send_json_success( array(
                 'status' => $status,
-                'message' => __( 'Workflow status retrieved successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Workflow status retrieved successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Workflow Status Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to get workflow status. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to get workflow status. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -663,7 +663,7 @@ class TTS_Workflow_System {
         check_ajax_referer( 'tts_workflow_nonce', 'nonce' );
 
         if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         $name = sanitize_text_field( wp_unslash( $_POST['name'] ?? '' ) );
@@ -674,7 +674,7 @@ class TTS_Workflow_System {
         $category = sanitize_text_field( wp_unslash( $_POST['category'] ?? '' ) );
 
         if ( empty( $name ) || empty( $template_content ) ) {
-            wp_send_json_error( array( 'message' => __( 'Template name and content are required.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Template name and content are required.', 'fp-publisher' ) ) );
         }
 
         try {
@@ -682,11 +682,11 @@ class TTS_Workflow_System {
             
             wp_send_json_success( array(
                 'template_id' => $template_id,
-                'message' => __( 'Content template created successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Content template created successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Template Creation Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to create template. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to create template. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -734,7 +734,7 @@ class TTS_Workflow_System {
         check_ajax_referer( 'tts_workflow_nonce', 'nonce' );
 
         if ( ! current_user_can( 'read' ) ) {
-            wp_die( esc_html__( 'You do not have sufficient permissions.', 'trello-social-auto-publisher' ) );
+            wp_die( esc_html__( 'You do not have sufficient permissions.', 'fp-publisher' ) );
         }
 
         try {
@@ -742,11 +742,11 @@ class TTS_Workflow_System {
             
             wp_send_json_success( array(
                 'dashboard' => $dashboard,
-                'message' => __( 'Team dashboard data retrieved successfully!', 'trello-social-auto-publisher' )
+                'message' => __( 'Team dashboard data retrieved successfully!', 'fp-publisher' )
             ) );
         } catch ( Exception $e ) {
             error_log( 'TTS Team Dashboard Error: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => __( 'Failed to get dashboard data. Please try again.', 'trello-social-auto-publisher' ) ) );
+            wp_send_json_error( array( 'message' => __( 'Failed to get dashboard data. Please try again.', 'fp-publisher' ) ) );
         }
     }
 
@@ -847,13 +847,13 @@ class TTS_Workflow_System {
         }
         
         $subject = sprintf( 
-            __( '[%s] Content Approval Required: %s', 'trello-social-auto-publisher' ),
+            __( '[%s] Content Approval Required: %s', 'fp-publisher' ),
             get_bloginfo( 'name' ),
             $post->post_title
         );
         
         $message = sprintf(
-            __( "Hi %s,\n\nNew content has been submitted for your approval:\n\nTitle: %s\nSubmitted by: %s\nPriority: %s\nDeadline: %s\n\nPlease review and approve or reject this content in your dashboard.\n\nBest regards,\nSocial Auto Publisher", 'trello-social-auto-publisher' ),
+            __( "Hi %s,\n\nNew content has been submitted for your approval:\n\nTitle: %s\nSubmitted by: %s\nPriority: %s\nDeadline: %s\n\nPlease review and approve or reject this content in your dashboard.\n\nBest regards,\nSocial Auto Publisher", 'fp-publisher' ),
             $assigned_user->display_name,
             $post->post_title,
             $submitted_user->display_name,
@@ -896,13 +896,13 @@ class TTS_Workflow_System {
         }
         
         $subject = sprintf( 
-            __( '[%s] Content Approved: %s', 'trello-social-auto-publisher' ),
+            __( '[%s] Content Approved: %s', 'fp-publisher' ),
             get_bloginfo( 'name' ),
             $post->post_title
         );
         
         $message = sprintf(
-            __( "Hi %s,\n\nYour content has been approved:\n\nTitle: %s\nApproved by: %s\nApproved on: %s\n\nYour content is now ready for publishing.\n\nBest regards,\nSocial Auto Publisher", 'trello-social-auto-publisher' ),
+            __( "Hi %s,\n\nYour content has been approved:\n\nTitle: %s\nApproved by: %s\nApproved on: %s\n\nYour content is now ready for publishing.\n\nBest regards,\nSocial Auto Publisher", 'fp-publisher' ),
             $submitted_user->display_name,
             $post->post_title,
             $approved_user->display_name,
@@ -942,13 +942,13 @@ class TTS_Workflow_System {
         }
         
         $subject = sprintf( 
-            __( '[%s] Content Rejected: %s', 'trello-social-auto-publisher' ),
+            __( '[%s] Content Rejected: %s', 'fp-publisher' ),
             get_bloginfo( 'name' ),
             $post->post_title
         );
         
         $message = sprintf(
-            __( "Hi %s,\n\nYour content has been rejected:\n\nTitle: %s\nRejected by: %s\nRejected on: %s\nReason: %s\n\nPlease review the feedback and resubmit when ready.\n\nBest regards,\nSocial Auto Publisher", 'trello-social-auto-publisher' ),
+            __( "Hi %s,\n\nYour content has been rejected:\n\nTitle: %s\nRejected by: %s\nRejected on: %s\nReason: %s\n\nPlease review the feedback and resubmit when ready.\n\nBest regards,\nSocial Auto Publisher", 'fp-publisher' ),
             $submitted_user->display_name,
             $post->post_title,
             $rejected_user->display_name,

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-blog.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-blog.php
@@ -26,7 +26,7 @@ class TTS_Publisher_Blog {
      */
     public function publish( $post_id, $credentials, $message ) {
         if ( empty( $message ) ) {
-            $error = __( 'Blog content is empty', 'trello-social-auto-publisher' );
+            $error = __( 'Blog content is empty', 'fp-publisher' );
             tts_log_event( $post_id, 'blog', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'blog' );
             return new \WP_Error( 'blog_no_content', $error );
@@ -61,7 +61,7 @@ class TTS_Publisher_Blog {
         
         if ( is_wp_error( $blog_post_id ) ) {
             $error = sprintf( 
-                __( 'Failed to create blog post: %s', 'trello-social-auto-publisher' ), 
+                __( 'Failed to create blog post: %s', 'fp-publisher' ), 
                 $blog_post_id->get_error_message() 
             );
             tts_log_event( $post_id, 'blog', 'error', $error, '' );
@@ -91,7 +91,7 @@ class TTS_Publisher_Blog {
         );
         
         $response = sprintf( 
-            __( 'Published to blog (Post ID: %d)', 'trello-social-auto-publisher' ), 
+            __( 'Published to blog (Post ID: %d)', 'fp-publisher' ), 
             $blog_post_id 
         );
         
@@ -144,7 +144,7 @@ class TTS_Publisher_Blog {
             if ( $source_url ) {
                 $content .= sprintf( 
                     '<p><em>%s: <a href="%s">%s</a></em></p>', 
-                    __( 'Source', 'trello-social-auto-publisher' ),
+                    __( 'Source', 'fp-publisher' ),
                     esc_url( $source_url ),
                     esc_html( get_the_title( $post_id ) )
                 );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook-story.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook-story.php
@@ -28,7 +28,7 @@ class TTS_Publisher_Facebook_Story {
         $token       = $context['token'] ?? '';
 
         if ( empty( $media_path ) ) {
-            $error = __( 'Missing credentials or media for Facebook Story', 'trello-social-auto-publisher' );
+            $error = __( 'Missing credentials or media for Facebook Story', 'fp-publisher' );
             tts_log_event( $post_id, 'facebook_story', 'error', $error, '' );
 
             return array(
@@ -59,7 +59,7 @@ class TTS_Publisher_Facebook_Story {
         }
 
         if ( empty( $page_id ) || empty( $token ) ) {
-            $error = __( 'Invalid Facebook credentials', 'trello-social-auto-publisher' );
+            $error = __( 'Invalid Facebook credentials', 'fp-publisher' );
             tts_log_event( $post_id, 'facebook_story', 'error', $error, '' );
 
             return array(
@@ -98,7 +98,7 @@ class TTS_Publisher_Facebook_Story {
         $code = wp_remote_retrieve_response_code( $result );
 
         if ( 200 !== $code || empty( $data['id'] ) ) {
-            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'facebook_story', 'error', $error, $data );
 
             return array(
@@ -136,14 +136,14 @@ class TTS_Publisher_Facebook_Story {
             tts_notify_publication( $post_id, 'error', 'facebook_story' );
             $error_code = $result['error_code'] ?? 'facebook_story_error';
             $error_data = $result['error_data'] ?? array();
-            $error_msg  = $result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error_msg  = $result['error'] ?? __( 'Unknown error', 'fp-publisher' );
 
             return new \WP_Error( $error_code, $error_msg, $error_data );
         }
 
         $data     = $result['data'] ?? array();
         $response = array(
-            'message' => __( 'Published Facebook Story', 'trello-social-auto-publisher' ),
+            'message' => __( 'Published Facebook Story', 'fp-publisher' ),
             'id'      => $data['id'] ?? '',
         );
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
@@ -28,7 +28,7 @@ class TTS_Publisher_Facebook {
         list( $page_id, $token ) = $this->resolve_credentials( $credentials, $post_id, $context );
 
         if ( empty( $page_id ) || empty( $token ) ) {
-            $error = __( 'Invalid Facebook credentials', 'trello-social-auto-publisher' );
+            $error = __( 'Invalid Facebook credentials', 'fp-publisher' );
             tts_log_event( $post_id, 'facebook', 'error', $error, '' );
 
             return array(
@@ -39,7 +39,7 @@ class TTS_Publisher_Facebook {
         }
 
         if ( empty( $media_path ) ) {
-            $error = __( 'Missing media path for Facebook upload', 'trello-social-auto-publisher' );
+            $error = __( 'Missing media path for Facebook upload', 'fp-publisher' );
             tts_log_event( $post_id, 'facebook', 'error', $error, '' );
 
             return array(
@@ -125,7 +125,7 @@ class TTS_Publisher_Facebook {
         $data = json_decode( wp_remote_retrieve_body( $result ), true );
 
         if ( 200 !== $code || empty( $data['id'] ) ) {
-            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'facebook', 'error', $error, $data );
 
             return array(
@@ -157,7 +157,7 @@ class TTS_Publisher_Facebook {
      */
     public function publish( $post_id, $credentials, $message ) {
         if ( empty( $credentials ) ) {
-            $error = __( 'Facebook token missing', 'trello-social-auto-publisher' );
+            $error = __( 'Facebook token missing', 'fp-publisher' );
             tts_log_event( $post_id, 'facebook', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'facebook' );
             return new \WP_Error( 'facebook_no_token', $error );
@@ -175,7 +175,7 @@ class TTS_Publisher_Facebook {
         }
 
         if ( empty( $page_id ) || empty( $token ) ) {
-            $error = __( 'Invalid Facebook credentials', 'trello-social-auto-publisher' );
+            $error = __( 'Invalid Facebook credentials', 'fp-publisher' );
             tts_log_event( $post_id, 'facebook', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'facebook' );
             return new \WP_Error( 'facebook_bad_credentials', $error );
@@ -243,12 +243,12 @@ class TTS_Publisher_Facebook {
             $code = wp_remote_retrieve_response_code( $result );
             $data = json_decode( wp_remote_retrieve_body( $result ), true );
             if ( 200 === $code && isset( $data['id'] ) ) {
-                $response = __( 'Published to Facebook', 'trello-social-auto-publisher' );
+                $response = __( 'Published to Facebook', 'fp-publisher' );
                 tts_log_event( $post_id, 'facebook', 'success', $response, $data );
                 tts_notify_publication( $post_id, 'success', 'facebook' );
                 return $response;
             }
-            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'facebook', 'error', $error, $data );
             tts_notify_publication( $post_id, 'error', 'facebook' );
             return new \WP_Error( 'facebook_error', $error, $data );
@@ -282,7 +282,7 @@ class TTS_Publisher_Facebook {
                 tts_notify_publication( $post_id, 'error', 'facebook' );
                 $error_code = $video_result['error_code'] ?? 'facebook_error';
                 $error_data = $video_result['error_data'] ?? array();
-                $error_msg  = $video_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+                $error_msg  = $video_result['error'] ?? __( 'Unknown error', 'fp-publisher' );
 
                 return new \WP_Error( $error_code, $error_msg, $error_data );
             }
@@ -307,7 +307,7 @@ class TTS_Publisher_Facebook {
                 tts_notify_publication( $post_id, 'error', 'facebook' );
                 $error_code = $image_result['error_code'] ?? 'facebook_error';
                 $error_data = $image_result['error_data'] ?? array();
-                $error_msg  = $image_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+                $error_msg  = $image_result['error'] ?? __( 'Unknown error', 'fp-publisher' );
 
                 return new \WP_Error( $error_code, $error_msg, $error_data );
             }
@@ -315,7 +315,7 @@ class TTS_Publisher_Facebook {
             $last_response = $image_result['data'];
         }
 
-        $response = __( 'Published to Facebook', 'trello-social-auto-publisher' );
+        $response = __( 'Published to Facebook', 'fp-publisher' );
         tts_log_event( $post_id, 'facebook', 'success', $response, $last_response );
         tts_notify_publication( $post_id, 'success', 'facebook' );
         return $response;

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram-story.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram-story.php
@@ -38,7 +38,7 @@ class TTS_Publisher_Instagram_Story {
         }
 
         if ( empty( $ig_user_id ) || empty( $token ) || empty( $media_path ) ) {
-            $error = __( 'Missing credentials or media for Instagram Story', 'trello-social-auto-publisher' );
+            $error = __( 'Missing credentials or media for Instagram Story', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram_story', 'error', $error, '' );
 
             return array(
@@ -84,7 +84,7 @@ class TTS_Publisher_Instagram_Story {
         $code = wp_remote_retrieve_response_code( $result );
 
         if ( 200 !== $code || empty( $data['id'] ) ) {
-            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram_story', 'error', $error, $data );
 
             return array(
@@ -122,7 +122,7 @@ class TTS_Publisher_Instagram_Story {
         $publish_code = wp_remote_retrieve_response_code( $publish_result );
 
         if ( 200 !== $publish_code || empty( $publish_data['id'] ) ) {
-            $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram_story', 'error', $error, $publish_data );
 
             return array(
@@ -160,14 +160,14 @@ class TTS_Publisher_Instagram_Story {
             tts_notify_publication( $post_id, 'error', 'instagram_story' );
             $error_code = $result['error_code'] ?? 'instagram_story_error';
             $error_data = $result['error_data'] ?? array();
-            $error_msg  = $result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error_msg  = $result['error'] ?? __( 'Unknown error', 'fp-publisher' );
 
             return new \WP_Error( $error_code, $error_msg, $error_data );
         }
 
         $data     = $result['data'] ?? array();
         $response = array(
-            'message' => __( 'Published Instagram Story', 'trello-social-auto-publisher' ),
+            'message' => __( 'Published Instagram Story', 'fp-publisher' ),
             'id'      => $data['id'] ?? '',
         );
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
@@ -52,7 +52,7 @@ class TTS_Publisher_Instagram {
         }
 
         if ( empty( $ig_user_id ) || empty( $token ) ) {
-            $error = __( 'Invalid Instagram credentials', 'trello-social-auto-publisher' );
+            $error = __( 'Invalid Instagram credentials', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $error, '' );
 
             return array(
@@ -63,7 +63,7 @@ class TTS_Publisher_Instagram {
         }
 
         if ( empty( $media_path ) ) {
-            $error = __( 'No image or video to publish', 'trello-social-auto-publisher' );
+            $error = __( 'No image or video to publish', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $error, '' );
 
             return array(
@@ -134,7 +134,7 @@ class TTS_Publisher_Instagram {
         $data = json_decode( wp_remote_retrieve_body( $result ), true );
 
         if ( 200 !== $code || empty( $data['id'] ) ) {
-            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $error, $data );
 
             return array(
@@ -174,7 +174,7 @@ class TTS_Publisher_Instagram {
         $publish_data = json_decode( wp_remote_retrieve_body( $publish_result ), true );
 
         if ( 200 !== $publish_code || empty( $publish_data['id'] ) ) {
-            $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $error, $publish_data );
 
             return array(
@@ -211,7 +211,7 @@ class TTS_Publisher_Instagram {
     public function publish( $post_id, $credentials, $message ) {
         $this->post_id = $post_id;
         if ( empty( $credentials ) ) {
-            $message = __( 'Instagram token missing', 'trello-social-auto-publisher' );
+            $message = __( 'Instagram token missing', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $message, '' );
             tts_notify_publication( $post_id, 'error', 'instagram' );
             return new \WP_Error( 'instagram_no_token', $message );
@@ -219,7 +219,7 @@ class TTS_Publisher_Instagram {
 
         list( $ig_user_id, $token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
         if ( empty( $ig_user_id ) || empty( $token ) ) {
-            $error = __( 'Invalid Instagram credentials', 'trello-social-auto-publisher' );
+            $error = __( 'Invalid Instagram credentials', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'instagram' );
             return new \WP_Error( 'instagram_bad_credentials', $error );
@@ -268,7 +268,7 @@ class TTS_Publisher_Instagram {
             }
         }
         if ( empty( $media_items ) ) {
-            $error = __( 'No image or video to publish', 'trello-social-auto-publisher' );
+            $error = __( 'No image or video to publish', 'fp-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'instagram' );
             return new \WP_Error( 'instagram_no_media', $error );
@@ -293,7 +293,7 @@ class TTS_Publisher_Instagram {
                 tts_notify_publication( $post_id, 'error', 'instagram' );
                 $error_code = $upload_result['error_code'] ?? 'instagram_error';
                 $error_data = $upload_result['error_data'] ?? array();
-                $error_msg  = $upload_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+                $error_msg  = $upload_result['error'] ?? __( 'Unknown error', 'fp-publisher' );
 
                 return new \WP_Error( $error_code, $error_msg, $error_data );
             }
@@ -303,7 +303,7 @@ class TTS_Publisher_Instagram {
             }
         }
         $response = array(
-            'message' => __( 'Published to Instagram', 'trello-social-auto-publisher' ),
+            'message' => __( 'Published to Instagram', 'fp-publisher' ),
             'id'      => $first_media_id,
         );
         tts_log_event( $post_id, 'instagram', 'success', $response['message'], '' );
@@ -320,7 +320,7 @@ class TTS_Publisher_Instagram {
      */
     public function post_comment( $media_id, $text ) {
         if ( empty( $this->token ) || empty( $media_id ) || empty( $text ) ) {
-            return new \WP_Error( 'instagram_comment_missing_data', __( 'Missing data for Instagram comment', 'trello-social-auto-publisher' ) );
+            return new \WP_Error( 'instagram_comment_missing_data', __( 'Missing data for Instagram comment', 'fp-publisher' ) );
         }
         $endpoint = sprintf( 'https://graph.facebook.com/%s/comments', $media_id );
         $result   = wp_remote_post(
@@ -341,11 +341,11 @@ class TTS_Publisher_Instagram {
         $code = wp_remote_retrieve_response_code( $result );
         $data = json_decode( wp_remote_retrieve_body( $result ), true );
         if ( 200 !== $code || empty( $data['id'] ) ) {
-            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $this->post_id, 'instagram', 'error', $error, $data );
             return new \WP_Error( 'instagram_comment_error', $error, $data );
         }
-        $success = __( 'Comment posted to Instagram', 'trello-social-auto-publisher' );
+        $success = __( 'Comment posted to Instagram', 'fp-publisher' );
         tts_log_event( $this->post_id, 'instagram', 'success', $success, $data );
         return $success;
     }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php
@@ -26,7 +26,7 @@ class TTS_Publisher_TikTok {
         $token   = $context['token'] ?? ( $context['credentials'] ?? '' );
 
         if ( empty( $token ) ) {
-            $error = __( 'TikTok token missing or lacks video.upload scope', 'trello-social-auto-publisher' );
+            $error = __( 'TikTok token missing or lacks video.upload scope', 'fp-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
 
             return array(
@@ -37,7 +37,7 @@ class TTS_Publisher_TikTok {
         }
 
         if ( empty( $media_path ) ) {
-            $error = __( 'Video file not found', 'trello-social-auto-publisher' );
+            $error = __( 'Video file not found', 'fp-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
 
             return array(
@@ -77,7 +77,7 @@ class TTS_Publisher_TikTok {
         }
 
         if ( empty( $video_path ) || ! file_exists( $video_path ) ) {
-            $error = __( 'Video file not found', 'trello-social-auto-publisher' );
+            $error = __( 'Video file not found', 'fp-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
 
             return array(
@@ -94,7 +94,7 @@ class TTS_Publisher_TikTok {
                 @unlink( $video_path );
             }
 
-            $error = __( 'Unable to read video file', 'trello-social-auto-publisher' );
+            $error = __( 'Unable to read video file', 'fp-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
 
             return array(
@@ -135,7 +135,7 @@ class TTS_Publisher_TikTok {
         $upload_data = json_decode( wp_remote_retrieve_body( $upload_result ), true );
 
         if ( 200 !== $upload_code || empty( $upload_data['data']['video_id'] ) ) {
-            $error = isset( $upload_data['error']['message'] ) ? $upload_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $upload_data['error']['message'] ) ? $upload_data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, $upload_data );
 
             return array(
@@ -189,7 +189,7 @@ class TTS_Publisher_TikTok {
         $publish_data = json_decode( wp_remote_retrieve_body( $publish_result ), true );
 
         if ( 200 !== $publish_code || empty( $publish_data['data']['video_id'] ) ) {
-            $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, $publish_data );
 
             return array(
@@ -221,7 +221,7 @@ class TTS_Publisher_TikTok {
      */
     public function publish( $post_id, $token, $message ) {
         if ( empty( $token ) ) {
-            $error = __( 'TikTok token missing or lacks video.upload scope', 'trello-social-auto-publisher' );
+            $error = __( 'TikTok token missing or lacks video.upload scope', 'fp-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'tiktok' );
             return new \WP_Error( 'tiktok_no_token', $error );
@@ -246,7 +246,7 @@ class TTS_Publisher_TikTok {
             }
         }
         if ( empty( $videos ) ) {
-            $error = __( 'No video to publish', 'trello-social-auto-publisher' );
+            $error = __( 'No video to publish', 'fp-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'tiktok' );
             return new \WP_Error( 'tiktok_no_video', $error );
@@ -269,12 +269,12 @@ class TTS_Publisher_TikTok {
                 tts_notify_publication( $post_id, 'error', 'tiktok' );
                 $error_code = $upload_result['error_code'] ?? 'tiktok_error';
                 $error_data = $upload_result['error_data'] ?? array();
-                $error_msg  = $upload_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+                $error_msg  = $upload_result['error'] ?? __( 'Unknown error', 'fp-publisher' );
 
                 return new \WP_Error( $error_code, $error_msg, $error_data );
             }
         }
-        $response = __( 'Published to TikTok', 'trello-social-auto-publisher' );
+        $response = __( 'Published to TikTok', 'fp-publisher' );
         tts_log_event( $post_id, 'tiktok', 'success', $response, '' );
         tts_notify_publication( $post_id, 'success', 'tiktok' );
         return $response;

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
@@ -38,7 +38,7 @@ class TTS_Publisher_YouTube {
         }
 
         if ( empty( $token ) ) {
-            $error = __( 'Unable to obtain YouTube access token', 'trello-social-auto-publisher' );
+            $error = __( 'Unable to obtain YouTube access token', 'fp-publisher' );
             tts_log_event( $post_id, 'youtube', 'error', $error, '' );
 
             return array(
@@ -77,7 +77,7 @@ class TTS_Publisher_YouTube {
         }
 
         if ( empty( $video_path ) || ! file_exists( $video_path ) ) {
-            $error = __( 'Video file not found', 'trello-social-auto-publisher' );
+            $error = __( 'Video file not found', 'fp-publisher' );
             tts_log_event( $post_id, 'youtube', 'error', $error, '' );
 
             return array(
@@ -151,7 +151,7 @@ class TTS_Publisher_YouTube {
             if ( $cleanup ) {
                 @unlink( $video_path );
             }
-            $error = __( 'Upload URL missing', 'trello-social-auto-publisher' );
+            $error = __( 'Upload URL missing', 'fp-publisher' );
             tts_log_event( $post_id, 'youtube', 'error', $error, '' );
 
             return array(
@@ -167,7 +167,7 @@ class TTS_Publisher_YouTube {
         }
 
         if ( false === $video_body ) {
-            $error = __( 'Unable to read video file', 'trello-social-auto-publisher' );
+            $error = __( 'Unable to read video file', 'fp-publisher' );
             tts_log_event( $post_id, 'youtube', 'error', $error, '' );
 
             return array(
@@ -205,7 +205,7 @@ class TTS_Publisher_YouTube {
         $data = json_decode( wp_remote_retrieve_body( $upload ), true );
 
         if ( 200 !== $code || empty( $data['id'] ) ) {
-            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'fp-publisher' );
             tts_log_event( $post_id, 'youtube', 'error', $error, $data );
 
             return array(
@@ -232,7 +232,7 @@ class TTS_Publisher_YouTube {
      */
     public function publish( $post_id, $credentials, $message ) {
         if ( empty( $credentials ) ) {
-            $error = __( 'YouTube token missing', 'trello-social-auto-publisher' );
+            $error = __( 'YouTube token missing', 'fp-publisher' );
             tts_log_event( $post_id, 'youtube', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'youtube' );
             return new \WP_Error( 'youtube_no_token', $error );
@@ -241,7 +241,7 @@ class TTS_Publisher_YouTube {
         list( $access_tok, $creds, $client_id ) = $this->resolve_access_token( $credentials, $post_id );
 
         if ( empty( $access_tok ) ) {
-            $error = __( 'Unable to obtain YouTube access token', 'trello-social-auto-publisher' );
+            $error = __( 'Unable to obtain YouTube access token', 'fp-publisher' );
             tts_log_event( $post_id, 'youtube', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'youtube' );
             return new \WP_Error( 'youtube_no_access_token', $error );
@@ -266,7 +266,7 @@ class TTS_Publisher_YouTube {
             }
         }
         if ( empty( $videos ) ) {
-            $error = __( 'No video to publish', 'trello-social-auto-publisher' );
+            $error = __( 'No video to publish', 'fp-publisher' );
             tts_log_event( $post_id, 'youtube', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'youtube' );
             return new \WP_Error( 'youtube_no_video', $error );
@@ -292,12 +292,12 @@ class TTS_Publisher_YouTube {
                 tts_notify_publication( $post_id, 'error', 'youtube' );
                 $error_code = $upload_result['error_code'] ?? 'youtube_error';
                 $error_data = $upload_result['error_data'] ?? array();
-                $error_msg  = $upload_result['error'] ?? __( 'Unknown error', 'trello-social-auto-publisher' );
+                $error_msg  = $upload_result['error'] ?? __( 'Unknown error', 'fp-publisher' );
 
                 return new \WP_Error( $error_code, $error_msg, $error_data );
             }
         }
-        $response = __( 'Published to YouTube', 'trello-social-auto-publisher' );
+        $response = __( 'Published to YouTube', 'fp-publisher' );
         tts_log_event( $post_id, 'youtube', 'success', $response, '' );
         tts_notify_publication( $post_id, 'success', 'youtube' );
         return $response;

--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-notify.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-notify.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function tts_notify_publication( $post_id, $status, $channel ) {
     $title   = get_the_title( $post_id );
     $message = sprintf(
-        __( 'Post "%s" on %s: %s', 'trello-social-auto-publisher' ),
+        __( 'Post "%s" on %s: %s', 'fp-publisher' ),
         $title,
         $channel,
         $status
@@ -42,7 +42,7 @@ function tts_notify_publication( $post_id, $status, $channel ) {
     }
 
     $subject = sprintf(
-        __( '[Social Publish] %s - %s', 'trello-social-auto-publisher' ),
+        __( '[Social Publish] %s - %s', 'fp-publisher' ),
         $channel,
         $status
     );


### PR DESCRIPTION
## Summary
- update all Trello Social Auto Publisher translation calls to use the fp-publisher text domain
- ensure localized JavaScript snippets and AJAX responses reference the fp-publisher domain for translations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbd635d8b4832f9f6b84d303292439