### PR TITLE
Add nonces to client wizard steps

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -2072,6 +2072,17 @@ class TTS_Admin {
             echo '</form>';
         } elseif ( 3 === $step ) {
             echo '<form method="post" class="tts-wizard-step tts-step-3">';
+            $nonce_field = wp_nonce_field( 'tts_client_wizard', 'tts_wizard_nonce', true, false );
+            if ( isset( $_POST['tts_wizard_nonce'] ) ) {
+                $nonce_value = wp_unslash( $_POST['tts_wizard_nonce'] );
+                $nonce_field = preg_replace(
+                    '/value="[^"]*"/',
+                    'value="' . esc_attr( $nonce_value ) . '"',
+                    $nonce_field,
+                    1
+                );
+            }
+            echo $nonce_field; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             echo '<input type="hidden" name="step" value="4" />';
             echo '<input type="hidden" name="trello_key" value="' . esc_attr( $trello_key ) . '" />';
             echo '<input type="hidden" name="trello_token" value="' . esc_attr( $trello_token ) . '" />';
@@ -2134,6 +2145,17 @@ class TTS_Admin {
             }
 
             echo '<form method="post" class="tts-wizard-step tts-step-4">';
+            $nonce_field = wp_nonce_field( 'tts_client_wizard', 'tts_wizard_nonce', true, false );
+            if ( isset( $_POST['tts_wizard_nonce'] ) ) {
+                $nonce_value = wp_unslash( $_POST['tts_wizard_nonce'] );
+                $nonce_field = preg_replace(
+                    '/value="[^"]*"/',
+                    'value="' . esc_attr( $nonce_value ) . '"',
+                    $nonce_field,
+                    1
+                );
+            }
+            echo $nonce_field; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             echo '<input type="hidden" name="step" value="4" />';
             echo '<input type="hidden" name="finalize" value="1" />';
             echo '<input type="hidden" name="trello_key" value="' . esc_attr( $trello_key ) . '" />';


### PR DESCRIPTION
## Summary
- ensure the step 3 Trello list form outputs the client wizard nonce so submissions pass verification
- preserve the nonce when rendering the step 4 confirmation form so the finalize request succeeds

## Testing
- php /tmp/simulate_wizard.php


------
https://chatgpt.com/codex/tasks/task_e_68d171728f74832fae78e7a7be5be5d7