### PR TITLE
Ensure dashboard script includes WP dependencies

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -359,21 +359,18 @@ class TTS_Admin {
             $css_version
         );
 
+        if ( ! $this->dashboard_needs_react_components() ) {
+            return;
+        }
+
         $js_version = filemtime( plugin_dir_path( __FILE__ ) . 'js/tts-dashboard.js' );
         wp_enqueue_script(
             'tts-dashboard',
             plugin_dir_url( __FILE__ ) . 'js/tts-dashboard.js',
-            array( 'tts-core', 'tts-notifications' ),
+            array( 'tts-core', 'tts-notifications', 'wp-element', 'wp-components', 'wp-api-fetch' ),
             $js_version,
             true
         );
-
-        // Conditional loading of React components only if needed
-        if ( $this->dashboard_needs_react_components() ) {
-            wp_enqueue_script( 'wp-element' );
-            wp_enqueue_script( 'wp-components' );
-            wp_enqueue_script( 'wp-api-fetch' );
-        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- add the WordPress React package handles to the dashboard script dependencies
- stop enqueuing the dashboard script when the advanced UI is disabled so dependencies remain intact

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cc48923ca0832f9eb269d3b56b7bb3