### PR TITLE
Harden import handling for FP Publisher

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class TTS_Admin {
 
+    const DEFAULT_IMPORT_MAX_FILE_SIZE = 5 * MB_IN_BYTES;
+
     /**
      * Stores admin notices for missing menu callbacks.
      *
@@ -141,6 +143,38 @@ class TTS_Admin {
         }
 
         return true;
+    }
+
+    /**
+     * Determine the maximum allowed import file size.
+     *
+     * @return int Maximum file size in bytes.
+     */
+    private function get_max_import_file_size() {
+        $upload_limit = wp_convert_hr_to_bytes( ini_get( 'upload_max_filesize' ) );
+        $post_limit   = wp_convert_hr_to_bytes( ini_get( 'post_max_size' ) );
+
+        $limits = array_filter(
+            array(
+                self::DEFAULT_IMPORT_MAX_FILE_SIZE,
+                $upload_limit,
+                $post_limit,
+            ),
+            function ( $value ) {
+                return is_numeric( $value ) && $value > 0;
+            }
+        );
+
+        $limit = ! empty( $limits ) ? min( $limits ) : self::DEFAULT_IMPORT_MAX_FILE_SIZE;
+
+        /**
+         * Filter the maximum allowed import file size.
+         *
+         * @param int $limit Maximum file size in bytes.
+         */
+        $limit = apply_filters( 'tts_import_max_file_size', (int) $limit );
+
+        return max( 1, (int) $limit );
     }
 
     /**
@@ -3926,6 +3960,25 @@ class TTS_Admin {
 
         $file = $_FILES['import_file'];
 
+        $max_size = $this->get_max_import_file_size();
+
+        if ( empty( $file['size'] ) || ! is_numeric( $file['size'] ) ) {
+            return wp_send_json_error( array( 'message' => __( 'Invalid file upload.', 'fp-publisher' ) ), 400 );
+        }
+
+        if ( (int) $file['size'] > $max_size ) {
+            return wp_send_json_error(
+                array(
+                    'message' => sprintf(
+                        /* translators: %s: maximum allowed file size */
+                        __( 'The uploaded file exceeds the maximum allowed size of %s.', 'fp-publisher' ),
+                        size_format( $max_size )
+                    ),
+                ),
+                400
+            );
+        }
+
         if ( ! isset( $file['error'] ) || UPLOAD_ERR_OK !== $file['error'] ) {
             $error_message = __( 'File upload failed.', 'fp-publisher' );
             if ( isset( $file['error'] ) ) {
@@ -3960,6 +4013,16 @@ class TTS_Admin {
 
         if ( ! isset( $file['tmp_name'] ) || ! is_uploaded_file( $file['tmp_name'] ) ) {
             return wp_send_json_error( array( 'message' => __( 'Invalid uploaded file.', 'fp-publisher' ) ), 400 );
+        }
+
+        if ( ! function_exists( 'wp_check_filetype_and_ext' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+
+        $filetype = wp_check_filetype_and_ext( $file['tmp_name'], $file['name'], array( 'json' => 'application/json' ) );
+
+        if ( empty( $filetype['ext'] ) || 'json' !== $filetype['ext'] ) {
+            return wp_send_json_error( array( 'message' => __( 'The uploaded file must be a valid JSON export from FP Publisher.', 'fp-publisher' ) ), 400 );
         }
 
         $file_contents = file_get_contents( $file['tmp_name'] );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-advanced-utils.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-advanced-utils.php
@@ -301,13 +301,27 @@ class TTS_Advanced_Utils {
                         'post_type' => 'tts_client',
                         'post_status' => 'publish'
                     ) );
-                    
+
                     if ( $client_id && ! is_wp_error( $client_id ) ) {
                         // Import meta data
                         if ( isset( $client_data['meta'] ) ) {
                             foreach ( $client_data['meta'] as $key => $values ) {
+                                $meta_key = self::sanitize_import_meta_key( $key );
+
+                                if ( null === $meta_key ) {
+                                    continue;
+                                }
+
+                                $values = is_array( $values ) ? $values : array( $values );
+
                                 foreach ( $values as $value ) {
-                                    add_post_meta( $client_id, $key, maybe_unserialize( $value ) );
+                                    $meta_value = self::sanitize_import_meta_value( $value );
+
+                                    if ( null === $meta_value ) {
+                                        continue;
+                                    }
+
+                                    add_post_meta( $client_id, $meta_key, $meta_value );
                                 }
                             }
                         }
@@ -327,13 +341,27 @@ class TTS_Advanced_Utils {
                         'post_type' => 'tts_social_post',
                         'post_status' => 'draft' // Always import as draft for safety
                     ) );
-                    
+
                     if ( $post_id && ! is_wp_error( $post_id ) ) {
                         // Import meta data
                         if ( isset( $post_data['meta'] ) ) {
                             foreach ( $post_data['meta'] as $key => $values ) {
+                                $meta_key = self::sanitize_import_meta_key( $key );
+
+                                if ( null === $meta_key ) {
+                                    continue;
+                                }
+
+                                $values = is_array( $values ) ? $values : array( $values );
+
                                 foreach ( $values as $value ) {
-                                    add_post_meta( $post_id, $key, maybe_unserialize( $value ) );
+                                    $meta_value = self::sanitize_import_meta_value( $value );
+
+                                    if ( null === $meta_value ) {
+                                        continue;
+                                    }
+
+                                    add_post_meta( $post_id, $meta_key, $meta_value );
                                 }
                             }
                         }
@@ -387,6 +415,125 @@ class TTS_Advanced_Utils {
         }
         
         return array( 'valid' => true );
+    }
+
+    /**
+     * Sanitize an imported meta key.
+     *
+     * @param mixed $meta_key Raw meta key from the import file.
+     * @return string|null Sanitized meta key or null when the key is not permitted.
+     */
+    private static function sanitize_import_meta_key( $meta_key ) {
+        if ( ! is_string( $meta_key ) || '' === $meta_key ) {
+            return null;
+        }
+
+        $allowed_prefixes = self::get_allowed_import_meta_prefixes();
+
+        if ( ! empty( $allowed_prefixes ) ) {
+            $matches_prefix = false;
+
+            foreach ( $allowed_prefixes as $prefix ) {
+                if ( 0 === strpos( $meta_key, $prefix ) ) {
+                    $matches_prefix = true;
+                    break;
+                }
+            }
+
+            if ( ! $matches_prefix ) {
+                return null;
+            }
+        }
+
+        $sanitized_key = sanitize_key( $meta_key );
+
+        if ( '' === $sanitized_key ) {
+            return null;
+        }
+
+        return $sanitized_key;
+    }
+
+    /**
+     * Retrieve the list of allowed meta key prefixes for imports.
+     *
+     * @return array<int, string> Allowed prefixes. An empty array allows all keys.
+     */
+    private static function get_allowed_import_meta_prefixes() {
+        /**
+         * Filter the allowed meta key prefixes when importing data.
+         *
+         * Returning an empty array allows all meta keys that sanitize correctly.
+         *
+         * @param array<int, string> $prefixes Allowed prefixes.
+         */
+        $prefixes = apply_filters( 'tts_import_allowed_meta_prefixes', array() );
+
+        if ( ! is_array( $prefixes ) ) {
+            return array();
+        }
+
+        $prefixes = array_filter(
+            array_map(
+                function ( $prefix ) {
+                    return is_string( $prefix ) ? $prefix : '';
+                },
+                $prefixes
+            ),
+            function ( $prefix ) {
+                return '' !== $prefix;
+            }
+        );
+
+        return array_values( $prefixes );
+    }
+
+    /**
+     * Sanitize a meta value before storing it in the database.
+     *
+     * @param mixed $value Meta value from the import file.
+     * @return mixed|null Sanitized value or null when the value should be skipped.
+     */
+    private static function sanitize_import_meta_value( $value ) {
+        if ( is_object( $value ) ) {
+            $value = (array) $value;
+        }
+
+        if ( is_array( $value ) ) {
+            $sanitized = array();
+
+            foreach ( $value as $key => $item ) {
+                $clean = self::sanitize_import_meta_value( $item );
+
+                if ( null === $clean ) {
+                    continue;
+                }
+
+                $sanitized[ $key ] = $clean;
+            }
+
+            return $sanitized;
+        }
+
+        if ( null === $value ) {
+            return null;
+        }
+
+        if ( is_bool( $value ) || is_int( $value ) || is_float( $value ) ) {
+            return $value;
+        }
+
+        if ( is_string( $value ) ) {
+            if ( self::SECRET_PLACEHOLDER === $value ) {
+                return null;
+            }
+
+            $value = wp_kses_post( $value );
+
+            return trim( $value );
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Summary
- enforce file size limits and MIME validation for admin data imports
- sanitize imported meta keys and values while skipping placeholder secrets

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-advanced-utils.php

------
https://chatgpt.com/codex/tasks/task_e_68d441424c64832fa0f6a5dd5ba089be