### PR TITLE
Load AI admin features assets without feature flag

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -478,11 +478,6 @@ class TTS_Admin {
      * Enqueue AI features specific assets.
      */
     private function enqueue_ai_features_assets() {
-        // Only load large AI assets if user has premium features enabled
-        if ( ! get_option( 'tts_ai_features_enabled', false ) ) {
-            return;
-        }
-
         $js_version = filemtime( plugin_dir_path( __FILE__ ) . 'js/tts-advanced-features.js' );
         wp_enqueue_script(
             'tts-advanced-features',


### PR DESCRIPTION
## Summary
- ensure the AI admin JavaScript always loads by removing the hidden tts_ai_features_enabled gate while keeping existing dependencies

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d12f88ba04832f94b27d69f1fef8dc