### PR TITLE
Implement singleton for frequency monitor

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-dashboard-widget.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-dashboard-widget.php
@@ -40,7 +40,7 @@ class TTS_Frequency_Dashboard_Widget {
      * Render the widget content.
      */
     public function render_widget() {
-        $monitor = new TTS_Frequency_Monitor();
+        $monitor = TTS_Frequency_Monitor::get_instance();
         $clients = get_posts( array(
             'post_type' => 'tts_client',
             'post_status' => 'publish',
@@ -316,7 +316,7 @@ class TTS_Frequency_Dashboard_Widget {
         }
 
         // Trigger a quick frequency check
-        $monitor = new TTS_Frequency_Monitor();
+        $monitor = TTS_Frequency_Monitor::get_instance();
         $monitor->check_all_clients();
 
         wp_send_json_success();

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-status-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-status-page.php
@@ -71,7 +71,7 @@ class TTS_Frequency_Status_Page {
      * Render the page content.
      */
     public function render_page() {
-        $monitor = new TTS_Frequency_Monitor();
+        $monitor = TTS_Frequency_Monitor::get_instance();
         $clients = get_posts( array(
             'post_type' => 'tts_client',
             'post_status' => 'publish',
@@ -224,7 +224,7 @@ class TTS_Frequency_Status_Page {
             wp_die( __( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
-        $monitor = new TTS_Frequency_Monitor();
+        $monitor = TTS_Frequency_Monitor::get_instance();
         $clients = get_posts( array(
             'post_type' => 'tts_client',
             'post_status' => 'publish',
@@ -250,7 +250,7 @@ class TTS_Frequency_Status_Page {
             wp_die( __( 'Insufficient permissions', 'fp-publisher' ) );
         }
 
-        $monitor = new TTS_Frequency_Monitor();
+        $monitor = TTS_Frequency_Monitor::get_instance();
         $monitor->check_all_clients();
 
         wp_send_json_success( array( 'message' => __( 'Frequency check completed', 'fp-publisher' ) ) );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-frequency-monitor.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-frequency-monitor.php
@@ -15,12 +15,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 class TTS_Frequency_Monitor {
 
     /**
+     * Singleton instance of the frequency monitor.
+     *
+     * @var TTS_Frequency_Monitor|null
+     */
+    private static $instance = null;
+
+    /**
      * Constructor.
      */
-    public function __construct() {
+    private function __construct() {
         add_action( 'init', array( $this, 'schedule_frequency_check' ) );
         add_action( 'tts_check_publishing_frequencies', array( $this, 'check_all_clients' ) );
         add_action( 'tts_publish_social_post', array( $this, 'record_publication' ), 20, 2 );
+    }
+
+    /**
+     * Retrieve the singleton instance of the monitor.
+     *
+     * @return TTS_Frequency_Monitor
+     */
+    public static function get_instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
     }
 
     /**
@@ -368,4 +388,4 @@ class TTS_Frequency_Monitor {
     }
 }
 
-new TTS_Frequency_Monitor();
+TTS_Frequency_Monitor::get_instance();


### PR DESCRIPTION
## Summary
- convert `TTS_Frequency_Monitor` into a singleton with a `get_instance()` accessor
- update the frequency status page and dashboard widget to reuse the shared monitor instance

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-frequency-monitor.php
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-status-page.php
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-frequency-dashboard-widget.php


------
https://chatgpt.com/codex/tasks/task_e_68cc3b3b37ac832f8a50a763a7f18467