### PR TITLE
Adjust dashboard post fetch statuses

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js
@@ -188,8 +188,14 @@ const Dashboard = () => {
 
     const fetchPosts = async () => {
         try {
-            const data = await apiFetch({ 
-                path: '/wp/v2/tts_social_post?per_page=100&status=any&_fields=id,title,meta,date' 
+            const statuses = ['publish', 'draft', 'pending', 'future', 'private'];
+            const nonPublicStatuses = ['draft', 'pending', 'future', 'private'];
+            const shouldIncludeContext = statuses.some((status) => nonPublicStatuses.includes(status));
+            const statusQuery = encodeURIComponent(statuses.join(','));
+            const contextQuery = shouldIncludeContext ? '&context=edit' : '';
+
+            const data = await apiFetch({
+                path: `/wp/v2/tts_social_post?per_page=100&status=${statusQuery}&_fields=id,title,meta,date${contextQuery}`
             });
             setPosts(data);
             setLastUpdate(new Date());


### PR DESCRIPTION
## Summary
- request the trello social posts endpoint with explicit publish, draft, pending, future, and private statuses
- add context=edit to the request when non-public statuses are included so private data remains accessible to the dashboard

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d162825270832f99ad0b5ae4ac56cc