### PR TITLE
Allow fetching social posts in any status

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-content-source.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-content-source.php
@@ -126,6 +126,7 @@ class TTS_Content_Source {
     public static function get_posts_by_source( $source, $args = array() ) {
         $default_args = array(
             'post_type'      => 'tts_social_post',
+            'post_status'    => 'any',
             'meta_query'     => array(
                 array(
                     'key'     => '_tts_content_source',


### PR DESCRIPTION
## Summary
- allow content source queries to include social posts in any status so drafts and pending items appear in listings

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-content-source.php

------
https://chatgpt.com/codex/tasks/task_e_68d14f3fd934832faa248b9baf8c6fc2