### PR TITLE
Ensure export modal submits AJAX request with nonce

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -4006,7 +4006,8 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         ?>
         <div class="tts-modal-content">
             <h2><?php esc_html_e( 'Export Data', 'fp-publisher' ); ?></h2>
-            <form id="tts-export-form">
+            <form id="tts-export-form" class="tts-ajax-form" data-ajax-action="tts_export_data">
+                <input type="hidden" name="nonce" value="<?php echo esc_attr( wp_create_nonce( 'tts_ajax_nonce' ) ); ?>">
                 <div class="tts-export-options">
                     <p class="description">
                         <?php esc_html_e( 'Sensitive credentials are excluded unless you explicitly include them below.', 'fp-publisher' ); ?>

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-core.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-core.js
@@ -209,8 +209,19 @@
             }
 
             const formData = new FormData($form[0]);
-            formData.append('action', action);
-            formData.append('nonce', this.config.nonce);
+
+            if (action === 'tts_export_data') {
+                $form.find('input[type="checkbox"]').each((index, checkbox) => {
+                    if (!checkbox.name) {
+                        return;
+                    }
+
+                    formData.set(checkbox.name, checkbox.checked ? 'true' : 'false');
+                });
+            }
+
+            formData.set('action', action);
+            formData.set('nonce', this.config.nonce);
 
             // Set loading state
             $submitBtn.addClass(this.config.loadingClass).prop('disabled', true);


### PR DESCRIPTION
## Summary
- update the export modal form to opt into the shared AJAX handling, include the action attribute, and embed the nonce field
- normalize checkbox values before dispatching the export AJAX call so PHP receives the expected true/false strings
- reuse the localized nonce inside AJAX form submissions to prevent duplicate values

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d17b1ff5c8832f956fb26e64e0bff7