### PR TITLE
Allow retrieving unpublished content in source queries

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-content-source.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-content-source.php
@@ -138,7 +138,7 @@ class TTS_Content_Source {
     public static function get_posts_by_source( $source, $args = array() ) {
         $default_args = array(
             'post_type'      => 'tts_social_post',
-            'post_status'    => 'any',
+            'post_status'    => array( 'publish', 'draft', 'pending', 'future', 'private' ),
             'meta_query'     => array(
                 array(
                     'key'     => '_tts_content_source',


### PR DESCRIPTION
## Summary
- allow content source queries to include publish, draft, pending, future, and private posts by default

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-content-source.php

------
https://chatgpt.com/codex/tasks/task_e_68d151d80d40832f85288139f53312dc