### PR TITLE
Ensure workflow tables only install on activation

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-workflow-system.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-workflow-system.php
@@ -18,7 +18,6 @@ class TTS_Workflow_System {
      * Initialize workflow system.
      */
     public function __construct() {
-        add_action( 'init', array( $this, 'create_workflow_tables' ) );
         add_action( 'wp_ajax_tts_submit_for_approval', array( $this, 'ajax_submit_for_approval' ) );
         add_action( 'wp_ajax_tts_approve_content', array( $this, 'ajax_approve_content' ) );
         add_action( 'wp_ajax_tts_reject_content', array( $this, 'ajax_reject_content' ) );
@@ -35,11 +34,18 @@ class TTS_Workflow_System {
     }
 
     /**
+     * Install workflow database schema.
+     */
+    public static function install() {
+        self::create_workflow_tables();
+    }
+
+    /**
      * Create workflow-related database tables.
      */
-    public function create_workflow_tables() {
+    private static function create_workflow_tables() {
         global $wpdb;
-        
+
         $charset_collate = $wpdb->get_charset_collate();
         
         // Workflow states table

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -37,6 +37,12 @@ function tsap_plugin_activate() {
     if ( class_exists( 'TTS_Security_Audit' ) ) {
         TTS_Security_Audit::activate();
     }
+
+    require_once TSAP_PLUGIN_DIR . 'includes/class-tts-workflow-system.php';
+
+    if ( class_exists( 'TTS_Workflow_System' ) ) {
+        TTS_Workflow_System::install();
+    }
 }
 
 add_action( 'plugins_loaded', function () {


### PR DESCRIPTION
## Summary
- add a static installer to `TTS_Workflow_System` so table creation can run without instantiation
- call the workflow installer from the activation hook instead of on every request

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-workflow-system.php
- php -l wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php

------
https://chatgpt.com/codex/tasks/task_e_68d167ab26dc832fa969b7deddb4d069