### PR TITLE
Adjust security audit file access logic for admin contexts

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-security-audit.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-security-audit.php
@@ -381,13 +381,22 @@ class TTS_Security_Audit {
      */
     public function monitor_file_access() {
         $request_uri = $_SERVER['REQUEST_URI'] ?? '';
+
+        if ( empty( $request_uri ) ) {
+            return;
+        }
+
+        if ( ( function_exists( 'is_admin' ) && is_admin() ) ||
+             ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ||
+             false !== strpos( $request_uri, '/wp-admin/' ) ) {
+            return;
+        }
+
         $suspicious_patterns = array(
-            '\.php$',
             'wp-config',
             '\.sql$',
             '\.log$',
             'backup',
-            'admin\.php',
             'install\.php'
         );
         


### PR DESCRIPTION
## Summary
- skip monitoring suspicious file access when handling admin or AJAX requests
- narrow the list of suspicious path markers to reduce routine false positives

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-security-audit.php

------
https://chatgpt.com/codex/tasks/task_e_68d186a6fbd0832fb38c6be980761a38