### PR TITLE
Add deactivation cleanup for scheduled tasks

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -77,15 +77,15 @@ class TTS_CPT {
         $roles = array(
             'fp_publisher_manager'  => array(
                 'name' => __( 'FP Publisher Manager', 'fp-publisher' ),
-                'caps' => $this->get_manager_capabilities(),
+                'caps' => self::get_manager_capabilities(),
             ),
             'fp_publisher_editor'   => array(
                 'name' => __( 'FP Publisher Editor', 'fp-publisher' ),
-                'caps' => $this->get_editor_capabilities(),
+                'caps' => self::get_editor_capabilities(),
             ),
             'fp_publisher_reviewer' => array(
                 'name' => __( 'FP Publisher Reviewer', 'fp-publisher' ),
-                'caps' => $this->get_reviewer_capabilities(),
+                'caps' => self::get_reviewer_capabilities(),
             ),
         );
 
@@ -105,8 +105,32 @@ class TTS_CPT {
 
         $admin_role = get_role( 'administrator' );
         if ( $admin_role instanceof WP_Role ) {
-            foreach ( array_keys( $this->get_manager_capabilities() ) as $capability ) {
+            foreach ( array_keys( self::get_manager_capabilities() ) as $capability ) {
                 $admin_role->add_cap( $capability );
+            }
+        }
+    }
+
+    /**
+     * Remove custom roles and capabilities during plugin deactivation.
+     */
+    public static function remove_roles() {
+        $roles = array(
+            'fp_publisher_manager',
+            'fp_publisher_editor',
+            'fp_publisher_reviewer',
+        );
+
+        foreach ( $roles as $role_key ) {
+            if ( function_exists( 'remove_role' ) ) {
+                remove_role( $role_key );
+            }
+        }
+
+        $admin_role = get_role( 'administrator' );
+        if ( $admin_role instanceof WP_Role ) {
+            foreach ( array_keys( self::get_manager_capabilities() ) as $capability ) {
+                $admin_role->remove_cap( $capability );
             }
         }
     }
@@ -116,7 +140,7 @@ class TTS_CPT {
      *
      * @return array<string, bool>
      */
-    private function get_post_management_capabilities() {
+    private static function get_post_management_capabilities() {
         return array(
             'tts_read_social_post'              => true,
             'tts_read_social_posts'             => true,
@@ -141,7 +165,7 @@ class TTS_CPT {
      *
      * @return array<string, bool>
      */
-    private function get_manager_capabilities() {
+    private static function get_manager_capabilities() {
         return array_merge(
             array(
                 'read'                  => true,
@@ -154,7 +178,7 @@ class TTS_CPT {
                 'tts_import_data'       => true,
                 'tts_approve_posts'     => true,
             ),
-            $this->get_post_management_capabilities()
+            self::get_post_management_capabilities()
         );
     }
 
@@ -163,14 +187,14 @@ class TTS_CPT {
      *
      * @return array<string, bool>
      */
-    private function get_editor_capabilities() {
+    private static function get_editor_capabilities() {
         return array_merge(
             array(
                 'read'             => true,
                 'tts_view_reports' => true,
                 'tts_approve_posts'=> true,
             ),
-            $this->get_post_management_capabilities()
+            self::get_post_management_capabilities()
         );
     }
 
@@ -179,7 +203,7 @@ class TTS_CPT {
      *
      * @return array<string, bool>
      */
-    private function get_reviewer_capabilities() {
+    private static function get_reviewer_capabilities() {
         return array(
             'read'                          => true,
             'tts_read_social_post'          => true,

--- a/wp-content/plugins/trello-social-auto-publisher/tests/bootstrap.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/bootstrap.php
@@ -59,6 +59,13 @@ $GLOBALS['tts_registered_post_meta']  = array();
 $GLOBALS['tts_registered_roles']      = array();
 $GLOBALS['tts_test_posts']            = array();
 $GLOBALS['tts_deleted_posts']         = array();
+$GLOBALS['tts_cleared_scheduled_hooks'] = array();
+$GLOBALS['tts_unscheduled_actions']   = array();
+$GLOBALS['tts_scheduled_actions']     = array();
+$GLOBALS['tts_scheduled_single_events'] = array();
+$GLOBALS['tts_registered_activation_hooks'] = array();
+$GLOBALS['tts_registered_deactivation_hooks'] = array();
+$GLOBALS['tts_is_admin']              = false;
 
 if ( ! function_exists( '__' ) ) {
     function __( $text, $domain = null ) {
@@ -113,6 +120,12 @@ if ( ! function_exists( 'esc_attr_e' ) ) {
 if ( ! function_exists( 'esc_attr' ) ) {
     function esc_attr( $text ) {
         return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+    }
+}
+
+if ( ! function_exists( 'is_admin' ) ) {
+    function is_admin() {
+        return ! empty( $GLOBALS['tts_is_admin'] );
     }
 }
 
@@ -392,6 +405,10 @@ if ( ! class_exists( 'WP_Role' ) ) {
             $this->capabilities[ $capability ] = (bool) $grant;
         }
 
+        public function remove_cap( $capability ) {
+            unset( $this->capabilities[ $capability ] );
+        }
+
         public function has_cap( $capability ) {
             return ! empty( $this->capabilities[ $capability ] );
         }
@@ -409,9 +426,27 @@ if ( ! function_exists( 'add_role' ) ) {
     }
 }
 
+if ( ! function_exists( 'remove_role' ) ) {
+    function remove_role( $role ) {
+        unset( $GLOBALS['tts_registered_roles'][ $role ] );
+    }
+}
+
 if ( ! function_exists( 'get_role' ) ) {
     function get_role( $role ) {
         return $GLOBALS['tts_registered_roles'][ $role ] ?? null;
+    }
+}
+
+if ( ! function_exists( 'register_activation_hook' ) ) {
+    function register_activation_hook( $file, $callback ) {
+        $GLOBALS['tts_registered_activation_hooks'][ $file ] = $callback;
+    }
+}
+
+if ( ! function_exists( 'register_deactivation_hook' ) ) {
+    function register_deactivation_hook( $file, $callback ) {
+        $GLOBALS['tts_registered_deactivation_hooks'][ $file ] = $callback;
     }
 }
 
@@ -745,6 +780,54 @@ if ( ! function_exists( 'wp_schedule_event' ) ) {
             'timestamp'  => $timestamp,
             'recurrence' => $recurrence,
             'args'       => $args,
+        );
+
+        return true;
+    }
+}
+
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+    function wp_schedule_single_event( $timestamp, $hook, $args = array() ) {
+        $GLOBALS['tts_scheduled_single_events'][] = array(
+            'hook'      => $hook,
+            'timestamp' => $timestamp,
+            'args'      => $args,
+        );
+
+        return true;
+    }
+}
+
+if ( ! function_exists( 'wp_clear_scheduled_hook' ) ) {
+    function wp_clear_scheduled_hook( $hook, $args = array() ) {
+        $GLOBALS['tts_cleared_scheduled_hooks'][] = array(
+            'hook' => $hook,
+            'args' => $args,
+        );
+
+        return true;
+    }
+}
+
+if ( ! function_exists( 'as_schedule_single_action' ) ) {
+    function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+        $GLOBALS['tts_scheduled_actions'][] = array(
+            'hook'      => $hook,
+            'timestamp' => $timestamp,
+            'args'      => $args,
+            'group'     => $group,
+        );
+
+        return uniqid( 'action_', true );
+    }
+}
+
+if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
+    function as_unschedule_all_actions( $hook, $args = null, $group = null ) {
+        $GLOBALS['tts_unscheduled_actions'][] = array(
+            'hook'  => $hook,
+            'args'  => $args,
+            'group' => $group,
         );
 
         return true;
@@ -1203,6 +1286,13 @@ function tts_reset_test_state() {
     $GLOBALS['tts_registered_roles']      = array();
     $GLOBALS['tts_test_posts']            = array();
     $GLOBALS['tts_deleted_posts']         = array();
+    $GLOBALS['tts_cleared_scheduled_hooks'] = array();
+    $GLOBALS['tts_unscheduled_actions']   = array();
+    $GLOBALS['tts_scheduled_actions']     = array();
+    $GLOBALS['tts_scheduled_single_events'] = array();
+    $GLOBALS['tts_registered_activation_hooks'] = array();
+    $GLOBALS['tts_registered_deactivation_hooks'] = array();
+    $GLOBALS['tts_is_admin']              = false;
 
     $_GET     = array();
     $_POST    = array();

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-deactivation.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-deactivation.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/helpers/assertions.php';
+require_once __DIR__ . '/../trello-social-auto-publisher.php';
+
+$tests = array(
+    'deactivation_clears_cron_hooks' => function () {
+        tts_reset_test_state();
+
+        tsap_plugin_deactivate();
+
+        $expected_hooks = array(
+            'tts_refresh_tokens',
+            'tts_fetch_metrics',
+            'tts_check_links',
+            'tts_daily_competitor_analysis',
+            'tts_check_publishing_frequencies',
+            'tts_hourly_rate_limit_cleanup',
+            'tts_process_retry_queue',
+            'tts_database_cleanup',
+            'tts_weekly_cleanup',
+            'tts_hourly_cache_cleanup',
+            'tts_daily_backup',
+            'tts_hourly_health_check',
+            'tts_daily_system_report',
+            'tts_daily_security_cleanup',
+            'tts_integration_sync',
+            'tts_integration_sync_single',
+            'tts_purge_old_logs',
+        );
+
+        $recorded = $GLOBALS['tts_cleared_scheduled_hooks'];
+
+        foreach ( $expected_hooks as $hook ) {
+            $found = false;
+            foreach ( $recorded as $entry ) {
+                if ( isset( $entry['hook'] ) && $entry['hook'] === $hook ) {
+                    $found = true;
+                    break;
+                }
+            }
+
+            tts_assert_true(
+                $found,
+                sprintf( 'Expected deactivation to clear the "%s" cron hook.', $hook )
+            );
+        }
+    },
+    'deactivation_unschedules_action_scheduler_jobs' => function () {
+        tts_reset_test_state();
+
+        tsap_plugin_deactivate();
+
+        $expected = array(
+            'tts_publish_social_post',
+            'tts_integration_sync_single',
+            'tts_process_channel_job',
+        );
+
+        $hooks = array();
+        foreach ( $GLOBALS['tts_unscheduled_actions'] as $entry ) {
+            if ( isset( $entry['hook'] ) ) {
+                $hooks[] = $entry['hook'];
+            }
+        }
+
+        foreach ( $expected as $hook ) {
+            tts_assert_true(
+                in_array( $hook, $hooks, true ),
+                sprintf( 'Expected Action Scheduler hook "%s" to be unscheduled.', $hook )
+            );
+        }
+    },
+    'deactivation_removes_plugin_roles_and_caps' => function () {
+        tts_reset_test_state();
+
+        $GLOBALS['tts_registered_roles']['fp_publisher_manager']  = new WP_Role( 'fp_publisher_manager', array( 'tts_manage_clients' => true ) );
+        $GLOBALS['tts_registered_roles']['fp_publisher_editor']   = new WP_Role( 'fp_publisher_editor', array( 'tts_publish_social_posts' => true ) );
+        $GLOBALS['tts_registered_roles']['fp_publisher_reviewer'] = new WP_Role( 'fp_publisher_reviewer', array( 'tts_approve_posts' => true ) );
+
+        $admin_role = new WP_Role( 'administrator', array( 'manage_options' => true ) );
+        $admin_role->add_cap( 'tts_manage_clients' );
+        $admin_role->add_cap( 'tts_publish_social_posts' );
+        $admin_role->add_cap( 'tts_delete_social_posts' );
+        $GLOBALS['tts_registered_roles']['administrator'] = $admin_role;
+
+        tsap_plugin_deactivate();
+
+        tts_assert_false( isset( $GLOBALS['tts_registered_roles']['fp_publisher_manager'] ), 'Manager role should be removed on deactivation.' );
+        tts_assert_false( isset( $GLOBALS['tts_registered_roles']['fp_publisher_editor'] ), 'Editor role should be removed on deactivation.' );
+        tts_assert_false( isset( $GLOBALS['tts_registered_roles']['fp_publisher_reviewer'] ), 'Reviewer role should be removed on deactivation.' );
+
+        tts_assert_true( $admin_role->has_cap( 'manage_options' ), 'Core administrator capabilities must remain intact.' );
+        tts_assert_false( $admin_role->has_cap( 'tts_manage_clients' ), 'Plugin capabilities should be removed from administrator.' );
+        tts_assert_false( $admin_role->has_cap( 'tts_publish_social_posts' ), 'Publishing capability should be removed from administrator.' );
+        tts_assert_false( $admin_role->has_cap( 'tts_delete_social_posts' ), 'Deletion capability should be removed from administrator.' );
+    },
+);
+
+$failures = 0;
+$messages = array();
+
+echo "Running deactivation hardening tests\n";
+
+foreach ( $tests as $name => $callback ) {
+    try {
+        $callback();
+        echo '.';
+    } catch ( Throwable $e ) {
+        $failures++;
+        $messages[] = $name . ': ' . $e->getMessage();
+        echo 'F';
+    }
+}
+
+echo "\n";
+
+if ( $failures > 0 ) {
+    foreach ( $messages as $message ) {
+        echo $message . "\n";
+    }
+    exit( 1 );
+}
+
+echo "All tests passed\n";

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -109,6 +109,7 @@ if ( ! function_exists( 'tsap_register_default_services' ) ) {
 }
 
 register_activation_hook( __FILE__, 'tsap_plugin_activate' );
+register_deactivation_hook( __FILE__, 'tsap_plugin_deactivate' );
 
 /**
  * Handle plugin activation tasks.
@@ -136,6 +137,60 @@ function tsap_plugin_activate() {
 
     if ( class_exists( 'TTS_Integration_Hub' ) ) {
         TTS_Integration_Hub::install();
+    }
+}
+
+/**
+ * Handle plugin deactivation tasks.
+ */
+function tsap_plugin_deactivate() {
+    $scheduled_hooks = array(
+        'tts_refresh_tokens',
+        'tts_fetch_metrics',
+        'tts_check_links',
+        'tts_daily_competitor_analysis',
+        'tts_check_publishing_frequencies',
+        'tts_hourly_rate_limit_cleanup',
+        'tts_process_retry_queue',
+        'tts_database_cleanup',
+        'tts_weekly_cleanup',
+        'tts_hourly_cache_cleanup',
+        'tts_daily_backup',
+        'tts_hourly_health_check',
+        'tts_daily_system_report',
+        'tts_daily_security_cleanup',
+        'tts_integration_sync',
+        'tts_integration_sync_single',
+        'tts_purge_old_logs',
+    );
+
+    foreach ( $scheduled_hooks as $hook ) {
+        if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+            wp_clear_scheduled_hook( $hook );
+        }
+    }
+
+    $channel_queue_file = TSAP_PLUGIN_DIR . 'includes/class-tts-channel-queue.php';
+    if ( ! class_exists( 'TTS_Channel_Queue' ) && file_exists( $channel_queue_file ) ) {
+        require_once $channel_queue_file;
+    }
+
+    if ( function_exists( 'as_unschedule_all_actions' ) ) {
+        as_unschedule_all_actions( 'tts_publish_social_post' );
+        as_unschedule_all_actions( 'tts_integration_sync_single' );
+
+        if ( class_exists( 'TTS_Channel_Queue' ) ) {
+            as_unschedule_all_actions( TTS_Channel_Queue::ACTION_HOOK );
+        }
+    }
+
+    $cpt_file = TSAP_PLUGIN_DIR . 'includes/class-tts-cpt.php';
+    if ( ! class_exists( 'TTS_CPT' ) && file_exists( $cpt_file ) ) {
+        require_once $cpt_file;
+    }
+
+    if ( class_exists( 'TTS_CPT' ) && is_callable( array( 'TTS_CPT', 'remove_roles' ) ) ) {
+        TTS_CPT::remove_roles();
     }
 }
 


### PR DESCRIPTION
## Summary
- add a plugin deactivation handler that clears scheduled cron hooks, unschedules Action Scheduler jobs, and removes custom roles
- convert CPT capability helpers to static methods and expose a remove_roles() helper used during deactivation
- extend the test bootstrap with additional WordPress stubs and add deactivation coverage to the test suite

## Testing
- for file in tests/test-*.php; do php $file; done

------
https://chatgpt.com/codex/tasks/task_e_68d42a7a0dac832fbbaf44a7fa57acfb