### PR TITLE
Use OAuth header for YouTube metrics requests

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
@@ -178,7 +178,8 @@ class TTS_Analytics {
             if ( json_last_error() === JSON_ERROR_NONE && is_array( $decoded ) ) {
                 $access_token = isset( $decoded['access_token'] ) ? $decoded['access_token'] : '';
                 $api_key      = isset( $decoded['api_key'] ) ? $decoded['api_key'] : '';
-            } elseif ( 0 === strpos( $raw_creds, 'AIza' ) ) {
+            } elseif ( preg_match( '/^[A-Za-z0-9_\-]{35,40}$/', $raw_creds ) ) {
+                // Assume this is a Google API key based on its format (typically 39 chars, alphanumeric, -, _)
                 $api_key = $raw_creds;
             } else {
                 $access_token = $raw_creds;

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
@@ -161,15 +161,48 @@ class TTS_Analytics {
             return new WP_Error( 'yt_no_id', __( 'Missing YouTube video ID', 'fp-publisher' ) );
         }
 
-        $endpoint = add_query_arg(
-            array(
-                'id'   => $remote_id,
-                'part' => 'statistics',
-                'key'  => $credentials,
-            ),
-            'https://www.googleapis.com/youtube/v3/videos'
+        $access_token = '';
+        $api_key      = '';
+
+        if ( is_object( $credentials ) ) {
+            $credentials = (array) $credentials;
+        }
+
+        if ( is_array( $credentials ) ) {
+            $access_token = isset( $credentials['access_token'] ) ? $credentials['access_token'] : '';
+            $api_key      = isset( $credentials['api_key'] ) ? $credentials['api_key'] : '';
+        } elseif ( is_string( $credentials ) ) {
+            $raw_creds = trim( $credentials );
+
+            $decoded = json_decode( $raw_creds, true );
+            if ( json_last_error() === JSON_ERROR_NONE && is_array( $decoded ) ) {
+                $access_token = isset( $decoded['access_token'] ) ? $decoded['access_token'] : '';
+                $api_key      = isset( $decoded['api_key'] ) ? $decoded['api_key'] : '';
+            } elseif ( 0 === strpos( $raw_creds, 'AIza' ) ) {
+                $api_key = $raw_creds;
+            } else {
+                $access_token = $raw_creds;
+            }
+        }
+
+        $query_args = array(
+            'id'   => $remote_id,
+            'part' => 'statistics',
         );
-        $response = wp_remote_get( $endpoint, array( 'timeout' => 20 ) );
+
+        if ( ! empty( $api_key ) ) {
+            $query_args['key'] = $api_key;
+        }
+
+        $request_args = array( 'timeout' => 20 );
+        if ( ! empty( $access_token ) ) {
+            $request_args['headers'] = array(
+                'Authorization' => 'Bearer ' . $access_token,
+            );
+        }
+
+        $endpoint = add_query_arg( $query_args, 'https://www.googleapis.com/youtube/v3/videos' );
+        $response = wp_remote_get( $endpoint, $request_args );
         if ( is_wp_error( $response ) ) {
             return $response;
         }


### PR DESCRIPTION
## Summary
- parse stored YouTube credentials to differentiate between OAuth tokens and API keys
- send analytics requests with a Bearer authorization header when an access token is available while still allowing legacy API key usage

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php

------
https://chatgpt.com/codex/tasks/task_e_68d11356384c832fa8d8cd79e2c5b515