### PR TITLE
Ensure admin file size constant works without WordPress defaults

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+if ( ! defined( 'MB_IN_BYTES' ) ) {
+    define( 'MB_IN_BYTES', 1024 * 1024 );
+}
+
 /**
  * Handles admin pages and filters.
  */


### PR DESCRIPTION
## Summary
- define the MB_IN_BYTES fallback before the admin class loads so environments without WordPress defaults still function

## Testing
- for test in wp-content/plugins/trello-social-auto-publisher/tests/test-*.php; do echo "Running $test"; php "$test" || exit 1; done

------
https://chatgpt.com/codex/tasks/task_e_68d445135290832f9fb0d7e96e3c28c9