### PR TITLE
Add resilient channel queue and guarded publishing

### DIFF
--- a/docs/operations/resilience.md
+++ b/docs/operations/resilience.md
@@ -1,0 +1,89 @@
+# Resilienza della pubblicazione
+
+Questo documento descrive i controlli di resilienza del publisher TTS e come operare in caso di limiti o guasti dei canali.
+
+## Coda asincrona per canale
+
+* Ogni pubblicazione approvata viene scomposta in job per canale e accodata con `TTS_Channel_Queue` sull'hook `tts_process_channel_job`.
+* Il meta `_tts_channel_retry_state` traccia stato, tentativi, prossimo retry e dettagli dell'errore per ogni canale.
+* Il meta `_tts_queued_channels` elenca i canali pianificati; quando tutti risultano `completed` il post viene marcato come `published` e viene eseguita la chiusura del flusso (aggiornamento Trello, notifiche, ecc.).
+
+## Configurazione limiti per canale
+
+Le soglie vengono lette dall'opzione `tts_channel_limits` (array serializzato). È possibile impostarla via WP-CLI o tramite hook personalizzato. Ogni voce del dizionario ha la forma:
+
+```php
+update_option( 'tts_channel_limits', array(
+    'facebook' => array(
+        'max_pending' => 5,
+        'rate_limits' => array(
+            'requests_per_hour' => 120,
+            'requests_per_day'  => 2500,
+            'burst_limit'       => 30,
+        ),
+        'retry' => array(
+            'strategy'     => 'progressive',
+            'global_max'   => 4,
+            'jitter'       => 90,
+            'delays'       => array(
+                'low'      => 5,
+                'medium'   => 10,
+                'high'     => 30,
+                'critical' => 60,
+            ),
+            'max_attempts' => array(
+                'low'      => 4,
+                'medium'   => 3,
+                'high'     => 2,
+                'critical' => 1,
+            ),
+        ),
+        'circuit' => array(
+            'failure_threshold' => 3,
+            'cooldowns' => array(
+                'medium'   => 600,
+                'high'     => 900,
+                'critical' => 1800,
+            ),
+        ),
+    ),
+    'fallbacks' => array(
+        'manual_publish_url' => 'https://intranet.example.com/manual-publishing-playbook'
+    ),
+) );
+```
+
+* `max_pending` limita i job in attesa per canale.
+* `rate_limits` sovrascrive i limiti del `TTS_Rate_Limiter`.
+* `retry` definisce strategia, ritardi (in minuti) e tentativi massimi per severità.
+* `circuit` stabilisce soglia di apertura e durata di raffreddamento (secondi).
+* Il blocco `fallbacks` può contenere URL o istruzioni aggiuntive per l'operatore.
+
+## Circuit breaker e rate limiting
+
+* `TTS_Publisher_Guard` interroga il `TTS_Rate_Limiter` prima di ogni chiamata al publisher.
+* I fallimenti severi aprono il circuito per il canale; il meta della coda viene aggiornato a `awaiting_manual` e viene inviato un allarme (Slack + e-mail).
+* I retry seguono la strategia definita per severità con jitter casuale per evitare thundering herd.
+
+## Procedure operative
+
+1. **Verifica stato coda** – utilizzare il comando diagnostico nel backoffice che chiama `TTS_Scheduler::check_queue()`. Viene mostrato il totale pending/failed per `tts_publish_social_post` e `tts_process_channel_job`.
+2. **Sblocco circuito** – controllare l'opzione `tts_channel_circuit_breakers`; è possibile eliminare la voce del canale interessato per riaprire manualmente il circuito dopo aver risolto la causa.
+3. **Pubblicazione manuale** – seguire il playbook indicato in `tts_channel_limits['fallbacks']['manual_publish_url']` e registrare l'esito nel log operativo.
+4. **Reset stato job** – per riprocessare un canale rimuovere il sotto-array corrispondente da `_tts_channel_retry_state` e cancellare eventuali azioni pianificate con `as_unschedule_all_actions( 'tts_process_channel_job', ... )`.
+
+## Monitoraggio
+
+* Ogni job invia eventi sul canale di osservabilità `scheduler` (start, retry, success, error).
+* I log pubblicati sono accessibili dalla pagina `fp-publisher-log` del post; includono eventuali URL ritornati dal canale o messaggi di errore.
+
+## FAQ
+
+**Il canale è bloccato per "circuit breaker attivo".**
+: Controllare l'opzione `tts_channel_circuit_breakers` per conoscere il `open_until` e la severità dell'ultimo errore. Attendere lo sblocco automatico oppure intervenire manualmente seguendo il playbook.
+
+**I retry non partono.**
+: Verificare che l'opzione `tts_channel_limits` non imponga `max_pending` troppo basso e che l'azione cron `tts_process_retry_queue` del modulo di error recovery sia attiva.
+
+**Come modifico temporaneamente i limiti?**
+: Applicare un filtro `tts_rate_limiter_limits` o aggiornare `tts_channel_limits` tramite WP-CLI; i nuovi valori vengono applicati al volo a rate limiter e coda.

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-channel-queue.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-channel-queue.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Asynchronous channel queue built on top of Action Scheduler.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'TTS_Channel_Queue' ) ) {
+    /**
+     * Coordinates asynchronous channel jobs.
+     */
+    class TTS_Channel_Queue {
+
+        /**
+         * Action Scheduler hook name used for channel jobs.
+         */
+        const ACTION_HOOK = 'tts_process_channel_job';
+
+        /**
+         * Default configuration applied when no custom option is present.
+         *
+         * @var array
+         */
+        private $default_config = array(
+            'max_pending' => 10,
+            'retry'       => array(
+                'strategy'      => 'progressive',
+                'global_max'    => 5,
+                'jitter'        => 60,
+                'delays'        => array(
+                    'low'      => 5,
+                    'medium'   => 15,
+                    'high'     => 30,
+                    'critical' => 60,
+                ),
+                'max_attempts'  => array(
+                    'low'      => 5,
+                    'medium'   => 4,
+                    'high'     => 3,
+                    'critical' => 1,
+                ),
+            ),
+            'circuit'     => array(
+                'failure_threshold' => 3,
+                'cooldowns'         => array(
+                    'low'      => 300,
+                    'medium'   => 600,
+                    'high'     => 900,
+                    'critical' => 1800,
+                ),
+            ),
+        );
+
+        /**
+         * Enqueue a job for a specific channel.
+         *
+         * @param array $job       Job payload.
+         * @param int   $timestamp Execution timestamp.
+         *
+         * @return array|WP_Error  Normalized job payload or error.
+         */
+        public function enqueue_job( array $job, $timestamp ) {
+            if ( ! function_exists( 'as_schedule_single_action' ) ) {
+                return new WP_Error( 'action_scheduler_missing', __( 'Action Scheduler non è disponibile.', 'fp-publisher' ) );
+            }
+
+            $job      = $this->normalize_job( $job, $timestamp );
+            $channel  = $job['channel'];
+            $group    = $this->get_group_name( $channel );
+            $limit_ok = $this->enforce_pending_limit( $channel, $group );
+
+            if ( is_wp_error( $limit_ok ) ) {
+                return $limit_ok;
+            }
+
+            $args      = array( $this->strip_runtime_keys( $job ) );
+            $action_id = as_schedule_single_action( $timestamp, self::ACTION_HOOK, $args, $group );
+
+            $job['action_id']      = $action_id;
+            $job['action_group']   = $group;
+            $job['scheduled_args'] = $args;
+
+            return $job;
+        }
+
+        /**
+         * Retrieve configuration for a channel.
+         *
+         * @param string $channel Channel identifier.
+         *
+         * @return array
+         */
+        public function get_channel_config( $channel ) {
+            $channel = sanitize_key( $channel );
+            $config  = $this->get_raw_config();
+
+            if ( isset( $config[ $channel ] ) && is_array( $config[ $channel ] ) ) {
+                return $this->merge_config( $config[ $channel ] );
+            }
+
+            return $this->default_config;
+        }
+
+        /**
+         * Build a readable group name for Action Scheduler.
+         *
+         * @param string $channel Channel identifier.
+         *
+         * @return string
+         */
+        public function get_group_name( $channel ) {
+            $channel = sanitize_key( $channel );
+            if ( '' === $channel ) {
+                $channel = 'generic';
+            }
+
+            return 'tts_channel_' . $channel;
+        }
+
+        /**
+         * Normalize the job payload ensuring required metadata is present.
+         *
+         * @param array $job       Original job payload.
+         * @param int   $timestamp Scheduled timestamp.
+         *
+         * @return array
+         */
+        private function normalize_job( array $job, $timestamp ) {
+            $job['job_id']        = isset( $job['job_id'] ) ? (string) $job['job_id'] : uniqid( 'tts_job_', true );
+            $job['post_id']       = isset( $job['post_id'] ) ? absint( $job['post_id'] ) : 0;
+            $job['channel']       = isset( $job['channel'] ) ? sanitize_key( $job['channel'] ) : '';
+            $job['client_id']     = isset( $job['client_id'] ) ? absint( $job['client_id'] ) : 0;
+            $job['attempt']       = isset( $job['attempt'] ) ? absint( $job['attempt'] ) : 0;
+            $job['max_attempts']  = isset( $job['max_attempts'] ) ? absint( $job['max_attempts'] ) : 5;
+            $job['scheduled_for'] = isset( $job['scheduled_for'] ) ? (int) $job['scheduled_for'] : (int) $timestamp;
+            $job['metadata']      = isset( $job['metadata'] ) && is_array( $job['metadata'] ) ? $job['metadata'] : array();
+
+            $job['metadata']['queued_at']    = isset( $job['metadata']['queued_at'] ) ? (int) $job['metadata']['queued_at'] : time();
+            $job['metadata']['scheduled_for'] = $job['scheduled_for'];
+
+            $config                       = $this->get_channel_config( $job['channel'] );
+            $job['retry_blueprint']       = isset( $job['retry_blueprint'] ) && is_array( $job['retry_blueprint'] ) ? $job['retry_blueprint'] : $config['retry'];
+            $job['circuit_blueprint']     = isset( $job['circuit_blueprint'] ) && is_array( $job['circuit_blueprint'] ) ? $job['circuit_blueprint'] : $config['circuit'];
+            $job['retry_blueprint']['strategy']   = $job['retry_blueprint']['strategy'] ?? $config['retry']['strategy'];
+            $job['retry_blueprint']['delays']     = isset( $job['retry_blueprint']['delays'] ) && is_array( $job['retry_blueprint']['delays'] ) ? $job['retry_blueprint']['delays'] : $config['retry']['delays'];
+            $job['retry_blueprint']['max_attempts'] = isset( $job['retry_blueprint']['max_attempts'] ) && is_array( $job['retry_blueprint']['max_attempts'] ) ? $job['retry_blueprint']['max_attempts'] : $config['retry']['max_attempts'];
+            $job['retry_blueprint']['global_max']  = isset( $job['retry_blueprint']['global_max'] ) ? absint( $job['retry_blueprint']['global_max'] ) : $config['retry']['global_max'];
+            $job['retry_blueprint']['jitter']      = isset( $job['retry_blueprint']['jitter'] ) ? absint( $job['retry_blueprint']['jitter'] ) : $config['retry']['jitter'];
+
+            return $job;
+        }
+
+        /**
+         * Remove runtime-only keys before sending job to Action Scheduler.
+         *
+         * @param array $job Job payload.
+         *
+         * @return array
+         */
+        private function strip_runtime_keys( array $job ) {
+            $job = $job;
+            unset( $job['scheduled_args'], $job['action_id'], $job['action_group'] );
+            return $job;
+        }
+
+        /**
+         * Ensure channel pending limit is respected.
+         *
+         * @param string $channel Channel identifier.
+         * @param string $group   Action Scheduler group.
+         *
+         * @return true|WP_Error
+         */
+        private function enforce_pending_limit( $channel, $group ) {
+            $config = $this->get_channel_config( $channel );
+            $limit  = isset( $config['max_pending'] ) ? absint( $config['max_pending'] ) : 0;
+
+            if ( $limit <= 0 ) {
+                return true;
+            }
+
+            if ( ! function_exists( 'as_get_scheduled_actions' ) ) {
+                return true;
+            }
+
+            $pending_actions = as_get_scheduled_actions(
+                array(
+                    'hook'          => self::ACTION_HOOK,
+                    'status'        => 'pending',
+                    'group'         => $group,
+                    'return_format' => 'ids',
+                    'per_page'      => $limit + 1,
+                )
+            );
+
+            if ( is_array( $pending_actions ) && count( $pending_actions ) >= $limit ) {
+                return new WP_Error(
+                    'channel_queue_saturated',
+                    sprintf(
+                        __( 'Il canale %s ha raggiunto il numero massimo di job in attesa.', 'fp-publisher' ),
+                        $channel
+                    ),
+                    array(
+                        'channel' => $channel,
+                        'limit'   => $limit,
+                    )
+                );
+            }
+
+            return true;
+        }
+
+        /**
+         * Merge channel configuration with defaults.
+         *
+         * @param array $channel_config Channel-specific overrides.
+         *
+         * @return array
+         */
+        private function merge_config( array $channel_config ) {
+            $config = $this->default_config;
+
+            if ( isset( $channel_config['max_pending'] ) ) {
+                $config['max_pending'] = absint( $channel_config['max_pending'] );
+            }
+
+            if ( isset( $channel_config['retry'] ) && is_array( $channel_config['retry'] ) ) {
+                $config['retry'] = wp_parse_args( $channel_config['retry'], $config['retry'] );
+
+                if ( isset( $channel_config['retry']['delays'] ) && is_array( $channel_config['retry']['delays'] ) ) {
+                    $config['retry']['delays'] = wp_parse_args( $channel_config['retry']['delays'], $config['retry']['delays'] );
+                }
+
+                if ( isset( $channel_config['retry']['max_attempts'] ) && is_array( $channel_config['retry']['max_attempts'] ) ) {
+                    $config['retry']['max_attempts'] = wp_parse_args( $channel_config['retry']['max_attempts'], $config['retry']['max_attempts'] );
+                }
+            }
+
+            if ( isset( $channel_config['circuit'] ) && is_array( $channel_config['circuit'] ) ) {
+                $config['circuit'] = wp_parse_args( $channel_config['circuit'], $config['circuit'] );
+
+                if ( isset( $channel_config['circuit']['cooldowns'] ) && is_array( $channel_config['circuit']['cooldowns'] ) ) {
+                    $config['circuit']['cooldowns'] = wp_parse_args( $channel_config['circuit']['cooldowns'], $config['circuit']['cooldowns'] );
+                }
+            }
+
+            return $config;
+        }
+
+        /**
+         * Read raw configuration from WordPress options.
+         *
+         * @return array
+         */
+        private function get_raw_config() {
+            $option = get_option( 'tts_channel_limits', array() );
+
+            if ( ! is_array( $option ) ) {
+                return array();
+            }
+
+            return $option;
+        }
+    }
+}

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
@@ -51,6 +51,36 @@ class TTS_Error_Recovery {
     }
 
     /**
+     * Assess severity for an error payload.
+     *
+     * @param mixed $error Error instance/data.
+     *
+     * @return int Severity constant.
+     */
+    public function assess_error_severity( $error ) {
+        $normalized = $this->normalize_error( $error );
+        return $this->determine_severity( $normalized );
+    }
+
+    /**
+     * Human readable severity label.
+     *
+     * @param int $severity Severity constant.
+     *
+     * @return string
+     */
+    public function get_severity_label( $severity ) {
+        $severity_names = array(
+            self::SEVERITY_LOW      => 'low',
+            self::SEVERITY_MEDIUM   => 'medium',
+            self::SEVERITY_HIGH     => 'high',
+            self::SEVERITY_CRITICAL => 'critical',
+        );
+
+        return $severity_names[ $severity ] ?? 'unknown';
+    }
+
+    /**
      * Add custom cron schedules
      */
     public function add_custom_cron_schedules( $schedules ) {
@@ -82,17 +112,34 @@ class TTS_Error_Recovery {
         $error_data = $this->normalize_error( $error );
         $severity = $this->determine_severity( $error_data );
         $strategy = $this->determine_retry_strategy( $error_data, $operation );
-        
+        $skip_retry_queue = ! empty( $context['skip_retry_queue'] );
+
         // Log error with context
         $this->log_error( $error_data, $operation, $context, $severity );
-        
+
         // Determine if retry is appropriate
         if ( $this->should_retry( $error_data, $operation, $context ) ) {
-            return $this->queue_for_retry( $error_data, $operation, $context, $strategy );
+            if ( $skip_retry_queue ) {
+                $retry_count = ( $context['retry_count'] ?? 0 ) + 1;
+
+                return array(
+                    'status'        => 'retry_delegated',
+                    'retry_count'   => $retry_count,
+                    'strategy'      => $strategy,
+                    'severity'      => $severity,
+                    'severity_label' => $this->get_severity_label( $severity ),
+                );
+            }
+
+            return $this->queue_for_retry( $error_data, $operation, $context, $strategy, $severity );
         }
-        
+
         // Handle non-retryable errors
-        return $this->handle_permanent_failure( $error_data, $operation, $context );
+        $result = $this->handle_permanent_failure( $error_data, $operation, $context, $severity );
+        $result['severity']       = $severity;
+        $result['severity_label'] = $this->get_severity_label( $severity );
+
+        return $result;
     }
 
     /**
@@ -217,10 +264,10 @@ class TTS_Error_Recovery {
     /**
      * Queue operation for retry
      */
-    private function queue_for_retry( $error_data, $operation, $context, $strategy ) {
+    private function queue_for_retry( $error_data, $operation, $context, $strategy, $severity ) {
         $retry_count = ( $context['retry_count'] ?? 0 ) + 1;
         $next_attempt = $this->calculate_next_attempt( $retry_count, $strategy );
-        
+
         $retry_item = array(
             'id' => uniqid( 'retry_' ),
             'operation' => $operation,
@@ -235,18 +282,20 @@ class TTS_Error_Recovery {
         
         $this->add_to_retry_queue( $retry_item );
         
-        TTS_Logger::log( 
-            sprintf( 'Operation queued for retry: %s (attempt %d/%d)', 
-                $operation, $retry_count, $this->max_retries 
+        TTS_Logger::log(
+            sprintf( 'Operation queued for retry: %s (attempt %d/%d)',
+                $operation, $retry_count, $this->max_retries
             ),
             'info'
         );
-        
+
         return array(
             'status' => 'queued_for_retry',
             'retry_count' => $retry_count,
             'next_attempt' => $next_attempt,
-            'strategy' => $strategy
+            'strategy' => $strategy,
+            'severity' => $severity,
+            'severity_label' => $this->get_severity_label( $severity ),
         );
     }
 
@@ -704,24 +753,26 @@ class TTS_Error_Recovery {
     /**
      * Handle permanent failure
      */
-    private function handle_permanent_failure( $error_data, $operation, $context ) {
+    private function handle_permanent_failure( $error_data, $operation, $context, $severity ) {
         // Log permanent failure
-        TTS_Logger::log( 
-            sprintf( 'Permanent failure for operation: %s. Error: %s', 
-                $operation, $error_data['message'] 
+        TTS_Logger::log(
+            sprintf( 'Permanent failure for operation: %s. Error: %s',
+                $operation, $error_data['message']
             ),
             'error'
         );
-        
+
         // Send notification for critical failures
-        if ( $this->determine_severity( $error_data ) >= self::SEVERITY_HIGH ) {
+        if ( $severity >= self::SEVERITY_HIGH ) {
             $this->send_failure_notification( $error_data, $operation, $context );
         }
-        
+
         return array(
             'status' => 'permanent_failure',
             'error' => $error_data,
-            'operation' => $operation
+            'operation' => $operation,
+            'severity' => $severity,
+            'severity_label' => $this->get_severity_label( $severity ),
         );
     }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-publisher-guard.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-publisher-guard.php
@@ -1,0 +1,416 @@
+<?php
+/**
+ * Protective wrapper for publisher operations integrating rate limiting and error recovery.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'TTS_Publisher_Guard' ) ) {
+    /**
+     * Provides resilience primitives (rate limiting, circuit breaker, alarms).
+     */
+    class TTS_Publisher_Guard {
+
+        /**
+         * Rate limiter instance.
+         *
+         * @var TTS_Rate_Limiter|null
+         */
+        private $rate_limiter;
+
+        /**
+         * Error recovery orchestrator.
+         *
+         * @var TTS_Error_Recovery|null
+         */
+        private $error_recovery;
+
+        /**
+         * Notification channel for alarms.
+         *
+         * @var TTS_Notifier
+         */
+        private $notifier;
+
+        /**
+         * Option key storing circuit breaker state.
+         */
+        private $circuit_option = 'tts_channel_circuit_breakers';
+
+        /**
+         * Constructor.
+         *
+         * @param TTS_Rate_Limiter|null   $rate_limiter   Rate limiter dependency.
+         * @param TTS_Error_Recovery|null $error_recovery Error recovery handler.
+         * @param TTS_Notifier|null       $notifier       Optional notifier override.
+         */
+        public function __construct( $rate_limiter = null, $error_recovery = null, $notifier = null ) {
+            if ( $rate_limiter instanceof TTS_Rate_Limiter ) {
+                $this->rate_limiter = $rate_limiter;
+            }
+
+            if ( $error_recovery instanceof TTS_Error_Recovery ) {
+                $this->error_recovery = $error_recovery;
+            }
+
+            if ( $notifier instanceof TTS_Notifier ) {
+                $this->notifier = $notifier;
+            } else {
+                $this->notifier = new TTS_Notifier();
+            }
+        }
+
+        /**
+         * Execute an operation within the guard rails.
+         *
+         * @param string   $channel Channel identifier.
+         * @param callable $operation Operation callback.
+         * @param array    $context Additional context (post_id, retry_count, etc.).
+         *
+         * @return array Response payload describing success or failure.
+         */
+        public function execute( $channel, callable $operation, array $context = array() ) {
+            $channel = sanitize_key( $channel );
+            $context = $this->prepare_context( $channel, $context );
+
+            if ( empty( $channel ) ) {
+                return array(
+                    'success' => false,
+                    'error'   => new WP_Error( 'invalid_channel', __( 'Canale non valido.', 'fp-publisher' ) ),
+                    'severity' => TTS_Error_Recovery::SEVERITY_HIGH,
+                );
+            }
+
+            $circuit_state = $this->get_circuit_state( $channel );
+            $now           = time();
+
+            if ( 'open' === $circuit_state['state'] && $now < $circuit_state['open_until'] ) {
+                $error = new WP_Error(
+                    'circuit_open',
+                    sprintf( __( 'Circuit breaker attivo per il canale %s.', 'fp-publisher' ), $channel ),
+                    array(
+                        'retry_after' => $circuit_state['open_until'] - $now,
+                        'channel'     => $channel,
+                    )
+                );
+
+                return array(
+                    'success'  => false,
+                    'severity' => TTS_Error_Recovery::SEVERITY_HIGH,
+                    'error'    => $error,
+                    'circuit'  => $circuit_state,
+                );
+            }
+
+            if ( 'open' === $circuit_state['state'] && $now >= $circuit_state['open_until'] ) {
+                $circuit_state['state'] = 'half_open';
+                $this->store_circuit_state( $channel, $circuit_state );
+            }
+
+            $rate_context = null;
+            if ( $this->rate_limiter instanceof TTS_Rate_Limiter ) {
+                $rate_context = $this->rate_limiter->is_request_allowed( $channel );
+                if ( isset( $rate_context['allowed'] ) && false === $rate_context['allowed'] ) {
+                    $error = new WP_Error(
+                        'rate_limit',
+                        $rate_context['reason'] ?? __( 'Limite di velocità raggiunto.', 'fp-publisher' ),
+                        $rate_context
+                    );
+
+                    $failure = $this->handle_failure( $channel, $error, TTS_Error_Recovery::SEVERITY_MEDIUM, $context );
+                    $failure['rate_limit'] = $rate_context;
+
+                    return $failure;
+                }
+            }
+
+            $start = microtime( true );
+
+            try {
+                $result = call_user_func( $operation );
+            } catch ( Throwable $throwable ) {
+                return $this->handle_failure( $channel, $throwable, null, $context );
+            }
+
+            if ( is_wp_error( $result ) ) {
+                return $this->handle_failure( $channel, $result, null, $context );
+            }
+
+            $duration = microtime( true ) - $start;
+
+            if ( $this->rate_limiter instanceof TTS_Rate_Limiter ) {
+                $this->rate_limiter->record_request(
+                    $channel,
+                    'publish',
+                    array(
+                        'response_time' => $duration,
+                        'status_code'   => 200,
+                    )
+                );
+            }
+
+            $this->reset_circuit( $channel );
+
+            return array(
+                'success'    => true,
+                'result'     => $result,
+                'duration'   => $duration,
+                'rate_limit' => $rate_context,
+            );
+        }
+
+        /**
+         * Prepare execution context.
+         *
+         * @param string $channel Channel identifier.
+         * @param array  $context Additional context.
+         *
+         * @return array
+         */
+        private function prepare_context( $channel, array $context ) {
+            $context['channel'] = $channel;
+            $context['retry_count'] = isset( $context['retry_count'] ) ? absint( $context['retry_count'] ) : 0;
+            $context['skip_retry_queue'] = isset( $context['skip_retry_queue'] ) ? (bool) $context['skip_retry_queue'] : true;
+
+            return $context;
+        }
+
+        /**
+         * Handle failure path.
+         *
+         * @param string         $channel  Channel identifier.
+         * @param WP_Error|mixed $error    Error payload.
+         * @param int|null       $severity Optional severity override.
+         * @param array          $context  Additional context.
+         *
+         * @return array Failure response payload.
+         */
+        private function handle_failure( $channel, $error, $severity = null, array $context = array() ) {
+            if ( null === $severity && $this->error_recovery instanceof TTS_Error_Recovery ) {
+                $severity = $this->error_recovery->assess_error_severity( $error );
+            } elseif ( null === $severity ) {
+                $severity = TTS_Error_Recovery::SEVERITY_MEDIUM;
+            }
+
+            $context['channel'] = $channel;
+            $recovery_response  = null;
+
+            if ( $this->error_recovery instanceof TTS_Error_Recovery ) {
+                $context['skip_retry_queue'] = $context['skip_retry_queue'] ?? true;
+                $recovery_response = $this->error_recovery->handle_error( $error, 'api_publish_post', $context );
+            }
+
+            $severity_label = $this->get_severity_label( $severity );
+            $circuit_state  = $this->register_failure( $channel, $severity_label, $error, $context );
+
+            if ( $severity >= TTS_Error_Recovery::SEVERITY_HIGH ) {
+                $this->send_alarm( $channel, $error, $context, $circuit_state );
+            }
+
+            return array(
+                'success'        => false,
+                'severity'       => $severity,
+                'severity_label' => $severity_label,
+                'error'          => $error,
+                'recovery'       => $recovery_response,
+                'circuit'        => $circuit_state,
+            );
+        }
+
+        /**
+         * Get human readable severity label.
+         *
+         * @param int $severity Severity code.
+         *
+         * @return string
+         */
+        private function get_severity_label( $severity ) {
+            if ( $this->error_recovery instanceof TTS_Error_Recovery ) {
+                return $this->error_recovery->get_severity_label( $severity );
+            }
+
+            $map = array(
+                TTS_Error_Recovery::SEVERITY_LOW      => 'low',
+                TTS_Error_Recovery::SEVERITY_MEDIUM   => 'medium',
+                TTS_Error_Recovery::SEVERITY_HIGH     => 'high',
+                TTS_Error_Recovery::SEVERITY_CRITICAL => 'critical',
+            );
+
+            return $map[ $severity ] ?? 'unknown';
+        }
+
+        /**
+         * Register a failure and update the circuit breaker state.
+         *
+         * @param string $channel Channel identifier.
+         * @param string $severity_label Severity label.
+         * @param mixed  $error   Error object/data.
+         * @param array  $context Context information.
+         *
+         * @return array Updated circuit state.
+         */
+        private function register_failure( $channel, $severity_label, $error, array $context = array() ) {
+            $state   = $this->get_circuit_state( $channel );
+            $state['failure_count'] = isset( $state['failure_count'] ) ? absint( $state['failure_count'] ) + 1 : 1;
+            $state['last_error']    = $this->normalize_error_payload( $error );
+            $state['last_severity'] = $severity_label;
+            $state['last_failure']  = time();
+
+            $config = isset( $context['channel_config']['circuit'] ) ? $context['channel_config']['circuit'] : array();
+            $threshold = isset( $config['failure_threshold'] ) ? absint( $config['failure_threshold'] ) : 3;
+            $cooldowns = isset( $config['cooldowns'] ) && is_array( $config['cooldowns'] ) ? $config['cooldowns'] : array();
+
+            $cooldown = isset( $cooldowns[ $severity_label ] ) ? absint( $cooldowns[ $severity_label ] ) : 600;
+
+            if ( in_array( $severity_label, array( 'high', 'critical' ), true ) || $state['failure_count'] >= $threshold ) {
+                $state['state']       = 'open';
+                $state['open_until']  = time() + max( 60, $cooldown );
+                $state['failure_count'] = $state['failure_count'];
+            }
+
+            $this->store_circuit_state( $channel, $state );
+
+            return $state;
+        }
+
+        /**
+         * Reset the circuit for the channel after a successful execution.
+         *
+         * @param string $channel Channel identifier.
+         */
+        private function reset_circuit( $channel ) {
+            $state = $this->get_circuit_state( $channel );
+            if ( 'closed' === $state['state'] && empty( $state['failure_count'] ) ) {
+                return;
+            }
+
+            $state['state']         = 'closed';
+            $state['failure_count'] = 0;
+            $state['open_until']    = 0;
+            $state['last_error']    = null;
+            $state['last_severity'] = null;
+
+            $this->store_circuit_state( $channel, $state );
+        }
+
+        /**
+         * Retrieve circuit state for a channel.
+         *
+         * @param string $channel Channel identifier.
+         *
+         * @return array
+         */
+        private function get_circuit_state( $channel ) {
+            $store = get_option( $this->circuit_option, array() );
+
+            if ( isset( $store[ $channel ] ) && is_array( $store[ $channel ] ) ) {
+                return wp_parse_args(
+                    $store[ $channel ],
+                    array(
+                        'state'         => 'closed',
+                        'failure_count' => 0,
+                        'open_until'    => 0,
+                        'last_error'    => null,
+                        'last_severity' => null,
+                    )
+                );
+            }
+
+            return array(
+                'state'         => 'closed',
+                'failure_count' => 0,
+                'open_until'    => 0,
+                'last_error'    => null,
+                'last_severity' => null,
+            );
+        }
+
+        /**
+         * Persist circuit state.
+         *
+         * @param string $channel Channel identifier.
+         * @param array  $state   Circuit state payload.
+         */
+        private function store_circuit_state( $channel, array $state ) {
+            $store           = get_option( $this->circuit_option, array() );
+            $store[ $channel ] = $state;
+            update_option( $this->circuit_option, $store, false );
+        }
+
+        /**
+         * Normalize error payload for circuit storage.
+         *
+         * @param mixed $error Error payload.
+         *
+         * @return array|null
+         */
+        private function normalize_error_payload( $error ) {
+            if ( is_wp_error( $error ) ) {
+                return array(
+                    'code'    => $error->get_error_code(),
+                    'message' => $error->get_error_message(),
+                    'data'    => $error->get_error_data(),
+                );
+            }
+
+            if ( $error instanceof Throwable ) {
+                return array(
+                    'code'    => $error->getCode(),
+                    'message' => $error->getMessage(),
+                );
+            }
+
+            if ( is_array( $error ) ) {
+                return $error;
+            }
+
+            if ( is_string( $error ) ) {
+                return array(
+                    'code'    => 'error',
+                    'message' => $error,
+                );
+            }
+
+            return null;
+        }
+
+        /**
+         * Send alarm notification for severe incidents.
+         *
+         * @param string $channel Channel identifier.
+         * @param mixed  $error   Error payload.
+         * @param array  $context Context information.
+         * @param array  $state   Circuit state.
+         */
+        private function send_alarm( $channel, $error, array $context, array $state ) {
+            $message_parts = array();
+            $message_parts[] = sprintf( 'Channel: %s', $channel );
+
+            if ( is_wp_error( $error ) ) {
+                $message_parts[] = sprintf( 'Error: %s (%s)', $error->get_error_message(), $error->get_error_code() );
+            } elseif ( $error instanceof Throwable ) {
+                $message_parts[] = sprintf( 'Exception: %s', $error->getMessage() );
+            }
+
+            if ( isset( $context['post_id'] ) ) {
+                $message_parts[] = sprintf( 'Post ID: %d', absint( $context['post_id'] ) );
+            }
+
+            if ( isset( $state['open_until'] ) && $state['open_until'] > time() ) {
+                $message_parts[] = sprintf( 'Circuit open until: %s', date_i18n( 'c', $state['open_until'] ) );
+            }
+
+            $message = implode( ' | ', $message_parts );
+
+            $this->notifier->notify_slack( '[Publisher Guard] ' . $message );
+            $this->notifier->notify_email(
+                __( 'Blocco pubblicazione canale', 'fp-publisher' ),
+                $message
+            );
+        }
+    }
+}

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rate-limiter.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rate-limiter.php
@@ -66,6 +66,8 @@ class TTS_Rate_Limiter {
             $this->logger = null;
         }
 
+        $this->apply_custom_limits();
+
         add_action( 'wp_ajax_tts_check_rate_limits', array( $this, 'ajax_check_rate_limits' ) );
         add_action( 'wp_ajax_tts_reset_rate_limits', array( $this, 'ajax_reset_rate_limits' ) );
         add_action( 'wp_ajax_tts_get_quota_status', array( $this, 'ajax_get_quota_status' ) );
@@ -75,6 +77,31 @@ class TTS_Rate_Limiter {
         if ( ! wp_next_scheduled( 'tts_hourly_rate_limit_cleanup' ) ) {
             wp_schedule_event( time(), 'hourly', 'tts_hourly_rate_limit_cleanup' );
         }
+    }
+
+    /**
+     * Merge custom limits coming from configuration.
+     */
+    private function apply_custom_limits() {
+        $config = get_option( 'tts_channel_limits', array() );
+
+        if ( ! is_array( $config ) ) {
+            $config = array();
+        }
+
+        foreach ( $config as $channel => $settings ) {
+            if ( ! is_array( $settings ) || ! isset( $settings['rate_limits'] ) ) {
+                continue;
+            }
+
+            $channel_key = sanitize_key( $channel );
+            $overrides   = is_array( $settings['rate_limits'] ) ? $settings['rate_limits'] : array();
+            $defaults    = isset( $this->rate_limits[ $channel_key ] ) ? $this->rate_limits[ $channel_key ] : array();
+
+            $this->rate_limits[ $channel_key ] = wp_parse_args( $overrides, $defaults );
+        }
+
+        $this->rate_limits = apply_filters( 'tts_rate_limiter_limits', $this->rate_limits );
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -14,27 +14,47 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class TTS_Scheduler implements TTS_Scheduler_Interface {
 
-    /**
-     * Integration gateway used to notify downstream systems.
-     *
-     * @var TTS_Integration_Gateway_Interface|null
-     */
     private $integration_gateway;
-
-    /**
-     * Observability channel for telemetry.
-     *
-     * @var TTS_Observability_Channel_Interface|null
-     */
     private $telemetry_channel;
+    private $channel_queue;
+    private $rate_limiter;
+    private $error_recovery;
+    private $publisher_guard;
+    private $notifier;
+    private $retry_state_meta_key = '_tts_channel_retry_state';
+    private $queued_channels_meta_key = '_tts_queued_channels';
+    private $finalized_meta_key = '_tts_publication_finalized';
+    private $default_channel_config = array(
+        'max_pending' => 10,
+        'retry'       => array(
+            'strategy'     => 'progressive',
+            'global_max'   => 5,
+            'jitter'       => 60,
+            'delays'       => array(
+                'low'      => 5,
+                'medium'   => 15,
+                'high'     => 30,
+                'critical' => 60,
+            ),
+            'max_attempts' => array(
+                'low'      => 5,
+                'medium'   => 4,
+                'high'     => 3,
+                'critical' => 1,
+            ),
+        ),
+        'circuit'     => array(
+            'failure_threshold' => 3,
+            'cooldowns'         => array(
+                'low'      => 300,
+                'medium'   => 600,
+                'high'     => 900,
+                'critical' => 1800,
+            ),
+        ),
+    );
 
-    /**
-     * Constructor.
-     *
-     * @param TTS_Integration_Gateway_Interface|null   $integration_gateway Integration gateway dependency.
-     * @param TTS_Observability_Channel_Interface|null $telemetry_channel   Telemetry channel dependency.
-     */
-    public function __construct( $integration_gateway = null, $telemetry_channel = null ) {
+    public function __construct( $integration_gateway = null, $telemetry_channel = null, $channel_queue = null, $rate_limiter = null, $error_recovery = null, $publisher_guard = null ) {
         if ( $integration_gateway instanceof TTS_Integration_Gateway_Interface ) {
             $this->integration_gateway = $integration_gateway;
         } else {
@@ -47,30 +67,54 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
             $this->telemetry_channel = null;
         }
 
+        if ( $channel_queue instanceof TTS_Channel_Queue ) {
+            $this->channel_queue = $channel_queue;
+        } elseif ( class_exists( 'TTS_Channel_Queue' ) ) {
+            $this->channel_queue = new TTS_Channel_Queue();
+        } else {
+            $this->channel_queue = null;
+        }
+
+        if ( $rate_limiter instanceof TTS_Rate_Limiter ) {
+            $this->rate_limiter = $rate_limiter;
+        } else {
+            $this->rate_limiter = null;
+        }
+
+        if ( $error_recovery instanceof TTS_Error_Recovery ) {
+            $this->error_recovery = $error_recovery;
+        } else {
+            $this->error_recovery = class_exists( 'TTS_Error_Recovery' ) ? new TTS_Error_Recovery() : null;
+        }
+
+        if ( $publisher_guard instanceof TTS_Publisher_Guard ) {
+            $this->publisher_guard = $publisher_guard;
+        } elseif ( class_exists( 'TTS_Publisher_Guard' ) ) {
+            $this->publisher_guard = new TTS_Publisher_Guard( $this->rate_limiter, $this->error_recovery );
+        } else {
+            $this->publisher_guard = null;
+        }
+
+        $this->notifier = new TTS_Notifier();
+
         add_action( 'save_post_tts_social_post', array( $this, 'schedule_post' ), 10, 3 );
         add_action( 'tts_publish_social_post', array( $this, 'publish_social_post' ), 10, 2 );
+
+        if ( class_exists( 'TTS_Channel_Queue' ) ) {
+            add_action( TTS_Channel_Queue::ACTION_HOOK, array( $this, 'publish_social_post' ), 10, 1 );
+        }
     }
 
-    /**
-     * Schedule post publication via Action Scheduler.
-     *
-     * @param int     $post_id Post ID.
-     * @param WP_Post $post    Post object.
-     * @param bool    $update  Whether this is an existing post being updated.
-     */
     public function schedule_post( $post_id, $post, $update ) {
         if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
             return;
         }
 
-        // Security check: only process if this is a legitimate post save with proper nonce
         if ( isset( $_POST['_tts_approved'] ) ) {
-            // Verify nonce if processing form data
             if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-post_' . $post_id ) ) {
                 return;
             }
-            
-            // Check user capabilities for this specific post
+
             if ( ! current_user_can( 'edit_post', $post_id ) ) {
                 return;
             }
@@ -109,11 +153,6 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
         $this->queue_from_request( $request );
     }
 
-    /**
-     * Queue a publication based on a schedule request.
-     *
-     * @param TTS_Schedule_Request $request Schedule request payload.
-     */
     public function queue_from_request( TTS_Schedule_Request $request ) {
         $post_id = $request->get_post_id();
 
@@ -122,6 +161,9 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
         }
 
         $channels = $request->get_channels();
+        $channels = $this->resolve_channels_from_trello( $post_id, $request->get_client_id(), $channels );
+        $channels = $this->expand_channel_targets( $post_id, $channels );
+
         $this->unschedule_post_actions( $post_id, $channels );
 
         if ( ! $request->is_approved() ) {
@@ -150,19 +192,38 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
             return;
         }
 
-        $options = get_option( 'tts_settings', array() );
-
         if ( empty( $channels ) ) {
             as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( $post_id ) );
-        } else {
-            foreach ( $channels as $channel ) {
-                if ( ! is_string( $channel ) || '' === $channel ) {
+            return;
+        }
+
+        $this->initialize_queued_channels( $post_id, $channels );
+
+        foreach ( $channels as $channel ) {
+            $channel_config = $this->get_channel_config( $channel );
+            $job_payload    = $this->build_job_payload( $request, $channel, $timestamp, $channel_config );
+
+            if ( $this->channel_queue instanceof TTS_Channel_Queue ) {
+                $enqueued_job = $this->channel_queue->enqueue_job( $job_payload, $timestamp );
+
+                if ( is_wp_error( $enqueued_job ) ) {
+                    $this->maybe_record_event(
+                        'warning',
+                        __( 'Unable to enqueue channel job.', 'fp-publisher' ),
+                        array(
+                            'post_id'  => $post_id,
+                            'channel'  => $channel,
+                            'error'    => $enqueued_job->get_error_message(),
+                        )
+                    );
+
+                    as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( $post_id, $channel ) );
                     continue;
                 }
 
-                $offset = isset( $options[ $channel . '_offset' ] ) ? intval( $options[ $channel . '_offset' ] ) : 0;
-                $when   = $timestamp + $offset * MINUTE_IN_SECONDS;
-                as_schedule_single_action( $when, 'tts_publish_social_post', array( $post_id, $channel ) );
+                $this->register_job_state( $post_id, $channel, $enqueued_job, $channel_config );
+            } else {
+                as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( $post_id, $channel ) );
             }
         }
 
@@ -177,11 +238,6 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
         );
     }
 
-    /**
-     * Release scheduled actions for a post and optional channels.
-     *
-     * @param TTS_Schedule_Cancellation $cancellation Cancellation payload.
-     */
     public function release_schedule( TTS_Schedule_Cancellation $cancellation ) {
         $post_id = $cancellation->get_post_id();
 
@@ -202,12 +258,6 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
         );
     }
 
-    /**
-     * Unschedule any pending publish actions for a post.
-     *
-     * @param int          $post_id  Post ID.
-     * @param string|array $channels Optional channel or list of channels.
-     */
     private function unschedule_post_actions( $post_id, $channels = array() ) {
         $post_id = absint( $post_id );
 
@@ -218,8 +268,10 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
         as_unschedule_all_actions( 'tts_publish_social_post', array( $post_id ) );
         as_unschedule_all_actions( 'tts_publish_social_post', array( 'post_id' => $post_id ) );
 
+        $state = $this->get_channel_state( $post_id );
+
         if ( empty( $channels ) ) {
-            return;
+            $channels = array_keys( $state );
         }
 
         if ( ! is_array( $channels ) ) {
@@ -233,275 +285,406 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
 
             as_unschedule_all_actions( 'tts_publish_social_post', array( $post_id, $channel ) );
             as_unschedule_all_actions( 'tts_publish_social_post', array( 'post_id' => $post_id, 'channel' => $channel ) );
+
+            if ( $this->channel_queue instanceof TTS_Channel_Queue && isset( $state[ $channel ]['scheduled_args'] ) ) {
+                $args  = $state[ $channel ]['scheduled_args'];
+                $group = $state[ $channel ]['action_group'] ?? '';
+                as_unschedule_all_actions( TTS_Channel_Queue::ACTION_HOOK, $args, $group );
+            }
+
+            unset( $state[ $channel ] );
         }
+
+        $this->set_channel_state( $post_id, $state );
     }
 
-    /**
-     * Send an observability event when telemetry is available.
-     *
-     * @param string $level   Severity level.
-     * @param string $message Event message.
-     * @param array  $context Additional context.
-     */
-    private function maybe_record_event( $level, $message, $context = array() ) {
-        if ( ! $this->telemetry_channel instanceof TTS_Observability_Channel_Interface ) {
+    public function publish_social_post( $payload, $channel = '' ) {
+        if ( is_array( $payload ) && isset( $payload['post_id'] ) ) {
+            $this->process_channel_job( $payload );
             return;
         }
 
-        $event = new TTS_Observability_Event( 'scheduler', $level, $message, $context );
-        $this->telemetry_channel->record_event( $event );
-    }
-
-    /**
-     * Publish the social post to configured networks.
-     *
-     * @param int|array $post_id Post ID or legacy argument array.
-     * @param string    $channel Optional channel override.
-     */
-    public function publish_social_post( $post_id, $channel = '' ) {
-        if ( is_array( $post_id ) ) {
-            $args    = $post_id;
-            $post_id = isset( $args['post_id'] ) ? intval( $args['post_id'] ) : ( isset( $args[0] ) ? intval( $args[0] ) : 0 );
-            $channel = isset( $args['channel'] ) ? $args['channel'] : ( isset( $args[1] ) ? $args[1] : '' );
-        }
-
-        $post_id        = intval( $post_id );
-        $forced_channel = is_string( $channel ) ? sanitize_text_field( $channel ) : '';
+        $post_id = intval( $payload );
         if ( ! $post_id ) {
             return;
         }
 
-        $notifier = new TTS_Notifier();
+        $resolved_channel = is_string( $channel ) ? sanitize_key( $channel ) : '';
 
-        $attempt      = (int) get_post_meta( $post_id, '_tts_retry_count', true );
-        $max_attempts = 5;
+        $channels = array();
+        if ( '' !== $resolved_channel ) {
+            $channels = array( $resolved_channel );
+        } else {
+            $configured = get_post_meta( $post_id, '_tts_social_channel', true );
+            if ( is_array( $configured ) ) {
+                $channels = $configured;
+            } elseif ( ! empty( $configured ) ) {
+                $channels = array( $configured );
+            }
+        }
 
-        $client_id = intval( get_post_meta( $post_id, '_tts_client_id', true ) );
-        if ( ! $client_id ) {
-            tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing client ID', 'fp-publisher' ), '' );
+        $channels = $this->expand_channel_targets( $post_id, $channels );
+
+        if ( empty( $channels ) ) {
             return;
         }
 
-        tts_log_event( $post_id, 'scheduler', 'start', __( 'Publishing social post', 'fp-publisher' ), '' );
+        foreach ( $channels as $target_channel ) {
+            $job = $this->build_ad_hoc_job( $post_id, $target_channel );
+            $this->process_channel_job( $job );
+        }
+    }
 
-        $tokens = array(
-            'facebook'  => get_post_meta( $client_id, '_tts_fb_token', true ),
-            'instagram' => get_post_meta( $client_id, '_tts_ig_token', true ),
-            // Added support for YouTube uploads.
-            'youtube'   => get_post_meta( $client_id, '_tts_yt_token', true ),
-            // Added support for TikTok uploads.
-            'tiktok'    => get_post_meta( $client_id, '_tts_tt_token', true ),
-            // Added support for Blog publishing.
-            'blog'      => get_post_meta( $client_id, '_tts_blog_settings', true ),
+    private function process_channel_job( array $job ) {
+        $post_id = isset( $job['post_id'] ) ? absint( $job['post_id'] ) : 0;
+        $channel = isset( $job['channel'] ) ? sanitize_key( $job['channel'] ) : '';
+
+        if ( ! $post_id || '' === $channel ) {
+            return;
+        }
+
+        $client_id = isset( $job['client_id'] ) ? absint( $job['client_id'] ) : intval( get_post_meta( $post_id, '_tts_client_id', true ) );
+        if ( ! $client_id ) {
+            tts_log_event( $post_id, $channel, 'error', __( 'Missing client ID', 'fp-publisher' ), '' );
+            return;
+        }
+
+        $state          = $this->get_channel_state( $post_id );
+        $channel_state  = isset( $state[ $channel ] ) ? $state[ $channel ] : array();
+        $channel_config = isset( $channel_state['config'] ) ? $channel_state['config'] : $this->get_channel_config( $channel );
+
+        $attempt_index    = isset( $job['attempt'] ) ? absint( $job['attempt'] ) : ( isset( $channel_state['attempts'] ) ? absint( $channel_state['attempts'] ) : 0 );
+        $current_attempt  = max( 1, $attempt_index + 1 );
+        $max_attempts     = isset( $channel_state['max_attempts'] ) ? absint( $channel_state['max_attempts'] ) : ( isset( $job['max_attempts'] ) ? absint( $job['max_attempts'] ) : ( $channel_config['retry']['global_max'] ?? 5 ) );
+        $channel_state['status']        = 'in_progress';
+        $channel_state['last_started']  = time();
+        $channel_state['attempts']      = $current_attempt;
+        $channel_state['config']        = $channel_config;
+        $channel_state['job_id']        = $job['job_id'] ?? ( $channel_state['job_id'] ?? uniqid( 'tts_job_', true ) );
+        $channel_state['scheduled_args'] = $job['scheduled_args'] ?? ( $channel_state['scheduled_args'] ?? array( $job ) );
+        $channel_state['action_group']  = $job['action_group'] ?? ( $channel_state['action_group'] ?? '' );
+        $channel_state['next_attempt']  = null;
+        $channel_state['last_error']    = $channel_state['last_error'] ?? null;
+        $channel_state['last_updated']  = time();
+
+        $state[ $channel ] = $channel_state;
+        $this->set_channel_state( $post_id, $state );
+
+        tts_log_event( $post_id, $channel, 'start', __( 'Publishing social post', 'fp-publisher' ), '' );
+        $this->dispatch_integration_event( $post_id, $client_id, array( $channel ) );
+
+        $tokens       = $this->get_client_tokens( $client_id );
+        $options      = get_option( 'tts_settings', array() );
+        $attachments  = $this->get_post_attachments( $post_id );
+        $binding      = $this->resolve_publisher_binding( $channel );
+
+        if ( is_wp_error( $binding ) ) {
+            $this->handle_job_failure( $post_id, $channel, $client_id, $current_attempt, $max_attempts, $channel_config, $binding, $state );
+            return;
+        }
+
+        if ( ! file_exists( $binding['file'] ) ) {
+            $error = new WP_Error( 'missing_publisher', sprintf( __( 'Publisher file missing for %s.', 'fp-publisher' ), $channel ) );
+            $this->handle_job_failure( $post_id, $channel, $client_id, $current_attempt, $max_attempts, $channel_config, $error, $state );
+            return;
+        }
+
+        require_once $binding['file'];
+
+        if ( ! class_exists( $binding['class'] ) ) {
+            $error = new WP_Error( 'missing_publisher_class', sprintf( __( 'Publisher class missing for %s.', 'fp-publisher' ), $channel ) );
+            $this->handle_job_failure( $post_id, $channel, $client_id, $current_attempt, $max_attempts, $channel_config, $error, $state );
+            return;
+        }
+
+        $publisher   = new $binding['class']();
+        $credentials = isset( $tokens[ $binding['credential_key'] ] ) ? $tokens[ $binding['credential_key'] ] : '';
+        $message     = $this->resolve_message( $post_id, $channel, $options );
+        $guard_ctx   = array(
+            'post_id'        => $post_id,
+            'client_id'      => $client_id,
+            'retry_count'    => $current_attempt - 1,
+            'channel_config' => $channel_config,
+            'skip_retry_queue' => true,
         );
 
-        $options  = get_option( 'tts_settings', array() );
-        $channels = $forced_channel ? array( $forced_channel ) : get_post_meta( $post_id, '_tts_social_channel', true );
+        $operation = function () use ( $publisher, $binding, $post_id, $credentials, $message, $attachments, $channel ) {
+            if ( 'story' === $binding['mode'] ) {
+                $media_url = $this->get_story_media_url( $post_id );
+                if ( ! $media_url ) {
+                    return new WP_Error( 'missing_story_media', __( 'Missing Story media', 'fp-publisher' ) );
+                }
 
-        if ( ! is_array( $channels ) ) {
-            $channels = $channels ? array( $channels ) : array();
+                return $publisher->publish_story( $post_id, $credentials, $media_url );
+            }
+
+            if ( $attachments ) {
+                $processor   = new TTS_Image_Processor();
+                $resized_map = array();
+                foreach ( $attachments as $attachment_id ) {
+                    $url = $processor->resize_for_channel( $attachment_id, $channel );
+                    if ( $url ) {
+                        $resized_map[ $attachment_id ] = $url;
+                    }
+                }
+
+                if ( $resized_map ) {
+                    update_post_meta( $post_id, '_tts_resized_' . $channel, $resized_map );
+                }
+            }
+
+            $publish_result = $publisher->publish( $post_id, $credentials, $message );
+            if ( is_wp_error( $publish_result ) ) {
+                return $publish_result;
+            }
+
+            $payload = array(
+                'publish' => $publish_result,
+            );
+
+            if ( 'instagram' === $channel && is_array( $publish_result ) && isset( $publish_result['id'] ) ) {
+                $first_comment = get_post_meta( $post_id, '_tts_instagram_first_comment', true );
+                if ( $first_comment ) {
+                    $comment_res = $publisher->post_comment( $publish_result['id'], $first_comment );
+                    if ( is_wp_error( $comment_res ) ) {
+                        return $comment_res;
+                    }
+                    $payload['comment'] = $comment_res;
+                }
+            }
+
+            return $payload;
+        };
+
+        $guard_response = $this->execute_guarded_operation( $channel, $operation, $guard_ctx );
+
+        if ( ! empty( $guard_response['success'] ) ) {
+            $this->handle_job_success( $post_id, $channel, $client_id, $current_attempt, $state, $guard_response['result'], $channel_config );
+            return;
         }
+
+        $this->handle_job_failure(
+            $post_id,
+            $channel,
+            $client_id,
+            $current_attempt,
+            $max_attempts,
+            $channel_config,
+            $guard_response['error'] ?? new WP_Error( 'publisher_error', __( 'Unknown publishing error', 'fp-publisher' ) ),
+            $state,
+            $guard_response
+        );
+    }
+
+    private function execute_guarded_operation( $channel, callable $operation, array $context ) {
+        if ( $this->publisher_guard instanceof TTS_Publisher_Guard ) {
+            return $this->publisher_guard->execute( $channel, $operation, $context );
+        }
+
+        try {
+            $result = call_user_func( $operation );
+            if ( is_wp_error( $result ) ) {
+                return array(
+                    'success'  => false,
+                    'error'    => $result,
+                    'severity' => $this->error_recovery instanceof TTS_Error_Recovery ? $this->error_recovery->assess_error_severity( $result ) : TTS_Error_Recovery::SEVERITY_MEDIUM,
+                );
+            }
+
+            return array(
+                'success' => true,
+                'result'  => $result,
+            );
+        } catch ( \Throwable $exception ) {
+            return array(
+                'success'  => false,
+                'error'    => $exception,
+                'severity' => TTS_Error_Recovery::SEVERITY_HIGH,
+            );
+        }
+    }
+
+    private function handle_job_success( $post_id, $channel, $client_id, $current_attempt, array $state, $result, array $channel_config ) {
+        $channel_state = isset( $state[ $channel ] ) ? $state[ $channel ] : array();
+        $channel_state['status']        = 'completed';
+        $channel_state['attempts']      = $current_attempt;
+        $channel_state['last_error']    = null;
+        $channel_state['completed_at']  = time();
+        $channel_state['next_attempt']  = null;
+        $channel_state['scheduled_args'] = null;
+        $channel_state['action_group']  = null;
+        $channel_state['last_updated']  = time();
+        $state[ $channel ]              = $channel_state;
+        $this->set_channel_state( $post_id, $state );
+
+        $log = get_post_meta( $post_id, '_tts_publish_log', true );
+        if ( ! is_array( $log ) ) {
+            $log = array();
+        }
+
+        if ( is_array( $result ) && isset( $result['publish'] ) ) {
+            $log[ $channel ] = $result['publish'];
+            if ( isset( $result['comment'] ) ) {
+                $log['instagram_comment'] = $result['comment'];
+            }
+        } else {
+            $log[ $channel ] = $result;
+        }
+
+        update_post_meta( $post_id, '_tts_publish_log', $log );
+        tts_log_event( $post_id, $channel, 'success', __( 'Channel publish completed', 'fp-publisher' ), $log[ $channel ] );
 
         $this->maybe_record_event(
             'info',
-            __( 'Publishing social post triggered.', 'fp-publisher' ),
+            __( 'Channel job completed.', 'fp-publisher' ),
             array(
-                'post_id'   => $post_id,
-                'client_id' => $client_id,
-                'channels'  => $channels,
+                'post_id'  => $post_id,
+                'channel'  => $channel,
+                'attempts' => $current_attempt,
             )
         );
 
-        if ( $this->integration_gateway instanceof TTS_Integration_Gateway_Interface ) {
-            $message = new TTS_Integration_Message(
-                0,
-                'publication_sync',
-                array(
-                    'post_id'   => $post_id,
-                    'client_id' => $client_id,
-                    'channels'  => $channels,
-                ),
-                array(
-                    'post_id'  => $post_id,
-                    'channels' => $channels,
-                )
-            );
-            $this->integration_gateway->dispatch_message( $message );
+        $this->maybe_complete_post( $post_id, $client_id );
+    }
+
+    private function handle_job_failure( $post_id, $channel, $client_id, $current_attempt, $max_attempts, array $channel_config, $error, array $state, $guard_response = null ) {
+        $channel_state = isset( $state[ $channel ] ) ? $state[ $channel ] : array();
+        $channel_state['status']       = 'retry_pending';
+        $channel_state['attempts']     = $current_attempt;
+        $channel_state['last_updated'] = time();
+
+        $severity = $guard_response['severity'] ?? ( $this->error_recovery instanceof TTS_Error_Recovery ? $this->error_recovery->assess_error_severity( $error ) : TTS_Error_Recovery::SEVERITY_MEDIUM );
+        $severity_label = $guard_response['severity_label'] ?? ( $this->error_recovery instanceof TTS_Error_Recovery ? $this->error_recovery->get_severity_label( $severity ) : 'medium' );
+
+        $message = '';
+        if ( is_wp_error( $error ) ) {
+            $message = $error->get_error_message();
+        } elseif ( $error instanceof \Throwable ) {
+            $message = $error->getMessage();
+        } elseif ( is_array( $error ) && isset( $error['message'] ) ) {
+            $message = $error['message'];
+        } else {
+            $message = (string) $error;
         }
 
-        if ( empty( $channels ) && ! $forced_channel ) {
-            $mapped_channel = '';
-            $id_list        = get_post_meta( $post_id, '_trello_idList', true );
-            $board_id      = get_post_meta( $post_id, '_trello_board_id', true );
-            if ( empty( $id_list ) || empty( $board_id ) ) {
-                $card_id     = get_post_meta( $post_id, '_trello_card_id', true );
-                $trello_key   = get_post_meta( $client_id, '_tts_trello_key', true );
-                $trello_token = get_post_meta( $client_id, '_tts_trello_token', true );
-                if ( $card_id && $trello_key && $trello_token ) {
-                    $url      = 'https://api.trello.com/1/cards/' . rawurlencode( $card_id ) . '?fields=idList,idBoard&key=' . rawurlencode( $trello_key ) . '&token=' . rawurlencode( $trello_token );
-                    $response = wp_remote_get( $url, array( 'timeout' => 20 ) );
-                    if ( ! is_wp_error( $response ) ) {
-                        $body = json_decode( wp_remote_retrieve_body( $response ), true );
-                        if ( isset( $body['idList'] ) ) {
-                            $id_list = $body['idList'];
-                        }
-                        if ( isset( $body['idBoard'] ) ) {
-                            $board_id = $body['idBoard'];
-                        }
-                    }
-                }
-            }
-            if ( $board_id ) {
-                update_post_meta( $post_id, '_trello_board_id', $board_id );
-            }
-            if ( $id_list ) {
-                $mapping = get_post_meta( $client_id, '_tts_trello_map', true );
-                if ( is_array( $mapping ) ) {
-                    foreach ( $mapping as $row ) {
-                        if ( isset( $row['idList'], $row['canale_social'] ) && $row['idList'] === $id_list ) {
-                            $mapped_channel = $row['canale_social'];
-                            break;
-                        }
-                    }
-                }
-            }
-            if ( $mapped_channel ) {
-                $channels = array( $mapped_channel );
-            }
+        $channel_state['last_error'] = array(
+            'message'  => $message,
+            'severity' => $severity_label,
+            'time'     => time(),
+        );
+
+        $state[ $channel ] = $channel_state;
+        $this->set_channel_state( $post_id, $state );
+
+        $log = get_post_meta( $post_id, '_tts_publish_log', true );
+        if ( ! is_array( $log ) ) {
+            $log = array();
         }
-
-        if ( empty( $channels ) ) {
-            tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing social channel', 'fp-publisher' ), '' );
-            return;
-        }
-
-        $channels = is_array( $channels ) ? $channels : array( $channels );
-        $log      = array();
-
-        $attachment_ids = get_post_meta( $post_id, '_tts_attachment_ids', true );
-        $attachment_ids = is_array( $attachment_ids ) ? array_map( 'intval', $attachment_ids ) : array();
-        $manual_id      = (int) get_post_meta( $post_id, '_tts_manual_media', true );
-        if ( $manual_id ) {
-            $attachment_ids[] = $manual_id;
-        }
-
-        $processor = new TTS_Image_Processor();
-
-        $error = false;
-
-        foreach ( $channels as $ch ) {
-            if ( $attachment_ids ) {
-                $resized = array();
-                foreach ( $attachment_ids as $att_id ) {
-                    $url = $processor->resize_for_channel( $att_id, $ch );
-                    if ( $url ) {
-                        $resized[ $att_id ] = $url;
-                    }
-                }
-                if ( $resized ) {
-                    update_post_meta( $post_id, '_tts_resized_' . $ch, $resized );
-                }
-            }
-            $class = 'TTS_Publisher_' . ucfirst( $ch );
-            $file  = plugin_dir_path( __FILE__ ) . 'publishers/class-tts-publisher-' . $ch . '.php';
-
-            if ( file_exists( $file ) ) {
-                require_once $file;
-                if ( class_exists( $class ) ) {
-                    $publisher   = new $class();
-                    $credentials = isset( $tokens[ $ch ] ) ? $tokens[ $ch ] : '';
-                    $template    = isset( $options[ $ch . '_template' ] ) ? $options[ $ch . '_template' ] : '';
-                    $custom_message = get_post_meta( $post_id, '_tts_message_' . $ch, true );
-                    if ( $custom_message ) {
-                        $message = $custom_message;
-                    } else {
-                        $message = $template ? tts_apply_template( $template, $post_id, $ch ) : '';
-                    }
-
-                    try {
-                        $log[ $ch ] = $publisher->publish( $post_id, $credentials, $message );
-                        if ( is_wp_error( $log[ $ch ] ) ) {
-                            $error = true;
-                        } elseif ( 'instagram' === $ch ) {
-                            $first_comment = get_post_meta( $post_id, '_tts_instagram_first_comment', true );
-                            if ( $first_comment && is_array( $log[ $ch ] ) && isset( $log[ $ch ]['id'] ) ) {
-                                $comment_res = $publisher->post_comment( $log[ $ch ]['id'], $first_comment );
-                                if ( is_wp_error( $comment_res ) ) {
-                                    $error = true;
-                                    $log['instagram_comment'] = $comment_res;
-                                } else {
-                                    $log['instagram_comment'] = $comment_res;
-                                }
-                            }
-                        }
-                    } catch ( \Exception $e ) {
-                        $error       = true;
-                        $log[ $ch ]  = $e->getMessage();
-                        tts_log_event( $post_id, $ch, 'error', $e->getMessage(), '' );
-                    }
-                }
-            }
-        }
-
-        $publish_story = (bool) get_post_meta( $post_id, '_tts_publish_story', true );
-        if ( $publish_story ) {
-            $story_id  = (int) get_post_meta( $post_id, '_tts_story_media', true );
-            $media_url = $story_id ? wp_get_attachment_url( $story_id ) : '';
-            if ( $media_url ) {
-                $story_channels = array( 'facebook', 'instagram' );
-                foreach ( $story_channels as $story_channel ) {
-                    $class = 'TTS_Publisher_' . ucfirst( $story_channel ) . '_Story';
-                    $file  = plugin_dir_path( __FILE__ ) . 'publishers/class-tts-publisher-' . $story_channel . '-story.php';
-                    if ( file_exists( $file ) ) {
-                        require_once $file;
-                        if ( class_exists( $class ) ) {
-                            $publisher   = new $class();
-                            $credentials = isset( $tokens[ $story_channel ] ) ? $tokens[ $story_channel ] : '';
-                            try {
-                                $key             = $story_channel . '_story';
-                                $log[ $key ]     = $publisher->publish_story( $post_id, $credentials, $media_url );
-                                if ( is_wp_error( $log[ $key ] ) ) {
-                                    $error = true;
-                                }
-                            } catch ( \Exception $e ) {
-                                $error = true;
-                                $log[ $story_channel . '_story' ] = $e->getMessage();
-                                tts_log_event( $post_id, $story_channel . '_story', 'error', $e->getMessage(), '' );
-                            }
-                        }
-                    }
-                }
-            } else {
-                tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing Story media', 'fp-publisher' ), '' );
-                $error = true;
-            }
-        }
-
-        if ( $error ) {
-            if ( $attempt >= $max_attempts ) {
-                tts_log_event( $post_id, 'scheduler', 'error', __( 'Maximum retry attempts reached', 'fp-publisher' ), '' );
-                $log_url = admin_url( 'admin.php?page=fp-publisher-log&post_id=' . $post_id );
-                $message = sprintf( __( 'Publishing failed for post %1$s. Log: %2$s', 'fp-publisher' ), get_the_title( $post_id ), $log_url );
-                $notifier->notify_slack( $message );
-                $notifier->notify_email( __( 'Social publishing failed', 'fp-publisher' ), $message );
-                return;
-            }
-
-            $attempt++;
-            update_post_meta( $post_id, '_tts_retry_count', $attempt );
-
-            $delay     = $this->calculate_backoff_delay( $attempt );
-            $timestamp = time() + $delay * MINUTE_IN_SECONDS;
-            as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( $post_id ) );
-
-            tts_log_event( $post_id, 'scheduler', 'retry', sprintf( __( 'Retry #%1$d scheduled in %2$d minutes', 'fp-publisher' ), $attempt, $delay ), '' );
-            return;
-        }
-
-        delete_post_meta( $post_id, '_tts_retry_count' );
-        update_post_meta( $post_id, '_published_status', 'published' );
+        $log[ $channel ] = $message;
         update_post_meta( $post_id, '_tts_publish_log', $log );
 
+        tts_log_event( $post_id, $channel, 'error', $message, '' );
+
+        $allowed_attempts = $this->determine_allowed_attempts( $max_attempts, $severity_label, $channel_config );
+        $circuit_state    = $guard_response['circuit'] ?? array();
+        $circuit_open     = isset( $circuit_state['state'] ) && 'open' === $circuit_state['state'] && ( $circuit_state['open_until'] ?? 0 ) > time();
+
+        if ( $current_attempt >= $allowed_attempts || $circuit_open ) {
+            $channel_state['status'] = $circuit_open ? 'awaiting_manual' : 'failed';
+            $state[ $channel ]       = $channel_state;
+            $this->set_channel_state( $post_id, $state );
+
+            $this->alert_failure( $post_id, $channel, $client_id, $message, $severity_label );
+            update_post_meta( $post_id, '_published_status', 'failed' );
+
+            $this->maybe_record_event(
+                'error',
+                __( 'Channel publishing failed permanently.', 'fp-publisher' ),
+                array(
+                    'post_id'  => $post_id,
+                    'channel'  => $channel,
+                    'attempts' => $current_attempt,
+                    'severity' => $severity_label,
+                )
+            );
+            return;
+        }
+
+        if ( ! ( $this->channel_queue instanceof TTS_Channel_Queue ) ) {
+            $delay_minutes = $this->calculate_backoff_delay( $current_attempt );
+            $timestamp     = time() + $delay_minutes * MINUTE_IN_SECONDS;
+            as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( $post_id, $channel ) );
+
+            $this->maybe_record_event(
+                'retry',
+                __( 'Legacy retry scheduled due to missing queue.', 'fp-publisher' ),
+                array(
+                    'post_id'  => $post_id,
+                    'channel'  => $channel,
+                    'attempts' => $current_attempt,
+                )
+            );
+            return;
+        }
+
+        $delay_seconds = $this->calculate_retry_delay( $severity_label, $current_attempt, $channel_config );
+        $next_timestamp = time() + $delay_seconds;
+
+        $retry_job = array(
+            'post_id'           => $post_id,
+            'client_id'         => $client_id,
+            'channel'           => $channel,
+            'attempt'           => $current_attempt,
+            'max_attempts'      => $max_attempts,
+            'metadata'          => array(
+                'queued_at'      => time(),
+                'scheduled_for'  => $next_timestamp,
+                'queued_by'      => 'scheduler_retry',
+                'last_error'     => $message,
+            ),
+            'retry_blueprint'   => $channel_config['retry'],
+            'circuit_blueprint' => $channel_config['circuit'],
+        );
+
+        $enqueued_job = $this->channel_queue->enqueue_job( $retry_job, $next_timestamp );
+
+        if ( is_wp_error( $enqueued_job ) ) {
+            $channel_state['status'] = 'failed';
+            $state[ $channel ]       = $channel_state;
+            $this->set_channel_state( $post_id, $state );
+
+            $fallback_message = sprintf( '%s (enqueue error: %s)', $message, $enqueued_job->get_error_message() );
+            $this->alert_failure( $post_id, $channel, $client_id, $fallback_message, $severity_label );
+            update_post_meta( $post_id, '_published_status', 'failed' );
+            return;
+        }
+
+        $channel_state['status']        = 'queued_retry';
+        $channel_state['scheduled_args'] = $enqueued_job['scheduled_args'] ?? array( $retry_job );
+        $channel_state['action_group']  = $enqueued_job['action_group'] ?? '';
+        $channel_state['job_id']        = $enqueued_job['job_id'] ?? $channel_state['job_id'];
+        $channel_state['next_attempt']  = $next_timestamp;
+        $channel_state['last_updated']  = time();
+        $state[ $channel ]              = $channel_state;
+        $this->set_channel_state( $post_id, $state );
+
+        $delay_minutes = ceil( $delay_seconds / MINUTE_IN_SECONDS );
+        $this->maybe_record_event(
+            'retry',
+            __( 'Retry scheduled for channel job.', 'fp-publisher' ),
+            array(
+                'post_id'  => $post_id,
+                'channel'  => $channel,
+                'attempts' => $current_attempt,
+                'delay'    => $delay_minutes,
+                'severity' => $severity_label,
+            )
+        );
+
+        tts_log_event( $post_id, $channel, 'retry', sprintf( __( 'Retry #%1$d scheduled in %2$d minutes', 'fp-publisher' ), $current_attempt, $delay_minutes ), '' );
+    }
+
+    private function finalize_publication( $post_id, $client_id, array $log ) {
         $card_id       = get_post_meta( $post_id, '_trello_card_id', true );
         $trello_key    = get_post_meta( $client_id, '_tts_trello_key', true );
         $trello_token  = get_post_meta( $client_id, '_tts_trello_token', true );
@@ -511,6 +694,10 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
             $first_url = '';
             $links     = array();
             foreach ( $log as $channel => $entry ) {
+                if ( 'instagram_comment' === $channel ) {
+                    continue;
+                }
+
                 $link = '';
                 if ( is_string( $entry ) && preg_match( '/https?:\/\/[^\s]+/', $entry, $match ) ) {
                     $link = $match[0];
@@ -526,6 +713,7 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
                         }
                     }
                 }
+
                 if ( $link ) {
                     if ( empty( $first_url ) ) {
                         $first_url = $link;
@@ -543,9 +731,8 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
                     'timeout' => 20,
                 )
             );
-            if ( is_wp_error( $move_response ) ) {
-                tts_log_event( $post_id, 'trello', 'error', $move_response->get_error_message(), '' );
-            } else {
+
+            if ( ! is_wp_error( $move_response ) ) {
                 $comment_url = sprintf(
                     'https://api.trello.com/1/cards/%s/actions/comments?key=%s&token=%s',
                     rawurlencode( $card_id ),
@@ -570,7 +757,8 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
                     $comment_response2 = wp_remote_post(
                         $comment_url,
                         array(
-                            'body'    => array( 'text' => implode( "\n", $links ) ),
+                            'body'    => array( 'text' => implode( "
+", $links ) ),
                             'timeout' => 20,
                         )
                     );
@@ -578,6 +766,8 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
                         tts_log_event( $post_id, 'trello', 'error', $comment_response2->get_error_message(), '' );
                     }
                 }
+            } else {
+                tts_log_event( $post_id, 'trello', 'error', $move_response->get_error_message(), '' );
             }
         }
 
@@ -585,30 +775,403 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
 
         $log_url = admin_url( 'admin.php?page=fp-publisher-log&post_id=' . $post_id );
         $message = sprintf( __( 'Publishing completed for post %1$s. Log: %2$s', 'fp-publisher' ), get_the_title( $post_id ), $log_url );
-        $notifier->notify_slack( $message );
-        $notifier->notify_email( __( 'Social publishing completed', 'fp-publisher' ), $message );
+        $this->notifier->notify_slack( $message );
+        $this->notifier->notify_email( __( 'Social publishing completed', 'fp-publisher' ), $message );
     }
 
-    /**
-     * Check the status of the Action Scheduler queue used for publishing.
-     *
-     * @return string|WP_Error Human readable status message or error describing issues.
-     */
+    private function maybe_complete_post( $post_id, $client_id ) {
+        $queued = get_post_meta( $post_id, $this->queued_channels_meta_key, true );
+        if ( ! is_array( $queued ) || empty( $queued ) ) {
+            return;
+        }
+
+        $state = $this->get_channel_state( $post_id );
+        foreach ( $queued as $channel ) {
+            if ( ! isset( $state[ $channel ] ) || 'completed' !== $state[ $channel ]['status'] ) {
+                return;
+            }
+        }
+
+        if ( 'published' === get_post_meta( $post_id, '_published_status', true ) ) {
+            return;
+        }
+
+        update_post_meta( $post_id, '_published_status', 'published' );
+        update_post_meta( $post_id, $this->finalized_meta_key, time() );
+
+        $log = get_post_meta( $post_id, '_tts_publish_log', true );
+        if ( ! is_array( $log ) ) {
+            $log = array();
+        }
+
+        $this->finalize_publication( $post_id, $client_id, $log );
+    }
+
+    private function dispatch_integration_event( $post_id, $client_id, array $channels ) {
+        if ( ! $this->integration_gateway instanceof TTS_Integration_Gateway_Interface ) {
+            return;
+        }
+
+        $message = new TTS_Integration_Message(
+            0,
+            'publication_sync',
+            array(
+                'post_id'   => $post_id,
+                'client_id' => $client_id,
+                'channels'  => $channels,
+            ),
+            array(
+                'post_id'  => $post_id,
+                'channels' => $channels,
+            )
+        );
+
+        $this->integration_gateway->dispatch_message( $message );
+    }
+
+    private function get_post_attachments( $post_id ) {
+        $attachment_ids = get_post_meta( $post_id, '_tts_attachment_ids', true );
+        $attachment_ids = is_array( $attachment_ids ) ? array_map( 'intval', $attachment_ids ) : array();
+        $manual_id      = (int) get_post_meta( $post_id, '_tts_manual_media', true );
+        if ( $manual_id ) {
+            $attachment_ids[] = $manual_id;
+        }
+
+        return array_values( array_unique( array_filter( $attachment_ids ) ) );
+    }
+
+    private function get_story_media_url( $post_id ) {
+        $story_id = (int) get_post_meta( $post_id, '_tts_story_media', true );
+        return $story_id ? wp_get_attachment_url( $story_id ) : '';
+    }
+
+    private function get_client_tokens( $client_id ) {
+        return array(
+            'facebook'  => get_post_meta( $client_id, '_tts_fb_token', true ),
+            'instagram' => get_post_meta( $client_id, '_tts_ig_token', true ),
+            'youtube'   => get_post_meta( $client_id, '_tts_yt_token', true ),
+            'tiktok'    => get_post_meta( $client_id, '_tts_tt_token', true ),
+            'blog'      => get_post_meta( $client_id, '_tts_blog_settings', true ),
+        );
+    }
+
+    private function resolve_message( $post_id, $channel, $options ) {
+        $custom_message = get_post_meta( $post_id, '_tts_message_' . $channel, true );
+        if ( $custom_message ) {
+            return $custom_message;
+        }
+
+        $template = isset( $options[ $channel . '_template' ] ) ? $options[ $channel . '_template' ] : '';
+        return $template ? tts_apply_template( $template, $post_id, $channel ) : '';
+    }
+
+    private function resolve_publisher_binding( $channel ) {
+        $map = array(
+            'facebook' => array(
+                'class'          => 'TTS_Publisher_Facebook',
+                'file'           => plugin_dir_path( __FILE__ ) . 'publishers/class-tts-publisher-facebook.php',
+                'credential_key' => 'facebook',
+                'mode'           => 'standard',
+            ),
+            'facebook_story' => array(
+                'class'          => 'TTS_Publisher_Facebook_Story',
+                'file'           => plugin_dir_path( __FILE__ ) . 'publishers/class-tts-publisher-facebook-story.php',
+                'credential_key' => 'facebook',
+                'mode'           => 'story',
+            ),
+            'instagram' => array(
+                'class'          => 'TTS_Publisher_Instagram',
+                'file'           => plugin_dir_path( __FILE__ ) . 'publishers/class-tts-publisher-instagram.php',
+                'credential_key' => 'instagram',
+                'mode'           => 'standard',
+            ),
+            'instagram_story' => array(
+                'class'          => 'TTS_Publisher_Instagram_Story',
+                'file'           => plugin_dir_path( __FILE__ ) . 'publishers/class-tts-publisher-instagram-story.php',
+                'credential_key' => 'instagram',
+                'mode'           => 'story',
+            ),
+            'youtube' => array(
+                'class'          => 'TTS_Publisher_Youtube',
+                'file'           => plugin_dir_path( __FILE__ ) . 'publishers/class-tts-publisher-youtube.php',
+                'credential_key' => 'youtube',
+                'mode'           => 'standard',
+            ),
+            'tiktok' => array(
+                'class'          => 'TTS_Publisher_Tiktok',
+                'file'           => plugin_dir_path( __FILE__ ) . 'publishers/class-tts-publisher-tiktok.php',
+                'credential_key' => 'tiktok',
+                'mode'           => 'standard',
+            ),
+            'blog' => array(
+                'class'          => 'TTS_Publisher_Blog',
+                'file'           => plugin_dir_path( __FILE__ ) . 'publishers/class-tts-publisher-blog.php',
+                'credential_key' => 'blog',
+                'mode'           => 'standard',
+            ),
+        );
+
+        if ( isset( $map[ $channel ] ) ) {
+            return $map[ $channel ];
+        }
+
+        return new WP_Error( 'unknown_channel', sprintf( __( 'Unknown channel %s.', 'fp-publisher' ), $channel ) );
+    }
+
+    private function expand_channel_targets( $post_id, array $channels ) {
+        $channels = array_filter( array_map( 'sanitize_key', $channels ) );
+        $channels = array_values( array_unique( $channels ) );
+
+        if ( (bool) get_post_meta( $post_id, '_tts_publish_story', true ) ) {
+            $channels[] = 'facebook_story';
+            $channels[] = 'instagram_story';
+        }
+
+        return array_values( array_unique( $channels ) );
+    }
+
+    private function resolve_channels_from_trello( $post_id, $client_id, $channels ) {
+        if ( ! empty( $channels ) ) {
+            return $channels;
+        }
+
+        $id_list = get_post_meta( $post_id, '_trello_idList', true );
+        $board_id = get_post_meta( $post_id, '_trello_board_id', true );
+        if ( empty( $id_list ) || empty( $board_id ) ) {
+            $card_id     = get_post_meta( $post_id, '_trello_card_id', true );
+            $trello_key   = get_post_meta( $client_id, '_tts_trello_key', true );
+            $trello_token = get_post_meta( $client_id, '_tts_trello_token', true );
+            if ( $card_id && $trello_key && $trello_token ) {
+                $url      = 'https://api.trello.com/1/cards/' . rawurlencode( $card_id ) . '?fields=idList,idBoard&key=' . rawurlencode( $trello_key ) . '&token=' . rawurlencode( $trello_token );
+                $response = wp_remote_get( $url, array( 'timeout' => 20 ) );
+                if ( ! is_wp_error( $response ) ) {
+                    $body = json_decode( wp_remote_retrieve_body( $response ), true );
+                    if ( isset( $body['idList'] ) ) {
+                        $id_list = $body['idList'];
+                    }
+                    if ( isset( $body['idBoard'] ) ) {
+                        $board_id = $body['idBoard'];
+                    }
+                }
+            }
+        }
+        if ( $board_id ) {
+            update_post_meta( $post_id, '_trello_board_id', $board_id );
+        }
+        if ( $id_list ) {
+            $mapping = get_post_meta( $client_id, '_tts_trello_map', true );
+            if ( is_array( $mapping ) ) {
+                foreach ( $mapping as $row ) {
+                    if ( isset( $row['idList'], $row['canale_social'] ) && $row['idList'] === $id_list ) {
+                        $channels = array( $row['canale_social'] );
+                        break;
+                    }
+                }
+            }
+        }
+
+        return is_array( $channels ) ? $channels : array();
+    }
+
+    private function build_job_payload( TTS_Schedule_Request $request, $channel, $timestamp, array $config ) {
+        return array(
+            'post_id'           => $request->get_post_id(),
+            'client_id'         => $request->get_client_id(),
+            'channel'           => $channel,
+            'attempt'           => 0,
+            'max_attempts'      => $config['retry']['global_max'] ?? 5,
+            'scheduled_for'     => $timestamp,
+            'metadata'          => array(
+                'request'       => $request->to_array(),
+                'queued_at'     => time(),
+                'scheduled_for' => $timestamp,
+            ),
+            'retry_blueprint'   => $config['retry'],
+            'circuit_blueprint' => $config['circuit'],
+        );
+    }
+
+
+    private function build_ad_hoc_job( $post_id, $channel ) {
+        $client_id = intval( get_post_meta( $post_id, '_tts_client_id', true ) );
+        $config    = $this->get_channel_config( $channel );
+        $timestamp = time();
+
+        return array(
+            'post_id'           => $post_id,
+            'client_id'         => $client_id,
+            'channel'           => $channel,
+            'attempt'           => 0,
+            'max_attempts'      => $config['retry']['global_max'] ?? 5,
+            'scheduled_for'     => $timestamp,
+            'metadata'          => array(
+                'queued_at'     => $timestamp,
+                'scheduled_for' => $timestamp,
+                'queued_by'     => 'adhoc',
+            ),
+            'retry_blueprint'   => $config['retry'],
+            'circuit_blueprint' => $config['circuit'],
+        );
+    }
+
+    private function register_job_state( $post_id, $channel, array $job, array $config ) {
+        $state = $this->get_channel_state( $post_id );
+        $state[ $channel ] = array(
+            'status'         => 'queued',
+            'attempts'       => 0,
+            'max_attempts'   => $job['max_attempts'] ?? ( $config['retry']['global_max'] ?? 5 ),
+            'job_id'         => $job['job_id'] ?? uniqid( 'tts_job_', true ),
+            'scheduled_args' => $job['scheduled_args'] ?? array( $job ),
+            'action_group'   => $job['action_group'] ?? '',
+            'next_attempt'   => $job['scheduled_for'] ?? time(),
+            'config'         => $config,
+            'last_error'     => null,
+            'last_updated'   => time(),
+        );
+
+        $this->set_channel_state( $post_id, $state );
+    }
+
+    private function initialize_queued_channels( $post_id, array $channels ) {
+        update_post_meta( $post_id, $this->queued_channels_meta_key, array_values( array_unique( $channels ) ) );
+    }
+
+    private function get_channel_state( $post_id ) {
+        $state = get_post_meta( $post_id, $this->retry_state_meta_key, true );
+        return is_array( $state ) ? $state : array();
+    }
+
+    private function set_channel_state( $post_id, array $state ) {
+        if ( empty( $state ) ) {
+            delete_post_meta( $post_id, $this->retry_state_meta_key );
+            return;
+        }
+
+        update_post_meta( $post_id, $this->retry_state_meta_key, $state );
+    }
+
+    private function get_channel_config( $channel ) {
+        if ( $this->channel_queue instanceof TTS_Channel_Queue ) {
+            return $this->channel_queue->get_channel_config( $channel );
+        }
+
+        return $this->default_channel_config;
+    }
+
+    private function determine_allowed_attempts( $max_attempts, $severity_label, array $config ) {
+        $global_max = max( 1, absint( $max_attempts ) );
+        $severity_limits = isset( $config['retry']['max_attempts'] ) ? $config['retry']['max_attempts'] : array();
+        $severity_limit  = isset( $severity_limits[ $severity_label ] ) ? absint( $severity_limits[ $severity_label ] ) : $global_max;
+
+        if ( $severity_limit <= 0 ) {
+            $severity_limit = $global_max;
+        }
+
+        return min( $global_max, max( 1, $severity_limit ) );
+    }
+
+    private function calculate_retry_delay( $severity_label, $attempt, array $config ) {
+        $retry = isset( $config['retry'] ) ? $config['retry'] : array();
+        $delays = isset( $retry['delays'] ) ? $retry['delays'] : array();
+        $base_minutes = isset( $delays[ $severity_label ] ) ? absint( $delays[ $severity_label ] ) : 15;
+        $strategy = isset( $retry['strategy'] ) ? $retry['strategy'] : 'progressive';
+
+        switch ( $strategy ) {
+            case 'exponential':
+                $delay_minutes = $base_minutes * pow( 2, max( 0, $attempt - 1 ) );
+                break;
+            case 'fixed':
+                $delay_minutes = $base_minutes;
+                break;
+            default:
+                $delay_minutes = $base_minutes * max( 1, $attempt );
+                break;
+        }
+
+        $delay_seconds = $delay_minutes * MINUTE_IN_SECONDS;
+        $delay_seconds = min( $delay_seconds, 6 * HOUR_IN_SECONDS );
+
+        $jitter = isset( $retry['jitter'] ) ? absint( $retry['jitter'] ) : 60;
+        if ( $jitter > 0 ) {
+            $delay_seconds += wp_rand( 0, $jitter );
+        }
+
+        return max( 60, $delay_seconds );
+    }
+
+    private function alert_failure( $post_id, $channel, $client_id, $message, $severity_label ) {
+        $log_url = admin_url( 'admin.php?page=fp-publisher-log&post_id=' . $post_id );
+        $title   = get_the_title( $post_id );
+        $body    = sprintf(
+            __( 'Publishing failed for post %1$s on channel %2$s (severity: %3$s). Log: %4$s', 'fp-publisher' ),
+            $title ? $title : $post_id,
+            $channel,
+            $severity_label,
+            $log_url
+        );
+
+        $this->notifier->notify_slack( $body );
+        $this->notifier->notify_email( __( 'Social publishing failed', 'fp-publisher' ), $body );
+    }
+
+    private function maybe_record_event( $level, $message, $context = array() ) {
+        if ( ! $this->telemetry_channel instanceof TTS_Observability_Channel_Interface ) {
+            return;
+        }
+
+        $event = new TTS_Observability_Event( 'scheduler', $level, $message, $context );
+        $this->telemetry_channel->record_event( $event );
+    }
+
+    private function calculate_backoff_delay( $attempt ) {
+        $delays = array( 1, 5, 15, 30, 60 );
+
+        if ( $attempt <= 0 ) {
+            return 1;
+        }
+
+        return isset( $delays[ $attempt - 1 ] ) ? $delays[ $attempt - 1 ] : end( $delays );
+    }
+
     public static function check_queue() {
+        $hooks = array( 'tts_publish_social_post' );
+        if ( class_exists( 'TTS_Channel_Queue' ) ) {
+            $hooks[] = TTS_Channel_Queue::ACTION_HOOK;
+        }
+
         if ( ! class_exists( 'ActionScheduler' ) && ! class_exists( 'ActionScheduler_Store' ) && ! function_exists( 'as_get_scheduled_actions' ) ) {
             return new WP_Error( 'action_scheduler_missing', __( 'Action Scheduler non è disponibile.', 'fp-publisher' ) );
         }
 
-        $hook           = 'tts_publish_social_post';
-        $store          = null;
+        $pending_total = 0;
+        $failed_total  = 0;
+        $messages      = array();
+
+        foreach ( $hooks as $hook ) {
+            $status = self::inspect_queue_hook( $hook );
+            if ( is_wp_error( $status ) ) {
+                $messages[] = $status->get_error_message();
+            } else {
+                $pending_total += $status['pending'];
+                $failed_total  += $status['failed'];
+                if ( $status['message'] ) {
+                    $messages[] = $status['message'];
+                }
+            }
+        }
+
+        if ( $failed_total > 0 ) {
+            return new WP_Error( 'action_scheduler_failed_jobs', sprintf( _n( 'La coda ha %d azione fallita.', 'La coda ha %d azioni fallite.', $failed_total, 'fp-publisher' ), $failed_total ) );
+        }
+
+        return implode( ' ', array_filter( $messages ) );
+    }
+
+    private static function inspect_queue_hook( $hook ) {
         $pending_status = 'pending';
         $failed_status  = 'failed';
-
-        if ( class_exists( 'ActionScheduler' ) && is_callable( array( 'ActionScheduler', 'store' ) ) ) {
-            $store = ActionScheduler::store();
-        } elseif ( class_exists( 'ActionScheduler_Store' ) && is_callable( array( 'ActionScheduler_Store', 'instance' ) ) ) {
-            $store = ActionScheduler_Store::instance();
-        }
+        $pending_count  = 0;
+        $failed_count   = 0;
 
         if ( class_exists( 'ActionScheduler_Store' ) ) {
             if ( defined( 'ActionScheduler_Store::STATUS_PENDING' ) ) {
@@ -619,9 +1182,12 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
             }
         }
 
-        $pending_count     = 0;
-        $failed_count      = 0;
-        $oldest_pending_id = 0;
+        $store = null;
+        if ( class_exists( 'ActionScheduler' ) && is_callable( array( 'ActionScheduler', 'store' ) ) ) {
+            $store = ActionScheduler::store();
+        } elseif ( class_exists( 'ActionScheduler_Store' ) && is_callable( array( 'ActionScheduler_Store', 'instance' ) ) ) {
+            $store = ActionScheduler_Store::instance();
+        }
 
         if ( $store && method_exists( $store, 'query_actions' ) ) {
             $pending_count = (int) $store->query_actions(
@@ -639,22 +1205,6 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
                 ),
                 'count'
             );
-
-            $oldest_ids = $store->query_actions(
-                array(
-                    'hook'    => $hook,
-                    'status'  => $pending_status,
-                    'orderby' => 'date',
-                    'order'   => 'ASC',
-                    'per_page' => 1,
-                )
-            );
-
-            if ( is_array( $oldest_ids ) && ! empty( $oldest_ids ) ) {
-                $oldest_pending_id = (int) reset( $oldest_ids );
-            } elseif ( is_numeric( $oldest_ids ) ) {
-                $oldest_pending_id = (int) $oldest_ids;
-            }
         } elseif ( function_exists( 'as_get_scheduled_actions' ) ) {
             $pending_actions = as_get_scheduled_actions(
                 array(
@@ -678,10 +1228,6 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
 
             if ( is_array( $pending_actions ) ) {
                 $pending_count = count( $pending_actions );
-                $first_pending = reset( $pending_actions );
-                if ( $first_pending ) {
-                    $oldest_pending_id = (int) $first_pending;
-                }
             }
 
             if ( is_array( $failed_actions ) ) {
@@ -691,101 +1237,15 @@ class TTS_Scheduler implements TTS_Scheduler_Interface {
             return new WP_Error( 'action_scheduler_unavailable', __( 'Impossibile interrogare Action Scheduler.', 'fp-publisher' ) );
         }
 
-        $oldest_pending_age = 0;
-
-        if ( $oldest_pending_id && $store && method_exists( $store, 'get_date' ) ) {
-            try {
-                $oldest_date = $store->get_date( $oldest_pending_id );
-                if ( $oldest_date instanceof \DateTime ) {
-                    $oldest_pending_age = max( 0, time() - $oldest_date->getTimestamp() );
-                }
-            } catch ( \Exception $e ) {
-                // If we cannot retrieve the date we skip the stale queue check.
-            }
-        }
-
-        $pending_threshold = (int) apply_filters( 'tts_scheduler_pending_threshold', 25 );
-        $failed_threshold  = (int) apply_filters( 'tts_scheduler_failed_threshold', 0 );
-        $stale_threshold   = (int) apply_filters( 'tts_scheduler_pending_stale_threshold', 15 * MINUTE_IN_SECONDS );
-
-        if ( $failed_count > $failed_threshold ) {
-            return new WP_Error(
-                'action_scheduler_failed_jobs',
-                sprintf(
-                    _n( 'La coda ha %d azione fallita.', 'La coda ha %d azioni fallite.', $failed_count, 'fp-publisher' ),
-                    $failed_count
-                )
-            );
-        }
-
-        if ( $oldest_pending_age > $stale_threshold && $pending_count > 0 ) {
-            $minutes = (int) ceil( $oldest_pending_age / MINUTE_IN_SECONDS );
-
-            return new WP_Error(
-                'action_scheduler_queue_stale',
-                sprintf(
-                    _n(
-                        'L\'azione più vecchia è in attesa da %d minuto.',
-                        'L\'azione più vecchia è in attesa da %d minuti.',
-                        $minutes,
-                        'fp-publisher'
-                    ),
-                    $minutes
-                )
-            );
-        }
-
-        if ( $pending_count > $pending_threshold ) {
-            return new WP_Error(
-                'action_scheduler_queue_backlog',
-                sprintf(
-                    _n( 'Ci sono %d azione in attesa.', 'Ci sono %d azioni in attesa.', $pending_count, 'fp-publisher' ),
-                    $pending_count
-                )
-            );
-        }
-
-        $message = sprintf(
-            __( 'Coda regolare: %1$d in attesa, %2$d fallite.', 'fp-publisher' ),
-            $pending_count,
-            $failed_count
+        return array(
+            'pending' => $pending_count,
+            'failed'  => $failed_count,
+            'message' => sprintf(
+                __( 'Hook %1$s: %2$d pending, %3$d failed.', 'fp-publisher' ),
+                $hook,
+                $pending_count,
+                $failed_count
+            ),
         );
-
-        if ( function_exists( 'as_next_scheduled_action' ) ) {
-            $next_timestamp = as_next_scheduled_action( $hook );
-
-            if ( $next_timestamp ) {
-                $now = time();
-
-                if ( $next_timestamp <= $now ) {
-                    $message .= ' ' . __( 'Una nuova azione è pronta per l\'esecuzione.', 'fp-publisher' );
-                } else {
-                    $message .= ' ' . sprintf(
-                        __( 'Prossima esecuzione tra %s.', 'fp-publisher' ),
-                        human_time_diff( $now, $next_timestamp )
-                    );
-                }
-            } elseif ( 0 === $pending_count ) {
-                $message .= ' ' . __( 'Nessuna azione pianificata al momento.', 'fp-publisher' );
-            }
-        }
-
-        return $message;
-    }
-
-    /**
-     * Calculate delay for retry attempts in minutes.
-     *
-     * @param int $attempt Current attempt number.
-     * @return int Delay in minutes.
-     */
-    private function calculate_backoff_delay( $attempt ) {
-        $delays = array( 1, 5, 15, 30, 60 );
-
-        if ( $attempt <= 0 ) {
-            return 1;
-        }
-
-        return isset( $delays[ $attempt - 1 ] ) ? $delays[ $attempt - 1 ] : end( $delays );
     }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -60,15 +60,39 @@ if ( ! function_exists( 'tsap_register_default_services' ) ) {
             } );
         }
 
-        if ( ! $container->has( 'scheduler' ) && class_exists( 'TTS_Scheduler' ) ) {
-            $container->set( 'scheduler', function ( TTS_Service_Container $c ) {
-                return new TTS_Scheduler( $c->get( 'integration_hub' ) );
-            } );
-        }
-
         if ( ! $container->has( 'rate_limiter' ) && class_exists( 'TTS_Rate_Limiter' ) ) {
             $container->set( 'rate_limiter', function ( TTS_Service_Container $c ) {
                 return new TTS_Rate_Limiter( $c->get( 'logger' ) );
+            } );
+        }
+
+        if ( ! $container->has( 'error_recovery' ) && class_exists( 'TTS_Error_Recovery' ) ) {
+            $container->set( 'error_recovery', function () {
+                return new TTS_Error_Recovery();
+            } );
+        }
+
+        if ( ! $container->has( 'channel_queue' ) && class_exists( 'TTS_Channel_Queue' ) ) {
+            $container->set( 'channel_queue', function () {
+                return new TTS_Channel_Queue();
+            } );
+        }
+
+        if ( ! $container->has( 'publisher_guard' ) && class_exists( 'TTS_Publisher_Guard' ) ) {
+            $container->set( 'publisher_guard', function ( TTS_Service_Container $c ) {
+                return new TTS_Publisher_Guard( $c->get( 'rate_limiter' ), $c->get( 'error_recovery' ) );
+            } );
+        }
+
+        if ( ! $container->has( 'scheduler' ) && class_exists( 'TTS_Scheduler' ) ) {
+            $container->set( 'scheduler', function ( TTS_Service_Container $c ) {
+                $integration = $c->get( 'integration_hub' );
+                $queue       = $c->has( 'channel_queue' ) ? $c->get( 'channel_queue' ) : null;
+                $limiter     = $c->has( 'rate_limiter' ) ? $c->get( 'rate_limiter' ) : null;
+                $recovery    = $c->has( 'error_recovery' ) ? $c->get( 'error_recovery' ) : null;
+                $guard       = $c->has( 'publisher_guard' ) ? $c->get( 'publisher_guard' ) : null;
+
+                return new TTS_Scheduler( $integration, null, $queue, $limiter, $recovery, $guard );
             } );
         }
 
@@ -144,8 +168,10 @@ add_action( 'plugins_loaded', function () {
         'class-tts-notifier.php',
         'class-tts-performance.php',
         'class-tts-rate-limiter.php',
+        'class-tts-channel-queue.php',
         'class-tts-operating-contracts.php',
         'class-tts-scheduler.php',
+        'class-tts-publisher-guard.php',
         'class-tts-security-audit.php',
         'class-tts-settings.php',
         'class-tts-shortener.php',
@@ -189,7 +215,7 @@ add_action( 'plugins_loaded', function () {
     $container = tsap_service_container();
 
     // Ensure core services are bootstrapped so their hooks are registered.
-    foreach ( array( 'integration_hub', 'scheduler', 'rate_limiter', 'security_audit' ) as $service_id ) {
+    foreach ( array( 'integration_hub', 'channel_queue', 'error_recovery', 'scheduler', 'rate_limiter', 'publisher_guard', 'security_audit' ) as $service_id ) {
         if ( $container->has( $service_id ) ) {
             $container->get( $service_id );
         }


### PR DESCRIPTION
## Summary
- add Action Scheduler backed channel queue with per-channel retry metadata
- guard publisher invocations with rate limiting, circuit breaker, and severity-aware recovery
- refactor scheduler to use new queue/guard primitives and document resilience operations

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-channel-queue.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-publisher-guard.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-error-recovery.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rate-limiter.php
- php -l wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c40b809c832f972d1cf4c8ddb591