### PR TITLE
Allow calendar to show already published posts

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-calendar-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-calendar-page.php
@@ -56,12 +56,6 @@ class TTS_Calendar_Page {
                         'compare' => '<=',
                         'type'    => 'DATETIME',
                     ),
-                    array(
-                        'key'     => '_tts_publish_at',
-                        'value'   => current_time( 'mysql' ),
-                        'compare' => '>=',
-                        'type'    => 'DATETIME',
-                    ),
                 ),
             )
         );


### PR DESCRIPTION
## Summary
- remove the calendar query filter that hid posts with publish dates in the past
- keep the month start and end filters so the view remains scoped to the selected month

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-calendar-page.php

------
https://chatgpt.com/codex/tasks/task_e_68d117a20ef0832f98a1c23c31dae028