### PR TITLE
Ensure admin utilities load before advanced features

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -298,6 +298,16 @@ class TTS_Admin {
         );
         wp_enqueue_script( 'tts-notifications' );
 
+        $admin_utils_version = filemtime( plugin_dir_path( __FILE__ ) . 'js/tts-admin-utils.js' );
+        wp_register_script(
+            'tts-admin-utils',
+            plugin_dir_url( __FILE__ ) . 'js/tts-admin-utils.js',
+            array( 'tts-notifications', 'wp-util' ),
+            $admin_utils_version,
+            true
+        );
+        wp_enqueue_script( 'tts-admin-utils' );
+
         // Essential JavaScript with optimized dependencies
         $js_version = filemtime( plugin_dir_path( __FILE__ ) . 'js/tts-core.js' );
         wp_enqueue_script(
@@ -432,7 +442,7 @@ class TTS_Admin {
         wp_enqueue_script(
             'tts-advanced-features',
             plugin_dir_url( __FILE__ ) . 'js/tts-advanced-features.js',
-            array( 'tts-core', 'tts-notifications' ),
+            array( 'tts-core', 'tts-notifications', 'tts-admin-utils' ),
             $js_version,
             true
         );


### PR DESCRIPTION
## Summary
- register and enqueue the reusable admin utilities script with the core FP Publisher assets so it is always available on plugin pages
- make the advanced features bundle depend on the admin utilities script to guarantee modal helpers load before the toolbar features run

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cc4a2d133c832f87c3bd3927ededd6