### PR TITLE
Add secure metadata storage and token rotation hardening

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/SECURE-STORAGE.md
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/SECURE-STORAGE.md
@@ -1,0 +1,68 @@
+# Secure Storage and Token Management
+
+The FP Publisher plugin protects access tokens, application secrets and other
+sensitive metadata stored via `update_post_meta()` by transparently encrypting
+values at rest. The encryption layer is implemented in
+`TTS_Secure_Storage` and is loaded automatically when the plugin boots.
+
+## Encryption overview
+
+* Encryption uses OpenSSL AES-256-GCM with per-value IVs and integrity tags.
+* Managed keys can be provided through one of the following mechanisms:
+  * Environment variable `TTS_ENCRYPTION_KEY` containing a 32-byte key (raw,
+    hex encoded or base64 encoded).
+  * The `TTS_ENCRYPTION_KEY` PHP constant for static deployments.
+  * Custom providers can hook `tts_secure_storage_managed_key` or
+    `tts_secure_storage_resolve_key_by_id` to fetch keys from an external
+    vault, HSM or KMS.
+* Stored payloads include the key identifier so that rotated keys can be
+  resolved on demand.
+
+## Vault integrations
+
+`TTS_Secure_Storage::resolve_managed_secret()` supports declarative secret
+references in options and metadata. The following syntaxes are available:
+
+* `vault:aws-kms:<alias-or-arn>` &mdash; resolved through the
+  `tts_vault_resolve_aws-kms` filter. Use this to proxy requests to AWS KMS or
+  Secrets Manager.
+* `vault:hashicorp:<path>#<field>` (or any custom prefix) &mdash; handled via
+  provider-specific filters (`tts_vault_resolve_hashicorp`, etc.).
+* `env:NAME` &mdash; convenience helper to resolve values from environment
+  variables.
+
+Additional providers can be registered through the
+`tts_resolve_managed_secret` filter.
+
+## Token rotation
+
+`TTS_Token_Refresh` coordinates scheduled token refresh operations. Enhancements
+include:
+
+* Automatic rotation when tokens are near expiry (within 24 hours by default).
+* Rotation throttling to avoid unnecessary requests when tokens were refreshed
+  recently.
+* Safe fallbacks that retain the previous token value and update rotation
+  metadata (`*_token_previous`, `*_token_rotated_at`, `*_token_expires_at`).
+* Compatibility with vault-managed application secrets via the secure storage
+  resolvers described above.
+
+The refresh workflow raises the `tts_token_refresh_persist_token` filter to
+allow custom storage backends to persist refreshed tokens.
+
+## Security audit retention
+
+Security audit log payloads are encrypted before insertion into the custom log
+table and are automatically masked before being exposed to administrators. Log
+retention defaults to the following policy (in days):
+
+| Risk level | Retention |
+|------------|-----------|
+| Low        | 30        |
+| Medium     | 90        |
+| High       | 180       |
+| Critical   | 365       |
+
+The policy can be customised using the `tts_security_audit_retention_policy`
+filter. Manual cleanup requests honour the maximum retention allowed by the
+policy to ensure compliance with data governance requirements.

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-secure-storage.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-secure-storage.php
@@ -1,0 +1,733 @@
+<?php
+/**
+ * Secure storage utilities for secrets and sensitive metadata.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Provides helpers for encrypting and decrypting sensitive data at rest.
+ */
+class TTS_Secure_Storage {
+
+    const ENCRYPTION_PREFIX = 'tts-secure::';
+    const ENCRYPTION_VERSION = 1;
+    const CIPHER_METHOD = 'aes-256-gcm';
+
+    /**
+     * Singleton instance.
+     *
+     * @var TTS_Secure_Storage|null
+     */
+    private static $instance = null;
+
+    /**
+     * Runtime cache of decrypted meta values.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private $decrypted_meta_cache = array();
+
+    /**
+     * Runtime cache of encrypted meta values.
+     *
+     * @var array<int, array<string, string>>
+     */
+    private $encrypted_meta_cache = array();
+
+    /**
+     * Indicates whether metadata filters are temporarily suspended.
+     *
+     * @var bool
+     */
+    private $suspended = false;
+
+    /**
+     * Cached managed key material keyed by key identifier.
+     *
+     * @var array<string, array{key: string, key_id: string}>
+     */
+    private $managed_keys = array();
+
+    /**
+     * Cached list of explicitly sensitive meta keys.
+     *
+     * @var array<int, string>
+     */
+    private $sensitive_meta_keys = array(
+        '_tts_trello_key',
+        '_tts_trello_token',
+        '_tts_fb_token',
+        '_tts_ig_token',
+        '_tts_yt_token',
+        '_tts_tt_token',
+        '_tts_trello_map',
+        '_tts_publish_log',
+    );
+
+    /**
+     * Retrieve the shared instance.
+     *
+     * @return TTS_Secure_Storage
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Register WordPress hooks.
+     */
+    private function __construct() {
+        $this->sensitive_meta_keys = apply_filters( 'tts_sensitive_meta_keys', $this->sensitive_meta_keys );
+
+        if ( function_exists( 'add_filter' ) ) {
+            add_filter( 'add_post_metadata', array( $this, 'filter_add_post_metadata' ), 10, 5 );
+            add_filter( 'update_post_metadata', array( $this, 'filter_update_post_metadata' ), 10, 5 );
+            add_filter( 'get_post_metadata', array( $this, 'filter_get_post_metadata' ), 10, 4 );
+        }
+    }
+
+    /**
+     * Encrypt metadata values before insertion.
+     *
+     * @param null|bool $check      Short-circuit flag.
+     * @param int        $object_id Post ID.
+     * @param string     $meta_key  Meta key.
+     * @param mixed      $meta_value Meta value.
+     * @param bool       $unique    Whether meta key should be unique.
+     *
+     * @return mixed
+     */
+    public function filter_add_post_metadata( $check, $object_id, $meta_key, $meta_value, $unique ) {
+        if ( $this->suspended || ! $this->should_secure_meta( $meta_key, $meta_value ) ) {
+            return $check;
+        }
+
+        $encrypted = $this->encrypt_for_storage(
+            $meta_value,
+            array(
+                'meta_key' => $meta_key,
+                'post_id'  => $object_id,
+                'reason'   => 'add_post_meta',
+            )
+        );
+
+        if ( false === $encrypted ) {
+            return $check;
+        }
+
+        $this->remember_meta_value( $object_id, $meta_key, $meta_value, $encrypted );
+
+        return $this->run_while_suspended( function () use ( $object_id, $meta_key, $encrypted, $unique ) {
+            return add_post_meta( $object_id, $meta_key, $encrypted, $unique );
+        } );
+    }
+
+    /**
+     * Encrypt metadata values prior to update.
+     *
+     * @param null|bool $check      Short-circuit flag.
+     * @param int        $object_id Post ID.
+     * @param string     $meta_key  Meta key.
+     * @param mixed      $meta_value Meta value.
+     * @param mixed      $prev_value Previous value.
+     *
+     * @return mixed
+     */
+    public function filter_update_post_metadata( $check, $object_id, $meta_key, $meta_value, $prev_value ) {
+        if ( $this->suspended || ! $this->should_secure_meta( $meta_key, $meta_value ) ) {
+            return $check;
+        }
+
+        $encrypted = $this->encrypt_for_storage(
+            $meta_value,
+            array(
+                'meta_key' => $meta_key,
+                'post_id'  => $object_id,
+                'reason'   => 'update_post_meta',
+            )
+        );
+
+        if ( false === $encrypted ) {
+            return $check;
+        }
+
+        $this->remember_meta_value( $object_id, $meta_key, $meta_value, $encrypted );
+
+        return $this->run_while_suspended( function () use ( $object_id, $meta_key, $encrypted, $prev_value ) {
+            return update_post_meta( $object_id, $meta_key, $encrypted, $prev_value );
+        } );
+    }
+
+    /**
+     * Decrypt metadata values when retrieved.
+     *
+     * @param null|mixed $value     Short-circuit value.
+     * @param int        $object_id Post ID.
+     * @param string     $meta_key  Meta key.
+     * @param bool       $single    Whether to return a single value.
+     *
+     * @return mixed
+     */
+    public function filter_get_post_metadata( $value, $object_id, $meta_key, $single ) {
+        if ( $this->suspended || '' === $meta_key || ! $this->should_secure_meta( $meta_key, null ) ) {
+            return $value;
+        }
+
+        $cache_key = $this->build_cache_key( $object_id, $meta_key );
+
+        if ( isset( $this->decrypted_meta_cache[ $cache_key ] ) ) {
+            $decrypted = $this->decrypted_meta_cache[ $cache_key ];
+        } else {
+            $encrypted = $this->fetch_encrypted_meta( $object_id, $meta_key );
+
+            if ( null === $encrypted ) {
+                return $value;
+            }
+
+            $decrypted = $this->decrypt_from_storage(
+                $encrypted,
+                array(
+                    'meta_key' => $meta_key,
+                    'post_id'  => $object_id,
+                    'reason'   => 'get_post_meta',
+                )
+            );
+
+            $this->decrypted_meta_cache[ $cache_key ] = $decrypted;
+        }
+
+        if ( $single ) {
+            return $decrypted;
+        }
+
+        return array( $decrypted );
+    }
+
+    /**
+     * Encrypt an arbitrary value for storage.
+     *
+     * @param mixed $value   Value to encrypt.
+     * @param array $context Contextual information for key resolution.
+     *
+     * @return string|false
+     */
+    public function encrypt_for_storage( $value, $context = array() ) {
+        if ( is_string( $value ) && $this->is_encrypted_string( $value ) ) {
+            return $value;
+        }
+
+        $key_info = $this->get_encryption_key( $context );
+
+        if ( empty( $key_info['key'] ) ) {
+            $this->log_security_warning( 'Unable to resolve encryption key for secure storage.', $context );
+            return false;
+        }
+
+        $plain_value   = $this->normalize_plain_value( $value );
+        $iv_length     = openssl_cipher_iv_length( self::CIPHER_METHOD );
+        $iv            = random_bytes( $iv_length );
+        $tag           = '';
+        $ciphertext    = openssl_encrypt( $plain_value, self::CIPHER_METHOD, $key_info['key'], OPENSSL_RAW_DATA, $iv, $tag );
+
+        if ( false === $ciphertext ) {
+            $this->log_security_warning( 'OpenSSL failed to encrypt metadata payload.', $context );
+            return false;
+        }
+
+        $payload = array(
+            'v'       => self::ENCRYPTION_VERSION,
+            'key_id'  => $key_info['key_id'],
+            'iv'      => base64_encode( $iv ),
+            'tag'     => base64_encode( $tag ),
+            'cipher'  => base64_encode( $ciphertext ),
+            'encoded' => is_string( $value ) ? 'string' : 'serialized',
+        );
+
+        $json = wp_json_encode( $payload );
+
+        if ( false === $json ) {
+            $this->log_security_warning( 'Unable to encode encryption payload for storage.', $context );
+            return false;
+        }
+
+        return self::ENCRYPTION_PREFIX . base64_encode( $json );
+    }
+
+    /**
+     * Decrypt a value previously produced by encrypt_for_storage().
+     *
+     * @param mixed $value   Stored value.
+     * @param array $context Contextual information for key resolution.
+     *
+     * @return mixed
+     */
+    public function decrypt_from_storage( $value, $context = array() ) {
+        if ( ! is_string( $value ) || ! $this->is_encrypted_string( $value ) ) {
+            return maybe_unserialize( $value );
+        }
+
+        $encoded = substr( $value, strlen( self::ENCRYPTION_PREFIX ) );
+        $decoded = base64_decode( $encoded, true );
+
+        if ( false === $decoded ) {
+            $this->log_security_warning( 'Secure payload could not be base64 decoded.', $context );
+            return maybe_unserialize( $value );
+        }
+
+        $payload = json_decode( $decoded, true );
+
+        if ( ! is_array( $payload ) || empty( $payload['cipher'] ) || empty( $payload['iv'] ) ) {
+            $this->log_security_warning( 'Secure payload structure is invalid.', $context );
+            return maybe_unserialize( $value );
+        }
+
+        $key_info = $this->get_encryption_key( $context, isset( $payload['key_id'] ) ? (string) $payload['key_id'] : null );
+
+        if ( empty( $key_info['key'] ) ) {
+            $this->log_security_warning( 'Unable to resolve key for secure payload decryption.', $context );
+            return maybe_unserialize( $value );
+        }
+
+        $ciphertext = base64_decode( $payload['cipher'], true );
+        $iv         = base64_decode( $payload['iv'], true );
+        $tag        = isset( $payload['tag'] ) ? base64_decode( (string) $payload['tag'], true ) : '';
+
+        if ( false === $ciphertext || false === $iv ) {
+            $this->log_security_warning( 'Secure payload contains invalid binary data.', $context );
+            return maybe_unserialize( $value );
+        }
+
+        $plain = openssl_decrypt( $ciphertext, self::CIPHER_METHOD, $key_info['key'], OPENSSL_RAW_DATA, $iv, $tag );
+
+        if ( false === $plain ) {
+            $this->log_security_warning( 'OpenSSL failed to decrypt secure payload.', $context );
+            return maybe_unserialize( $value );
+        }
+
+        if ( isset( $payload['encoded'] ) && 'string' === $payload['encoded'] ) {
+            return $plain;
+        }
+
+        return maybe_unserialize( $plain );
+    }
+
+    /**
+     * Mask sensitive data before presenting it externally.
+     *
+     * @param mixed $data              Data to mask.
+     * @param array $additional_fields Additional keys to mask.
+     *
+     * @return mixed
+     */
+    public function mask_sensitive_data( $data, $additional_fields = array() ) {
+        if ( is_scalar( $data ) || null === $data ) {
+            return $this->mask_scalar( $data );
+        }
+
+        if ( is_object( $data ) ) {
+            $data = json_decode( wp_json_encode( $data ), true );
+        }
+
+        if ( ! is_array( $data ) ) {
+            return $data;
+        }
+
+        $sensitive_keys = array_merge(
+            array( 'token', 'secret', 'password', 'credential', 'auth', 'session', 'signature', 'key', 'bearer' ),
+            array_map( 'strtolower', array_filter( (array) $additional_fields ) )
+        );
+
+        $masked = array();
+
+        foreach ( $data as $key => $value ) {
+            if ( is_array( $value ) || is_object( $value ) ) {
+                $masked[ $key ] = $this->mask_sensitive_data( $value, $additional_fields );
+                continue;
+            }
+
+            $lower_key = strtolower( (string) $key );
+            $should_mask = false;
+
+            foreach ( $sensitive_keys as $needle ) {
+                if ( '' === $needle ) {
+                    continue;
+                }
+
+                if ( false !== strpos( $lower_key, $needle ) ) {
+                    $should_mask = true;
+                    break;
+                }
+            }
+
+            $masked[ $key ] = $should_mask ? $this->mask_scalar( $value ) : $value;
+        }
+
+        return $masked;
+    }
+
+    /**
+     * Resolve secrets stored using managed vault notations.
+     *
+     * @param mixed $value   Value or reference.
+     * @param array $context Contextual data.
+     *
+     * @return mixed
+     */
+    public function resolve_managed_secret( $value, $context = array() ) {
+        if ( ! is_string( $value ) ) {
+            return $value;
+        }
+
+        if ( 0 === strpos( $value, 'env:' ) ) {
+            $env_key = substr( $value, 4 );
+            $env_val = getenv( $env_key );
+            return false !== $env_val ? $env_val : '';
+        }
+
+        if ( 0 === strpos( $value, 'vault:' ) ) {
+            $parts = explode( ':', $value, 3 );
+            if ( count( $parts ) >= 3 ) {
+                $provider  = strtolower( $parts[1] );
+                $reference = $parts[2];
+
+                $filtered = apply_filters( 'tts_vault_resolve_' . $provider, null, $reference, $context );
+                if ( null !== $filtered ) {
+                    return $filtered;
+                }
+            }
+        }
+
+        return apply_filters( 'tts_resolve_managed_secret', $value, $context );
+    }
+
+    /**
+     * Check whether the provided value already uses the secure prefix.
+     *
+     * @param mixed $value Value to inspect.
+     *
+     * @return bool
+     */
+    public function is_encrypted_string( $value ) {
+        return is_string( $value ) && 0 === strpos( $value, self::ENCRYPTION_PREFIX );
+    }
+
+    /**
+     * Determine whether the provided meta key should be encrypted.
+     *
+     * @param string $meta_key Meta key.
+     * @param mixed  $meta_value Meta value.
+     *
+     * @return bool
+     */
+    private function should_secure_meta( $meta_key, $meta_value ) {
+        if ( '' === $meta_key ) {
+            return false;
+        }
+
+        $meta_key = (string) $meta_key;
+
+        if ( in_array( $meta_key, $this->sensitive_meta_keys, true ) ) {
+            return true;
+        }
+
+        $lower_key = strtolower( $meta_key );
+        $patterns  = array( '_token', 'token_', '_secret', 'secret_', '_credential', '_password', 'password_', '_auth', 'auth_', '_key' );
+
+        foreach ( $patterns as $pattern ) {
+            if ( false !== strpos( $lower_key, $pattern ) ) {
+                return true;
+            }
+        }
+
+        return apply_filters( 'tts_should_secure_meta_key', false, $meta_key, $meta_value );
+    }
+
+    /**
+     * Fetch encrypted metadata from runtime cache or database.
+     *
+     * @param int    $object_id Post ID.
+     * @param string $meta_key  Meta key.
+     *
+     * @return string|null
+     */
+    private function fetch_encrypted_meta( $object_id, $meta_key ) {
+        if ( isset( $this->encrypted_meta_cache[ $object_id ][ $meta_key ] ) ) {
+            return $this->encrypted_meta_cache[ $object_id ][ $meta_key ];
+        }
+
+        global $wpdb;
+
+        if ( ! isset( $wpdb ) || ! isset( $wpdb->postmeta ) ) {
+            return null;
+        }
+
+        $table = $wpdb->postmeta;
+
+        if ( method_exists( $wpdb, 'prepare' ) ) {
+            $sql = $wpdb->prepare(
+                "SELECT meta_value FROM {$table} WHERE post_id = %d AND meta_key = %s ORDER BY meta_id DESC LIMIT 1",
+                $object_id,
+                $meta_key
+            );
+        } else {
+            $object_id = (int) $object_id;
+            $meta_key  = addslashes( (string) $meta_key );
+            $sql       = "SELECT meta_value FROM {$table} WHERE post_id = {$object_id} AND meta_key = '{$meta_key}' ORDER BY meta_id DESC LIMIT 1";
+        }
+
+        if ( method_exists( $wpdb, 'get_var' ) ) {
+            $value = $wpdb->get_var( $sql );
+        } else {
+            $value = null;
+        }
+
+        if ( null !== $value ) {
+            $this->encrypted_meta_cache[ $object_id ][ $meta_key ] = $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Derive plain string representation for encryption.
+     *
+     * @param mixed $value Value to normalize.
+     *
+     * @return string
+     */
+    private function normalize_plain_value( $value ) {
+        if ( is_string( $value ) ) {
+            return $value;
+        }
+
+        if ( is_scalar( $value ) || null === $value ) {
+            return (string) $value;
+        }
+
+        return maybe_serialize( $value );
+    }
+
+    /**
+     * Build cache key for metadata cache.
+     *
+     * @param int    $object_id Post ID.
+     * @param string $meta_key  Meta key.
+     *
+     * @return string
+     */
+    private function build_cache_key( $object_id, $meta_key ) {
+        return $object_id . ':' . $meta_key;
+    }
+
+    /**
+     * Temporarily suspend metadata interception while executing a callback.
+     *
+     * @param callable $callback Callback to execute.
+     *
+     * @return mixed
+     */
+    private function run_while_suspended( $callback ) {
+        $previous        = $this->suspended;
+        $this->suspended = true;
+
+        try {
+            $result = call_user_func( $callback );
+        } finally {
+            $this->suspended = $previous;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Cache encrypted and decrypted meta values for reuse within the request.
+     *
+     * @param int    $object_id Post ID.
+     * @param string $meta_key  Meta key.
+     * @param mixed  $meta_value Original value.
+     * @param string $encrypted Encrypted payload.
+     */
+    private function remember_meta_value( $object_id, $meta_key, $meta_value, $encrypted ) {
+        $cache_key = $this->build_cache_key( $object_id, $meta_key );
+        $this->decrypted_meta_cache[ $cache_key ]       = maybe_unserialize( $meta_value );
+        $this->encrypted_meta_cache[ $object_id ][ $meta_key ] = $encrypted;
+    }
+
+    /**
+     * Retrieve an encryption key from managed storage.
+     *
+     * @param array       $context Contextual information.
+     * @param string|null $requested_key_id Specific key identifier if provided.
+     *
+     * @return array{key: string, key_id: string}
+     */
+    private function get_encryption_key( $context = array(), $requested_key_id = null ) {
+        $cache_key = $requested_key_id ?: 'default';
+
+        if ( isset( $this->managed_keys[ $cache_key ] ) ) {
+            return $this->managed_keys[ $cache_key ];
+        }
+
+        $context = is_array( $context ) ? $context : array();
+
+        if ( null !== $requested_key_id ) {
+            $resolved = apply_filters( 'tts_secure_storage_resolve_key_by_id', null, $requested_key_id, $context );
+            if ( is_string( $resolved ) && '' !== $resolved ) {
+                $key_material = $this->normalize_key_material( $resolved );
+                if ( $key_material ) {
+                    $this->managed_keys[ $requested_key_id ] = array(
+                        'key'    => $key_material,
+                        'key_id' => $requested_key_id,
+                    );
+                    return $this->managed_keys[ $requested_key_id ];
+                }
+            }
+        }
+
+        $default_source = $this->get_default_key_material();
+        $managed        = apply_filters( 'tts_secure_storage_managed_key', $default_source, $context, $requested_key_id );
+
+        $key_string = '';
+        $key_id     = 'default';
+
+        if ( is_array( $managed ) ) {
+            if ( isset( $managed['key'] ) ) {
+                $key_string = (string) $managed['key'];
+            }
+            if ( isset( $managed['key_id'] ) ) {
+                $key_id = (string) $managed['key_id'];
+            }
+        } elseif ( is_string( $managed ) && '' !== $managed ) {
+            $key_string = $managed;
+        }
+
+        if ( '' === $key_string && isset( $default_source['key'] ) ) {
+            $key_string = (string) $default_source['key'];
+        }
+
+        $resolved_secret = $this->resolve_managed_secret( $key_string, $context );
+        $key_material    = $this->normalize_key_material( $resolved_secret );
+
+        if ( ! $key_material ) {
+            $this->log_security_warning( 'Managed key material could not be resolved.', $context );
+            return array( 'key' => '', 'key_id' => $key_id );
+        }
+
+        $this->managed_keys[ $cache_key ] = array(
+            'key'    => $key_material,
+            'key_id' => $key_id,
+        );
+
+        return $this->managed_keys[ $cache_key ];
+    }
+
+    /**
+     * Retrieve default key material based on environment values.
+     *
+     * @return array{key: string, key_id: string}
+     */
+    private function get_default_key_material() {
+        $candidates = array(
+            defined( 'TTS_ENCRYPTION_KEY' ) ? TTS_ENCRYPTION_KEY : '',
+            getenv( 'TTS_ENCRYPTION_KEY' ),
+            defined( 'AUTH_KEY' ) ? AUTH_KEY : '',
+            defined( 'SECURE_AUTH_KEY' ) ? SECURE_AUTH_KEY : '',
+            defined( 'LOGGED_IN_KEY' ) ? LOGGED_IN_KEY : '',
+        );
+
+        foreach ( $candidates as $candidate ) {
+            if ( is_string( $candidate ) && '' !== $candidate ) {
+                return array(
+                    'key'    => $candidate,
+                    'key_id' => 'default',
+                );
+            }
+        }
+
+        return array(
+            'key'    => hash( 'sha256', __FILE__ ),
+            'key_id' => 'generated-default',
+        );
+    }
+
+    /**
+     * Normalize key material into a 32-byte binary string.
+     *
+     * @param mixed $key_material Raw key material.
+     *
+     * @return string
+     */
+    private function normalize_key_material( $key_material ) {
+        if ( ! is_string( $key_material ) || '' === $key_material ) {
+            return '';
+        }
+
+        $key_material = trim( $key_material );
+
+        if ( strlen( $key_material ) === 44 ) {
+            $decoded = base64_decode( $key_material, true );
+            if ( false !== $decoded && 32 === strlen( $decoded ) ) {
+                return $decoded;
+            }
+        }
+
+        if ( preg_match( '/^[a-f0-9]{64}$/i', $key_material ) ) {
+            $decoded = pack( 'H*', $key_material );
+            if ( 32 === strlen( $decoded ) ) {
+                return $decoded;
+            }
+        }
+
+        if ( strlen( $key_material ) >= 32 ) {
+            return substr( $key_material, 0, 32 );
+        }
+
+        return hash( 'sha256', $key_material, true );
+    }
+
+    /**
+     * Mask scalar value by preserving limited context.
+     *
+     * @param mixed $value Value to mask.
+     *
+     * @return mixed
+     */
+    private function mask_scalar( $value ) {
+        if ( ! is_scalar( $value ) || '' === (string) $value ) {
+            return $value;
+        }
+
+        $value = (string) $value;
+        $length = strlen( $value );
+
+        if ( $length <= 4 ) {
+            return str_repeat( '*', $length );
+        }
+
+        $prefix = substr( $value, 0, 3 );
+        $suffix = substr( $value, -2 );
+
+        return $prefix . str_repeat( '*', max( 1, $length - 5 ) ) . $suffix;
+    }
+
+    /**
+     * Log a warning using the plugin logger when available.
+     *
+     * @param string $message Warning message.
+     * @param array  $context Contextual data.
+     */
+    private function log_security_warning( $message, $context = array() ) {
+        if ( class_exists( 'TTS_Logger' ) ) {
+            TTS_Logger::log( $message, 'warning', array_merge( (array) $context, array( 'component' => 'secure_storage' ) ) );
+        }
+    }
+}

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-security-audit.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-security-audit.php
@@ -19,6 +19,26 @@ class TTS_Security_Audit {
     private $api_abuse_threshold = 300;
 
     /**
+     * Secure storage utility for encryption and masking.
+     *
+     * @var TTS_Secure_Storage|null
+     */
+    private $secure_storage = null;
+
+    /**
+     * Default retention policy (days) per risk level.
+     *
+     * @var array<int|string, int>
+     */
+    private $retention_policy = array(
+        self::RISK_LOW      => 30,
+        self::RISK_MEDIUM   => 90,
+        self::RISK_HIGH     => 180,
+        self::RISK_CRITICAL => 365,
+        'default'           => 90,
+    );
+
+    /**
      * Event types for security auditing
      */
     const EVENT_LOGIN_ATTEMPT = 'login_attempt';
@@ -45,6 +65,10 @@ class TTS_Security_Audit {
      */
     public function __construct() {
         $this->ensure_audit_table_exists();
+
+        if ( class_exists( 'TTS_Secure_Storage' ) ) {
+            $this->secure_storage = TTS_Secure_Storage::instance();
+        }
 
         add_action( 'init', array( $this, 'init_security_monitoring' ) );
         add_action( 'wp_ajax_tts_get_security_audit', array( $this, 'ajax_get_security_audit' ) );
@@ -170,7 +194,7 @@ class TTS_Security_Audit {
                 'ip_address' => $this->get_client_ip(),
                 'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
                 'request_uri' => $_SERVER['REQUEST_URI'] ?? '',
-                'event_data' => wp_json_encode( $event_data ),
+                'event_data' => $this->prepare_event_data_for_storage( $event_data, $event_type ),
                 'timestamp' => current_time( 'mysql' )
             ),
             array( '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s' )
@@ -842,7 +866,18 @@ class TTS_Security_Audit {
             $query = $wpdb->prepare( $query, $where_values );
         }
         
-        return $wpdb->get_results( $query );
+        $logs = $wpdb->get_results( $query );
+
+        if ( empty( $logs ) ) {
+            return array();
+        }
+
+        foreach ( $logs as $index => $log ) {
+            $event_type = isset( $log->event_type ) ? (string) $log->event_type : '';
+            $logs[ $index ]->event_data = $this->prepare_event_data_for_display( $log->event_data, $event_type );
+        }
+
+        return $logs;
     }
 
     /**
@@ -990,6 +1025,13 @@ class TTS_Security_Audit {
         $table_name = $wpdb->prefix . $this->audit_table;
         
         $days_to_keep = max( 1, intval( $_POST['days_to_keep'] ?? 30 ) );
+        $policy       = $this->get_retention_policy();
+        $max_days     = $this->get_max_retention_days( $policy );
+
+        if ( $max_days > 0 ) {
+            $days_to_keep = min( $days_to_keep, $max_days );
+        }
+
         $cutoff_date = date( 'Y-m-d H:i:s', time() - ( $days_to_keep * DAY_IN_SECONDS ) );
         
         $deleted = $wpdb->query(
@@ -1010,18 +1052,29 @@ class TTS_Security_Audit {
      */
     public function cleanup_old_logs() {
         global $wpdb;
-        
+
         $table_name = $wpdb->prefix . $this->audit_table;
-        
-        // Delete logs older than 90 days
-        $cutoff_date = date( 'Y-m-d H:i:s', time() - ( 90 * DAY_IN_SECONDS ) );
-        
-        $deleted = $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM $table_name WHERE timestamp < %s",
-                $cutoff_date
-            )
-        );
+        $policy     = $this->get_retention_policy();
+
+        $deleted_total = 0;
+
+        foreach ( array( self::RISK_LOW, self::RISK_MEDIUM, self::RISK_HIGH, self::RISK_CRITICAL ) as $risk_level ) {
+            $days = isset( $policy[ $risk_level ] ) ? (int) $policy[ $risk_level ] : (int) $policy['default'];
+
+            if ( $days <= 0 ) {
+                continue;
+            }
+
+            $cutoff_date = date( 'Y-m-d H:i:s', time() - ( $days * DAY_IN_SECONDS ) );
+
+            $deleted_total += (int) $wpdb->query(
+                $wpdb->prepare(
+                    "DELETE FROM $table_name WHERE risk_level = %d AND timestamp < %s",
+                    $risk_level,
+                    $cutoff_date
+                )
+            );
+        }
         
         // Ensure table doesn't exceed max entries
         $total_entries = $wpdb->get_var( "SELECT COUNT(*) FROM $table_name" );
@@ -1033,9 +1086,146 @@ class TTS_Security_Audit {
             );
         }
         
-        if ( $deleted > 0 ) {
-            TTS_Logger::log( "Security audit cleanup: Deleted $deleted old log entries" );
+        if ( $deleted_total > 0 ) {
+            TTS_Logger::log( "Security audit cleanup: Deleted $deleted_total old log entries" );
         }
+    }
+
+    /**
+     * Prepare event data payload for encrypted storage.
+     *
+     * @param array  $event_data Event payload.
+     * @param string $event_type Event type identifier.
+     *
+     * @return string
+     */
+    private function prepare_event_data_for_storage( $event_data, $event_type ) {
+        $event_data = is_array( $event_data ) ? $event_data : (array) $event_data;
+
+        if ( $this->secure_storage ) {
+            $encrypted = $this->secure_storage->encrypt_for_storage(
+                $event_data,
+                array(
+                    'context'    => 'security_audit',
+                    'event_type' => $event_type,
+                )
+            );
+
+            if ( false !== $encrypted && ! empty( $encrypted ) ) {
+                return $encrypted;
+            }
+        }
+
+        $encoded = wp_json_encode( $event_data );
+
+        if ( false === $encoded ) {
+            $encoded = maybe_serialize( $event_data );
+        }
+
+        return $encoded;
+    }
+
+    /**
+     * Prepare stored event data for presentation to administrators.
+     *
+     * @param mixed  $stored     Stored payload.
+     * @param string $event_type Event type identifier.
+     *
+     * @return array
+     */
+    private function prepare_event_data_for_display( $stored, $event_type ) {
+        $decoded = array();
+
+        if ( $this->secure_storage && is_string( $stored ) && $this->secure_storage->is_encrypted_string( $stored ) ) {
+            $decoded = $this->secure_storage->decrypt_from_storage(
+                $stored,
+                array(
+                    'context'    => 'security_audit',
+                    'event_type' => $event_type,
+                )
+            );
+        } elseif ( is_string( $stored ) && '' !== $stored ) {
+            $json = json_decode( $stored, true );
+
+            if ( JSON_ERROR_NONE === json_last_error() ) {
+                $decoded = $json;
+            } else {
+                $maybe = maybe_unserialize( $stored );
+                if ( is_array( $maybe ) ) {
+                    $decoded = $maybe;
+                }
+            }
+        } elseif ( is_array( $stored ) ) {
+            $decoded = $stored;
+        }
+
+        if ( ! is_array( $decoded ) ) {
+            $decoded = array();
+        }
+
+        return $this->mask_event_data( $decoded );
+    }
+
+    /**
+     * Mask sensitive fields within an event payload.
+     *
+     * @param array $event_data Event payload.
+     *
+     * @return array
+     */
+    private function mask_event_data( $event_data ) {
+        if ( ! $this->secure_storage ) {
+            return $event_data;
+        }
+
+        $additional_fields = apply_filters(
+            'tts_security_audit_mask_fields',
+            array( 'session_id', 'user_email', 'post_data' )
+        );
+
+        return $this->secure_storage->mask_sensitive_data( $event_data, $additional_fields );
+    }
+
+    /**
+     * Retrieve the configured retention policy.
+     *
+     * @return array<int|string, int>
+     */
+    private function get_retention_policy() {
+        $policy = apply_filters( 'tts_security_audit_retention_policy', $this->retention_policy );
+
+        if ( ! is_array( $policy ) ) {
+            $policy = $this->retention_policy;
+        }
+
+        if ( ! isset( $policy['default'] ) ) {
+            $policy['default'] = $this->retention_policy['default'];
+        }
+
+        foreach ( $policy as $key => $value ) {
+            $policy[ $key ] = max( 0, intval( $value ) );
+        }
+
+        return $policy;
+    }
+
+    /**
+     * Determine the maximum retention period allowed by policy.
+     *
+     * @param array<int|string, int>|null $policy Optional policy override.
+     *
+     * @return int
+     */
+    private function get_max_retention_days( $policy = null ) {
+        $policy = is_array( $policy ) ? $policy : $this->get_retention_policy();
+
+        $values = array_filter( array_map( 'intval', $policy ) );
+
+        if ( empty( $values ) ) {
+            return 0;
+        }
+
+        return max( $values );
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-token-refresh.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-token-refresh.php
@@ -14,10 +14,43 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class TTS_Token_Refresh {
 
+    const EXPIRY_REFRESH_THRESHOLD = DAY_IN_SECONDS;
+    const DEFAULT_ROTATION_INTERVAL = WEEK_IN_SECONDS;
+    const MINIMUM_ROTATION_INTERVAL = HOUR_IN_SECONDS;
+
+    /**
+     * Shared secure storage instance.
+     *
+     * @var TTS_Secure_Storage|null
+     */
+    private static $secure_storage = null;
+
+    /**
+     * Metadata configuration per channel.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private static $token_meta_map = array(
+        'facebook'  => array(
+            'meta'          => '_tts_fb_token',
+            'previous_meta' => '_tts_fb_token_previous',
+            'expires_meta'  => '_tts_fb_token_expires_at',
+            'rotated_meta'  => '_tts_fb_token_rotated_at',
+        ),
+        'instagram' => array(
+            'meta'          => '_tts_ig_token',
+            'previous_meta' => '_tts_ig_token_previous',
+            'expires_meta'  => '_tts_ig_token_expires_at',
+            'rotated_meta'  => '_tts_ig_token_rotated_at',
+        ),
+    );
+
     /**
      * Refresh tokens for all tts_client posts.
      */
     public static function refresh_tokens() {
+        self::get_secure_storage();
+
         $clients = get_posts(
             array(
                 'post_type'      => 'tts_client',
@@ -41,85 +74,50 @@ class TTS_Token_Refresh {
      * @param int $client_id Client post ID.
      */
     protected static function refresh_client_tokens( $client_id ) {
-        $tokens       = array(
-            'facebook'  => array(
-                'meta'  => '_tts_fb_token',
-                'token' => get_post_meta( $client_id, '_tts_fb_token', true ),
-            ),
-            'instagram' => array(
-                'meta'  => '_tts_ig_token',
-                'token' => get_post_meta( $client_id, '_tts_ig_token', true ),
-            ),
-        );
-        $social_apps = get_option( 'tts_social_apps', array() );
-        $errors      = array();
+        $secure_storage = self::get_secure_storage();
+        $meta_map       = self::$token_meta_map;
+        $social_apps    = get_option( 'tts_social_apps', array() );
+        $errors         = array();
 
-        foreach ( $tokens as $channel => $data ) {
-            $token          = $data['token'];
-            $meta_key       = $data['meta'];
-            $channel_config = isset( $social_apps[ $channel ] ) ? $social_apps[ $channel ] : array();
+        foreach ( $meta_map as $channel => $meta_info ) {
+            $raw_token = get_post_meta( $client_id, $meta_info['meta'], true );
 
-            if ( empty( $token ) ) {
-                continue;
-            }
-
-            $endpoint = '';
-            $url      = '';
-
-            if ( 'facebook' === $channel ) {
-                $app_id     = isset( $channel_config['app_id'] ) ? $channel_config['app_id'] : '';
-                $app_secret = isset( $channel_config['app_secret'] ) ? $channel_config['app_secret'] : '';
-
-                if ( empty( $app_id ) || empty( $app_secret ) ) {
-                    $error_message = __( 'Facebook app credentials are missing; cannot refresh token.', 'fp-publisher' );
-                    $error_data    = array(
-                        'client_id'       => $client_id,
-                        'missing_app_id'  => empty( $app_id ),
-                        'missing_secret'  => empty( $app_secret ),
-                    );
-                    $error         = new WP_Error( 'tts_facebook_credentials_missing', $error_message, $error_data );
-
-                    tts_log_event(
-                        $client_id,
-                        $channel,
-                        'error',
-                        'Token refresh failed: missing app credentials',
-                        array(
-                            'has_app_id'     => ! empty( $app_id ),
-                            'has_app_secret' => ! empty( $app_secret ),
-                        )
-                    );
-
-                    $errors[ $channel ] = $error;
-                    continue;
-                }
-
-                $endpoint = 'https://graph.facebook.com/v18.0/oauth/access_token';
-                $url      = add_query_arg(
+            if ( $secure_storage ) {
+                $raw_token = $secure_storage->resolve_managed_secret(
+                    $raw_token,
                     array(
-                        'grant_type'        => 'fb_exchange_token',
-                        'client_id'         => $app_id,
-                        'client_secret'     => $app_secret,
-                        'fb_exchange_token' => $token,
-                    ),
-                    $endpoint
-                );
-            } elseif ( 'instagram' === $channel ) {
-                $endpoint = 'https://graph.instagram.com/refresh_access_token';
-                $url      = add_query_arg(
-                    array(
-                        'grant_type'   => 'ig_refresh_token',
-                        'access_token' => $token,
-                    ),
-                    $endpoint
+                        'context'   => 'token_refresh',
+                        'channel'   => $channel,
+                        'client_id' => $client_id,
+                        'purpose'   => 'access_token',
+                    )
                 );
             }
 
-            if ( empty( $url ) ) {
+            $token = self::normalize_token_value( $raw_token );
+
+            if ( '' === $token ) {
                 continue;
             }
 
-            $response = wp_remote_get( $url );
+            $meta_info['token']      = $token;
+            $meta_info['expires_at'] = isset( $meta_info['expires_meta'] ) ? intval( get_post_meta( $client_id, $meta_info['expires_meta'], true ) ) : 0;
+            $meta_info['rotated_at'] = isset( $meta_info['rotated_meta'] ) ? intval( get_post_meta( $client_id, $meta_info['rotated_meta'], true ) ) : 0;
+
+            if ( ! self::should_refresh_token( $client_id, $channel, $meta_info ) ) {
+                continue;
+            }
+
+            $channel_config = isset( $social_apps[ $channel ] ) ? self::resolve_channel_config( $channel, $social_apps[ $channel ] ) : array();
+            $request        = self::build_refresh_request( $channel, $token, $channel_config, $client_id );
+
+            if ( is_wp_error( $request ) ) {
+                $errors[ $channel ] = $request;
+                continue;
+            }
+
+            $response = wp_remote_get( $request['url'] );
+
             if ( is_wp_error( $response ) ) {
                 $message = sprintf(
                     __( '%1$s token refresh request failed: %2$s', 'fp-publisher' ),
@@ -131,7 +129,7 @@ class TTS_Token_Refresh {
                     $message,
                     array(
                         'client_id' => $client_id,
-                        'endpoint'  => $endpoint,
+                        'endpoint'  => $request['endpoint'],
                     )
                 );
 
@@ -231,11 +229,23 @@ class TTS_Token_Refresh {
                 continue;
             }
 
-            update_post_meta( $client_id, $meta_key, sanitize_text_field( $body['access_token'] ) );
+            $storage_context = self::store_refreshed_token( $client_id, $channel, $meta_info, $body );
 
-            $log_context = array();
+            $log_context = array(
+                'rotation_source' => $request['endpoint'],
+                'storage'         => isset( $storage_context['storage'] ) ? $storage_context['storage'] : 'meta',
+            );
+
             if ( isset( $body['expires_in'] ) ) {
                 $log_context['expires_in'] = absint( $body['expires_in'] );
+            }
+
+            if ( isset( $storage_context['expires_at'] ) && $storage_context['expires_at'] ) {
+                $log_context['expires_at'] = $storage_context['expires_at'];
+            }
+
+            if ( isset( $meta_info['rotated_meta'] ) ) {
+                $log_context['rotated_at'] = time();
             }
 
             tts_log_event( $client_id, $channel, 'success', 'Token refreshed successfully', $log_context );
@@ -250,5 +260,240 @@ class TTS_Token_Refresh {
         }
 
         return true;
+    }
+
+    /**
+     * Retrieve the secure storage instance when available.
+     *
+     * @return TTS_Secure_Storage|null
+     */
+    private static function get_secure_storage() {
+        if ( null === self::$secure_storage && class_exists( 'TTS_Secure_Storage' ) ) {
+            self::$secure_storage = TTS_Secure_Storage::instance();
+        }
+
+        return self::$secure_storage;
+    }
+
+    /**
+     * Normalize token values to trimmed strings.
+     *
+     * @param mixed $token Raw token value.
+     *
+     * @return string
+     */
+    private static function normalize_token_value( $token ) {
+        if ( is_array( $token ) || is_object( $token ) ) {
+            $token = wp_json_encode( $token );
+        }
+
+        if ( ! is_string( $token ) ) {
+            return '';
+        }
+
+        return trim( $token );
+    }
+
+    /**
+     * Resolve channel configuration using managed secret providers.
+     *
+     * @param string $channel Channel identifier.
+     * @param mixed  $config  Raw configuration.
+     *
+     * @return array<string, mixed>
+     */
+    private static function resolve_channel_config( $channel, $config ) {
+        $config = is_array( $config ) ? $config : array();
+        $storage = self::get_secure_storage();
+
+        if ( ! $storage ) {
+            return $config;
+        }
+
+        foreach ( $config as $key => $value ) {
+            if ( is_scalar( $value ) ) {
+                $resolved = $storage->resolve_managed_secret(
+                    $value,
+                    array(
+                        'context' => 'token_refresh',
+                        'channel' => $channel,
+                        'field'   => $key,
+                    )
+                );
+
+                if ( is_scalar( $resolved ) ) {
+                    $config[ $key ] = trim( (string) $resolved );
+                }
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * Determine whether a token should be rotated.
+     *
+     * @param int    $client_id Client identifier.
+     * @param string $channel   Channel key.
+     * @param array  $meta_info Metadata for the token.
+     *
+     * @return bool
+     */
+    private static function should_refresh_token( $client_id, $channel, array $meta_info ) {
+        $decision = apply_filters( 'tts_should_refresh_social_token', null, $client_id, $channel, $meta_info );
+
+        if ( null !== $decision ) {
+            return (bool) $decision;
+        }
+
+        $now        = time();
+        $expires_at = isset( $meta_info['expires_at'] ) ? (int) $meta_info['expires_at'] : 0;
+        $rotated_at = isset( $meta_info['rotated_at'] ) ? (int) $meta_info['rotated_at'] : 0;
+
+        if ( $expires_at > 0 ) {
+            if ( $expires_at <= $now ) {
+                return true;
+            }
+
+            if ( ( $expires_at - $now ) <= self::EXPIRY_REFRESH_THRESHOLD ) {
+                return true;
+            }
+
+            if ( $rotated_at > 0 && ( $now - $rotated_at ) < self::MINIMUM_ROTATION_INTERVAL ) {
+                return false;
+            }
+
+            return false;
+        }
+
+        if ( $rotated_at <= 0 ) {
+            return true;
+        }
+
+        if ( ( $now - $rotated_at ) < self::MINIMUM_ROTATION_INTERVAL ) {
+            return false;
+        }
+
+        if ( ( $now - $rotated_at ) >= self::DEFAULT_ROTATION_INTERVAL ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Build the refresh request for a specific channel.
+     *
+     * @param string $channel Channel key.
+     * @param string $token   Current token.
+     * @param array  $config  Channel configuration.
+     * @param int    $client_id Client identifier.
+     *
+     * @return array{endpoint: string, url: string}|WP_Error
+     */
+    private static function build_refresh_request( $channel, $token, array $config, $client_id ) {
+        if ( 'facebook' === $channel ) {
+            $app_id     = isset( $config['app_id'] ) ? trim( (string) $config['app_id'] ) : '';
+            $app_secret = isset( $config['app_secret'] ) ? trim( (string) $config['app_secret'] ) : '';
+
+            if ( '' === $app_id || '' === $app_secret ) {
+                $error_message = __( 'Facebook app credentials are missing; cannot refresh token.', 'fp-publisher' );
+                $error_data    = array(
+                    'client_id'       => $client_id,
+                    'missing_app_id'  => '' === $app_id,
+                    'missing_secret'  => '' === $app_secret,
+                );
+
+                tts_log_event(
+                    $client_id,
+                    $channel,
+                    'error',
+                    'Token refresh failed: missing app credentials',
+                    array(
+                        'has_app_id'     => '' !== $app_id,
+                        'has_app_secret' => '' !== $app_secret,
+                    )
+                );
+
+                return new WP_Error( 'tts_facebook_credentials_missing', $error_message, $error_data );
+            }
+
+            $endpoint = 'https://graph.facebook.com/v18.0/oauth/access_token';
+            $url      = add_query_arg(
+                array(
+                    'grant_type'        => 'fb_exchange_token',
+                    'client_id'         => $app_id,
+                    'client_secret'     => $app_secret,
+                    'fb_exchange_token' => $token,
+                ),
+                $endpoint
+            );
+
+            return compact( 'endpoint', 'url' );
+        }
+
+        if ( 'instagram' === $channel ) {
+            $endpoint = 'https://graph.instagram.com/refresh_access_token';
+            $url      = add_query_arg(
+                array(
+                    'grant_type'   => 'ig_refresh_token',
+                    'access_token' => $token,
+                ),
+                $endpoint
+            );
+
+            return compact( 'endpoint', 'url' );
+        }
+
+        return new WP_Error(
+            'tts_' . $channel . '_unsupported_channel',
+            sprintf( __( 'Token refresh is not configured for the %s channel.', 'fp-publisher' ), $channel ),
+            array( 'client_id' => $client_id )
+        );
+    }
+
+    /**
+     * Persist refreshed token information and metadata.
+     *
+     * @param int    $client_id  Client identifier.
+     * @param string $channel    Channel key.
+     * @param array  $meta_info  Token metadata definitions.
+     * @param array  $body       API response payload.
+     *
+     * @return array<string, mixed>
+     */
+    private static function store_refreshed_token( $client_id, $channel, array $meta_info, array $body ) {
+        $new_token = sanitize_text_field( (string) $body['access_token'] );
+        $previous  = isset( $meta_info['token'] ) ? $meta_info['token'] : '';
+
+        if ( isset( $meta_info['previous_meta'] ) && '' !== $previous ) {
+            update_post_meta( $client_id, $meta_info['previous_meta'], $previous );
+        }
+
+        $handled = apply_filters( 'tts_token_refresh_persist_token', false, $client_id, $channel, $new_token, $meta_info, $body );
+
+        if ( ! $handled ) {
+            update_post_meta( $client_id, $meta_info['meta'], $new_token );
+        }
+
+        $expires_at = null;
+
+        if ( isset( $meta_info['expires_meta'] ) ) {
+            if ( isset( $body['expires_in'] ) ) {
+                $expires_at = time() + absint( $body['expires_in'] );
+                update_post_meta( $client_id, $meta_info['expires_meta'], $expires_at );
+            } else {
+                delete_post_meta( $client_id, $meta_info['expires_meta'] );
+            }
+        }
+
+        if ( isset( $meta_info['rotated_meta'] ) ) {
+            update_post_meta( $client_id, $meta_info['rotated_meta'], time() );
+        }
+
+        return array(
+            'storage'    => $handled ? 'external' : 'meta',
+            'expires_at' => $expires_at,
+        );
     }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/tests/bootstrap.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/bootstrap.php
@@ -20,6 +20,12 @@ if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 if ( ! defined( 'DAY_IN_SECONDS' ) ) {
     define( 'DAY_IN_SECONDS', 24 * HOUR_IN_SECONDS );
 }
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+    define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
+}
+
+// Provide deterministic encryption material for tests.
+putenv( 'TTS_ENCRYPTION_KEY=YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI=' );
 
 // Global containers used by the tests.
 $GLOBALS['tts_test_options']         = array();
@@ -41,6 +47,7 @@ $GLOBALS['tts_current_user']         = null;
 $GLOBALS['tts_current_screen']       = null;
 $GLOBALS['tts_test_transients']      = array();
 $GLOBALS['tts_is_user_logged_in']    = null;
+$GLOBALS['tts_http_responses']       = array();
 
 if ( ! function_exists( '__' ) ) {
     function __( $text, $domain = null ) {
@@ -134,6 +141,12 @@ if ( ! function_exists( 'wp_unslash' ) ) {
     }
 }
 
+if ( ! function_exists( 'absint' ) ) {
+    function absint( $maybeint ) {
+        return abs( (int) $maybeint );
+    }
+}
+
 if ( ! function_exists( 'sanitize_key' ) ) {
     function sanitize_key( $key ) {
         $key = strtolower( (string) $key );
@@ -156,6 +169,47 @@ if ( ! function_exists( 'plugin_dir_url' ) ) {
 if ( ! function_exists( 'plugin_dir_path' ) ) {
     function plugin_dir_path( $file ) {
         return rtrim( dirname( $file ), '/\\' ) . '/';
+    }
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+    function add_query_arg( $params, $url = '' ) {
+        $params = (array) $params;
+        $parsed = parse_url( $url );
+        $query  = array();
+
+        if ( isset( $parsed['query'] ) ) {
+            parse_str( $parsed['query'], $query );
+        }
+
+        foreach ( $params as $key => $value ) {
+            $query[ $key ] = $value;
+        }
+
+        $scheme   = isset( $parsed['scheme'] ) ? $parsed['scheme'] . '://' : '';
+        $host     = $parsed['host'] ?? '';
+        $port     = isset( $parsed['port'] ) ? ':' . $parsed['port'] : '';
+        $path     = $parsed['path'] ?? '';
+        $base     = $scheme . $host . $port . $path;
+        $fragment = isset( $parsed['fragment'] ) ? '#' . $parsed['fragment'] : '';
+
+        $query_string = http_build_query( $query );
+
+        if ( '' !== $query_string ) {
+            return $base . '?' . $query_string . $fragment;
+        }
+
+        return $base . $fragment;
+    }
+}
+
+if ( ! function_exists( 'current_time' ) ) {
+    function current_time( $type ) {
+        if ( 'mysql' === $type ) {
+            return gmdate( 'Y-m-d H:i:s' );
+        }
+
+        return time();
     }
 }
 
@@ -405,6 +459,36 @@ if ( ! function_exists( 'wp_send_json_success' ) ) {
     }
 }
 
+if ( ! function_exists( 'wp_remote_get' ) ) {
+    function wp_remote_get( $url ) {
+        if ( isset( $GLOBALS['tts_http_responses'][ $url ] ) ) {
+            return $GLOBALS['tts_http_responses'][ $url ];
+        }
+
+        return new WP_Error( 'http_not_stubbed', 'No stubbed response for ' . $url );
+    }
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+    function wp_remote_retrieve_response_code( $response ) {
+        if ( is_array( $response ) && isset( $response['response']['code'] ) ) {
+            return (int) $response['response']['code'];
+        }
+
+        return 0;
+    }
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+    function wp_remote_retrieve_body( $response ) {
+        if ( is_array( $response ) && isset( $response['body'] ) ) {
+            return $response['body'];
+        }
+
+        return '';
+    }
+}
+
 if ( ! function_exists( 'wp_send_json_error' ) ) {
     function wp_send_json_error( $data = null, $status_code = 200 ) {
         $response = array(
@@ -501,6 +585,20 @@ if ( ! function_exists( 'wp_parse_args' ) ) {
     }
 }
 
+if ( ! function_exists( 'maybe_serialize' ) ) {
+    function maybe_serialize( $data ) {
+        if ( is_array( $data ) || is_object( $data ) ) {
+            return serialize( $data );
+        }
+
+        if ( is_serialized( $data ) ) {
+            return serialize( $data );
+        }
+
+        return $data;
+    }
+}
+
 if ( ! function_exists( 'maybe_unserialize' ) ) {
     function maybe_unserialize( $data ) {
         if ( ! is_string( $data ) ) {
@@ -511,6 +609,26 @@ if ( ! function_exists( 'maybe_unserialize' ) ) {
             return $unserialized;
         }
         return $data;
+    }
+}
+
+if ( ! function_exists( 'is_serialized' ) ) {
+    function is_serialized( $data ) {
+        if ( ! is_string( $data ) ) {
+            return false;
+        }
+
+        $data = trim( $data );
+
+        if ( 'N;' === $data ) {
+            return true;
+        }
+
+        if ( ! preg_match( '/^[adObis]:/', $data ) ) {
+            return false;
+        }
+
+        return @unserialize( $data ) !== false || 'b:0;' === $data;
     }
 }
 
@@ -527,20 +645,77 @@ if ( ! function_exists( 'update_option' ) ) {
     }
 }
 
+if ( ! function_exists( 'add_post_meta' ) ) {
+    function add_post_meta( $post_id, $key, $value, $unique = false ) {
+        $check = apply_filters( 'add_post_metadata', null, $post_id, $key, $value, $unique );
+        if ( null !== $check ) {
+            return $check;
+        }
+
+        if ( $unique && isset( $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ] ) ) {
+            return false;
+        }
+
+        $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ] = maybe_serialize( $value );
+
+        return true;
+    }
+}
+
 if ( ! function_exists( 'get_post_meta' ) ) {
     function get_post_meta( $post_id, $key, $single = false ) {
-        if ( isset( $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ] ) ) {
-            $value = $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ];
-            return $single ? $value : array( $value );
+        $check = apply_filters( 'get_post_metadata', null, $post_id, $key, $single );
+        if ( null !== $check ) {
+            return $check;
         }
-        return $single ? '' : array();
+
+        if ( '' === $key ) {
+            $all = $GLOBALS['tts_test_post_meta'][ $post_id ] ?? array();
+            $result = array();
+
+            foreach ( $all as $meta_key => $meta_value ) {
+                $result[ $meta_key ] = maybe_unserialize( $meta_value );
+            }
+
+            return $result;
+        }
+
+        if ( ! isset( $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ] ) ) {
+            return $single ? '' : array();
+        }
+
+        $value = maybe_unserialize( $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ] );
+
+        return $single ? $value : array( $value );
     }
 }
 
 if ( ! function_exists( 'update_post_meta' ) ) {
-    function update_post_meta( $post_id, $key, $value ) {
-        $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ] = $value;
+    function update_post_meta( $post_id, $key, $value, $prev_value = '' ) {
+        $check = apply_filters( 'update_post_metadata', null, $post_id, $key, $value, $prev_value );
+        if ( null !== $check ) {
+            return $check;
+        }
+
+        $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ] = maybe_serialize( $value );
+
         return true;
+    }
+}
+
+if ( ! function_exists( 'delete_post_meta' ) ) {
+    function delete_post_meta( $post_id, $key, $value = '' ) {
+        $check = apply_filters( 'delete_post_metadata', null, $post_id, $key, $value, false );
+        if ( null !== $check ) {
+            return $check;
+        }
+
+        if ( isset( $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ] ) ) {
+            unset( $GLOBALS['tts_test_post_meta'][ $post_id ][ $key ] );
+            return true;
+        }
+
+        return false;
     }
 }
 
@@ -603,9 +778,53 @@ if ( ! isset( $GLOBALS['wpdb'] ) ) {
     class TTS_Test_WPDB {
         public $postmeta = 'wp_postmeta';
         public $posts    = 'wp_posts';
+        public $prefix   = 'wp_';
 
         public function get_results( $query ) {
             return $GLOBALS['tts_test_wpdb_results'];
+        }
+
+        public function get_var( $query ) {
+            if ( preg_match( '/post_id\s*=\s*(\d+)/', $query, $matches ) ) {
+                $post_id = (int) $matches[1];
+                if ( preg_match( "/meta_key\s*=\s*'([^']+)'/", $query, $key_match ) ) {
+                    $meta_key = stripslashes( $key_match[1] );
+                    return $GLOBALS['tts_test_post_meta'][ $post_id ][ $meta_key ] ?? null;
+                }
+            }
+
+            return null;
+        }
+
+        public function insert( $table, $data, $format = array() ) {
+            return true;
+        }
+
+        public function query( $query ) {
+            return true;
+        }
+
+        public function prepare( $query, ...$args ) {
+            if ( empty( $args ) ) {
+                return $query;
+            }
+
+            $processed = $query;
+
+            foreach ( $args as $arg ) {
+                $replacement = is_numeric( $arg ) ? (string) $arg : "'" . addslashes( (string) $arg ) . "'";
+                $processed   = preg_replace( '/%s|%d/', $replacement, $processed, 1 );
+            }
+
+            return $processed;
+        }
+
+        public function esc_like( $text ) {
+            return addslashes( $text );
+        }
+
+        public function get_charset_collate() {
+            return 'DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci';
         }
     }
     $GLOBALS['wpdb'] = new TTS_Test_WPDB();
@@ -644,6 +863,7 @@ function tts_reset_test_state() {
     $GLOBALS['tts_current_screen']      = null;
     $GLOBALS['tts_test_transients']     = array();
     $GLOBALS['tts_is_user_logged_in']   = null;
+    $GLOBALS['tts_http_responses']      = array();
 
     $_GET     = array();
     $_POST    = array();

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-secure-storage.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-secure-storage.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/helpers/assertions.php';
+require_once __DIR__ . '/../includes/class-tts-secure-storage.php';
+
+$tests = array(
+    'metadata_encryption_round_trip' => function () {
+        tts_reset_test_state();
+
+        $storage = TTS_Secure_Storage::instance();
+
+        $post_id = 101;
+        $token   = 'plain-token-value-123';
+
+        update_post_meta( $post_id, '_tts_fb_token', $token );
+
+        tts_assert_true(
+            isset( $GLOBALS['tts_test_post_meta'][ $post_id ]['_tts_fb_token'] ),
+            'Encrypted meta should be stored in the test meta table.'
+        );
+
+        $stored_value = $GLOBALS['tts_test_post_meta'][ $post_id ]['_tts_fb_token'];
+
+        tts_assert_true(
+            is_string( $stored_value ) && 0 === strpos( $stored_value, TTS_Secure_Storage::ENCRYPTION_PREFIX ),
+            'Sensitive metadata should be stored using the secure storage prefix.'
+        );
+
+        $retrieved = get_post_meta( $post_id, '_tts_fb_token', true );
+
+        tts_assert_equals( $token, $retrieved, 'Encrypted metadata should be transparently decrypted when retrieved.' );
+    },
+    'resolve_managed_secret_supports_vault_providers' => function () {
+        tts_reset_test_state();
+
+        $storage = TTS_Secure_Storage::instance();
+
+        add_filter(
+            'tts_vault_resolve_aws-kms',
+            function ( $value, $reference ) {
+                if ( 'alias/test-secret' === $reference ) {
+                    return 'kms-secret-value';
+                }
+
+                return $value;
+            },
+            10,
+            2
+        );
+
+        $resolved = $storage->resolve_managed_secret( 'vault:aws-kms:alias/test-secret', array() );
+
+        tts_assert_equals( 'kms-secret-value', $resolved, 'AWS KMS provider filter should resolve vault secrets.' );
+    },
+    'mask_sensitive_data_redacts_tokens' => function () {
+        tts_reset_test_state();
+
+        $storage = TTS_Secure_Storage::instance();
+
+        $payload = array(
+            'token' => 'abcd1234',
+            'note'  => 'hello',
+        );
+
+        $masked = $storage->mask_sensitive_data( $payload );
+
+        tts_assert_true(
+            isset( $masked['token'] ) && 'abcd1234' !== $masked['token'],
+            'Token values should be masked when preparing data for display.'
+        );
+
+        tts_assert_equals( 'hello', $masked['note'], 'Non-sensitive fields should remain unchanged.' );
+    },
+);
+
+foreach ( $tests as $name => $test ) {
+    try {
+        $test();
+        echo "✅ {$name}\n";
+    } catch ( Throwable $e ) {
+        echo "❌ {$name}: " . $e->getMessage() . "\n";
+        exit( 1 );
+    }
+}

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-token-refresh.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-token-refresh.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/helpers/assertions.php';
+require_once __DIR__ . '/../includes/tts-logger.php';
+require_once __DIR__ . '/../includes/class-tts-secure-storage.php';
+require_once __DIR__ . '/../includes/class-tts-token-refresh.php';
+
+class TTS_Token_Refresh_Testable extends TTS_Token_Refresh {
+    public static function run_refresh( $client_id ) {
+        return parent::refresh_client_tokens( $client_id );
+    }
+}
+
+$tests = array(
+    'refresh_skips_recent_rotations' => function () {
+        tts_reset_test_state();
+
+        update_post_meta( 200, '_tts_fb_token', 'recent-token' );
+        update_post_meta( 200, '_tts_fb_token_rotated_at', time() );
+        update_option( 'tts_social_apps', array(
+            'facebook' => array(
+                'app_id'     => '123',
+                'app_secret' => '456',
+            ),
+        ) );
+
+        $result = TTS_Token_Refresh_Testable::run_refresh( 200 );
+
+        tts_assert_true( true === $result, 'Tokens rotated recently should not trigger remote refresh attempts.' );
+        tts_assert_true(
+            empty( $GLOBALS['tts_http_responses'] ),
+            'No HTTP responses should be consumed when refresh is skipped.'
+        );
+    },
+    'refresh_updates_tokens_when_expiring' => function () {
+        tts_reset_test_state();
+
+        $client_id = 201;
+        $old_token = 'old-token-value';
+        update_post_meta( $client_id, '_tts_fb_token', $old_token );
+        update_post_meta( $client_id, '_tts_fb_token_expires_at', time() + 1800 );
+        update_option( 'tts_social_apps', array(
+            'facebook' => array(
+                'app_id'     => 'my-app',
+                'app_secret' => 'vault:aws-kms:fb-secret',
+            ),
+        ) );
+
+        add_filter(
+            'tts_vault_resolve_aws-kms',
+            function ( $value, $reference ) {
+                if ( 'fb-secret' === $reference ) {
+                    return 'resolved-secret';
+                }
+
+                return $value;
+            },
+            10,
+            2
+        );
+
+        $expected_url = add_query_arg(
+            array(
+                'grant_type'        => 'fb_exchange_token',
+                'client_id'         => 'my-app',
+                'client_secret'     => 'resolved-secret',
+                'fb_exchange_token' => $old_token,
+            ),
+            'https://graph.facebook.com/v18.0/oauth/access_token'
+        );
+
+        $GLOBALS['tts_http_responses'][ $expected_url ] = array(
+            'response' => array( 'code' => 200 ),
+            'body'     => wp_json_encode(
+                array(
+                    'access_token' => 'new-token-value',
+                    'expires_in'   => 3600,
+                )
+            ),
+        );
+
+        $result = TTS_Token_Refresh_Testable::run_refresh( $client_id );
+
+        tts_assert_true( true === $result, 'Token refresh should succeed when the token is nearing expiration.' );
+
+        $stored_token = get_post_meta( $client_id, '_tts_fb_token', true );
+        tts_assert_equals( 'new-token-value', $stored_token, 'Refreshed tokens should be stored securely.' );
+
+        $previous_token = get_post_meta( $client_id, '_tts_fb_token_previous', true );
+        tts_assert_equals( $old_token, $previous_token, 'Previous token should be retained for fallback purposes.' );
+
+        $expires_at = get_post_meta( $client_id, '_tts_fb_token_expires_at', true );
+        tts_assert_true( $expires_at > time(), 'Expiration metadata should be updated after refresh.' );
+
+        $rotated_at = get_post_meta( $client_id, '_tts_fb_token_rotated_at', true );
+        tts_assert_true( $rotated_at > 0, 'Rotation timestamp should be recorded after refresh.' );
+    },
+);
+
+foreach ( $tests as $name => $test ) {
+    try {
+        $test();
+        echo "✅ {$name}\n";
+    } catch ( Throwable $e ) {
+        echo "❌ {$name}: " . $e->getMessage() . "\n";
+        exit( 1 );
+    }
+}

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -127,6 +127,7 @@ add_action( 'plugins_loaded', function () {
 
     // Load support files from the includes directory using whitelist for security.
     $tsap_includes = array(
+        'class-tts-secure-storage.php',
         'class-tts-advanced-utils.php',
         'class-tts-analytics.php',
         'class-tts-backup.php',
@@ -174,6 +175,10 @@ add_action( 'plugins_loaded', function () {
         if ( file_exists( $file ) ) {
             require_once $file;
         }
+    }
+
+    if ( class_exists( 'TTS_Secure_Storage' ) ) {
+        TTS_Secure_Storage::instance();
     }
 
     // Load REST API endpoints after other includes.

--- a/wp-content/plugins/trello-social-auto-publisher/wp-admin/includes/upgrade.php
+++ b/wp-content/plugins/trello-social-auto-publisher/wp-admin/includes/upgrade.php
@@ -1,0 +1,4 @@
+<?php
+function dbDelta( $sql ) {
+    return true;
+}


### PR DESCRIPTION
## Summary
- add a secure storage service to encrypt sensitive metadata, resolve managed secrets, and mask sensitive output
- encrypt security audit log payloads, enforce a configurable retention policy, and document secure storage usage
- harden token refresh logic with vault compatibility, rotation metadata, and new regression coverage

## Testing
- php tests/test-secure-storage.php
- php tests/test-token-refresh.php
- php tests/test-security-audit.php
- php tests/test-disable-trello.php
- php tests/test-logger.php
- php tests/test-service-container.php

------
https://chatgpt.com/codex/tasks/task_e_68d396465380832f9db81ebc293c1069