### PR TITLE
Load highlight dependencies on the frequency status page

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-status-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-status-page.php
@@ -48,7 +48,7 @@ class TTS_Frequency_Status_Page {
         wp_enqueue_script(
             'tts-frequency-status',
             plugin_dir_url( __FILE__ ) . '../admin/js/tts-frequency-status.js',
-            array( 'jquery' ),
+            array( 'jquery', 'jquery-effects-core', 'jquery-effects-highlight' ),
             '1.0',
             true
         );

--- a/wp-content/plugins/trello-social-auto-publisher/admin/css/tts-frequency-status.css
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/css/tts-frequency-status.css
@@ -53,12 +53,20 @@
     background-color: #fffbf0;
 }
 
+.tts-channel-row {
+    transition: background-color 0.4s ease-in-out;
+}
+
 .tts-channel-row.status-urgent {
     background-color: #fff2e8;
 }
 
 .tts-channel-row.status-overdue {
     background-color: #fff1f0;
+}
+
+.tts-highlight-fallback {
+    background-color: #fef2f2 !important;
 }
 
 .tts-progress-bar {

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-frequency-status.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-frequency-status.js
@@ -170,9 +170,27 @@ jQuery(document).ready(function($) {
      * Highlight urgent rows
      */
     function highlightUrgentRows() {
-        $('.tts-channel-row.status-urgent, .tts-channel-row.status-overdue').each(function() {
-            $(this).effect('highlight', {color: '#fef2f2'}, 1000);
-        });
+        var $rows = $('.tts-channel-row.status-urgent, .tts-channel-row.status-overdue');
+
+        if (!$rows.length) {
+            return;
+        }
+
+        if (typeof $.fn.effect === 'function') {
+            $rows.each(function() {
+                $(this).effect('highlight', { color: '#fef2f2' }, 1000);
+            });
+        } else {
+            $rows.each(function() {
+                var $row = $(this);
+
+                $row.addClass('tts-highlight-fallback');
+
+                setTimeout(function() {
+                    $row.removeClass('tts-highlight-fallback');
+                }, 1200);
+            });
+        }
     }
 
     // Initial highlight


### PR DESCRIPTION
## Summary
- ensure the frequency status script loads the jQuery UI highlight effect dependency
- guard the urgent row highlight code and provide a CSS fallback when the effect API is unavailable
- add styling to smooth the fallback highlight experience

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc2473eaa4832fbcd33c910e21c903