### PR TITLE
Enable dashboard React bundle for administrators

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -435,9 +435,8 @@ class TTS_Admin {
      * @return bool
      */
     private function dashboard_needs_react_components() {
-        // Check if current user has capabilities that require React components
-        return current_user_can( 'manage_options' ) && 
-               get_option( 'tts_enable_advanced_ui', false );
+        // Load the React bundle for users who can manage the plugin.
+        return current_user_can( 'manage_options' );
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure the dashboard React bundle loads for users who can manage the plugin
- remove the unused feature flag gate so administrators always receive the React widgets

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d10df8649c832f82cbea72b5d39b1f