### PR TITLE
Fix social connection status updates

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -2575,7 +2575,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
                             ?>
                             <div class="tts-connection-status" data-platform="<?php echo esc_attr( $platform ); ?>">
                                 <strong><?php esc_html_e( 'Status:', 'fp-publisher' ); ?></strong>
-                                <span class="tts-status-<?php echo esc_attr( $connection_status['status'] ); ?>">
+                                <span class="tts-status-message tts-status-<?php echo esc_attr( $connection_status['status'] ); ?>">
                                     <?php echo esc_html( $connection_status['message'] ); ?>
                                 </span>
                                 
@@ -2710,6 +2710,9 @@ class TTS_Social_Posts_Table extends WP_List_Table {
             }
             .tts-status-connected {
                 color: #00a32a;
+            }
+            .tts-status-error {
+                color: #d63638;
             }
             .tts-platform-actions {
                 display: flex;
@@ -3639,24 +3642,46 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         
         $platform = sanitize_text_field( $_POST['platform'] );
         $social_apps = get_option( 'tts_social_apps', array() );
-        
+
+        $status_messages = array(
+            'not-configured' => __( 'App credentials not configured', 'fp-publisher' ),
+            'configured' => __( 'Ready to connect accounts', 'fp-publisher' ),
+            'connected' => __( 'Account connected', 'fp-publisher' ),
+            'error' => __( 'Connection error. Please try again.', 'fp-publisher' ),
+        );
+
         if ( ! isset( $social_apps[$platform] ) ) {
-            wp_send_json_success( array( 'status' => 'not_configured' ) );
+            wp_send_json_success(
+                array(
+                    'status'  => 'not-configured',
+                    'message' => $status_messages['not-configured'],
+                )
+            );
             return;
         }
-        
+
         $settings = $social_apps[$platform];
         $required_fields = $this->get_required_platform_fields( $platform );
-        
+
         foreach ( $required_fields as $field ) {
             if ( empty( $settings[$field] ) ) {
-                wp_send_json_success( array( 'status' => 'not_configured' ) );
+                wp_send_json_success(
+                    array(
+                        'status'  => 'not-configured',
+                        'message' => $status_messages['not-configured'],
+                    )
+                );
                 return;
             }
         }
-        
+
         // Quick validation - just check if credentials are present
-        wp_send_json_success( array( 'status' => 'configured' ) );
+        wp_send_json_success(
+            array(
+                'status'  => 'configured',
+                'message' => $status_messages['configured'],
+            )
+        );
     }
     
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-social-connections.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-social-connections.js
@@ -333,7 +333,8 @@
                 $platformConfig.addClass('success');
                 
                 // Update connection status
-                this.updateConnectionStatus(platform, 'connected');
+                const statusMessage = response && response.data ? response.data.message : '';
+                this.updateConnectionStatus(platform, 'connected', statusMessage);
                 
                 setTimeout(() => $platformConfig.removeClass('success'), 2000);
             } else {
@@ -381,10 +382,43 @@
         /**
          * Update connection status
          */
-        updateConnectionStatus: function(platform, status) {
-            const $statusElement = $(`.tts-connection-status[data-platform="${platform}"] .tts-status-${status}`);
-            $statusElement.siblings().hide();
-            $statusElement.show();
+        updateConnectionStatus: function(platform, status, message = '') {
+            if (!platform || !status) {
+                return;
+            }
+
+            const normalizedStatus = String(status).replace(/_/g, '-');
+            const $container = $(`.tts-connection-status[data-platform="${platform}"]`);
+
+            if (!$container.length) {
+                return;
+            }
+
+            const $statusElement = $container.find('.tts-status-message');
+
+            if (!$statusElement.length) {
+                return;
+            }
+
+            const statusMessages = {
+                'not-configured': 'App credentials not configured',
+                'configured': 'Ready to connect accounts',
+                'connected': 'Account connected',
+                'error': 'Connection error. Please try again.'
+            };
+
+            const knownStatuses = Object.keys(statusMessages);
+            const safeStatus = knownStatuses.includes(normalizedStatus) ? normalizedStatus : 'error';
+            const fallbackMessage = statusMessages[safeStatus] || statusMessages['error'];
+            const textToShow = message || fallbackMessage;
+            const statusClassPrefix = 'tts-status-';
+            const statusClasses = knownStatuses.map(state => `${statusClassPrefix}${state}`).join(' ');
+
+            $statusElement
+                .removeClass(statusClasses)
+                .addClass(`${statusClassPrefix}${safeStatus}`)
+                .text(textToShow)
+                .show();
         },
 
         /**
@@ -436,8 +470,13 @@
                 nonce: TTS.Core.config.nonce
             })
             .done((response) => {
-                if (response.success) {
-                    this.updateConnectionStatus(platform, response.data.status);
+                if (response.success && response.data) {
+                    const statusMessage = response.data.message || '';
+                    const status = response.data.status || '';
+
+                    if (status) {
+                        this.updateConnectionStatus(platform, status, statusMessage);
+                    }
                 }
             });
         }


### PR DESCRIPTION
## Summary
- give the connection status span a persistent class and style for the error state
- normalize quick connection check responses to include user-facing messages
- update the social connections script to rewrite a single status element with normalized states and optional messages

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cc6d327b80832faa4863abc9c687b0