### PR TITLE
Improve export error handling and coverage

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -3928,8 +3928,15 @@ class TTS_Admin {
                 return wp_send_json_error( array( 'message' => __( 'Failed to access the upload directory. Please try again later.', 'fp-publisher' ) ), 500 );
             }
 
-            $file_path    = trailingslashit( $upload_dir['path'] ) . $filename;
-            $encoded_data = json_encode( $result['data'], JSON_PRETTY_PRINT );
+            $file_path = trailingslashit( $upload_dir['path'] ) . $filename;
+            $encoded_data = isset( $result['encoded'] ) ? $result['encoded'] : wp_json_encode( $result['data'], JSON_PRETTY_PRINT );
+
+            if ( ! is_string( $encoded_data ) || '' === $encoded_data ) {
+                error_log( 'TTS_Admin: Export encoding returned an invalid payload for ' . $file_path );
+
+                return wp_send_json_error( array( 'message' => __( 'Failed to encode the export package.', 'fp-publisher' ) ), 500 );
+            }
+
             $file_written = file_put_contents( $file_path, $encoded_data );
 
             if ( false === $file_written ) {
@@ -3947,7 +3954,13 @@ class TTS_Admin {
             );
         }
 
-        return wp_send_json_error( array( 'message' => sanitize_text_field( $result['error'] ) ), 500 );
+        $error_message = isset( $result['error'] ) ? sanitize_text_field( $result['error'] ) : __( 'Export failed due to an unexpected error.', 'fp-publisher' );
+
+        if ( isset( $result['error_code'] ) ) {
+            error_log( 'TTS_Admin: Export error [' . $result['error_code'] . '] ' . $error_message );
+        }
+
+        return wp_send_json_error( array( 'message' => $error_message ), 500 );
     }
     
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-advanced-utils.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-advanced-utils.php
@@ -191,21 +191,101 @@ class TTS_Advanced_Utils {
                     'export_date' => current_time( 'mysql' )
                 );
             }
-            
+
+            /**
+             * Allow third-parties to adjust the export payload before encoding.
+             *
+             * @since 1.0.0
+             *
+             * @param array $export_data Prepared export payload.
+             * @param array $options     Export options supplied by the user.
+             */
+            $export_data = apply_filters( 'tts_export_package', $export_data, $options );
+
+            $encoded_payload = self::encode_export_payload( $export_data );
+
+            if ( is_wp_error( $encoded_payload ) ) {
+                return array(
+                    'success'    => false,
+                    'error'      => $encoded_payload->get_error_message(),
+                    'error_code' => $encoded_payload->get_error_code(),
+                );
+            }
+
             return array(
-                'success' => true,
-                'data' => $export_data,
-                'file_size' => strlen( json_encode( $export_data ) )
+                'success'   => true,
+                'data'      => $export_data,
+                'file_size' => strlen( $encoded_payload ),
+                'encoded'   => $encoded_payload,
             );
-            
+
         } catch ( Exception $e ) {
             return array(
                 'success' => false,
-                'error' => 'Export failed: ' . $e->getMessage()
+                'error'   => 'Export failed: ' . $e->getMessage()
             );
         }
     }
-    
+
+    /**
+     * Encode the export payload to JSON with resilient error handling.
+     *
+     * @param array $export_data Export payload.
+     *
+     * @return string|WP_Error
+     */
+    private static function encode_export_payload( array $export_data ) {
+        $options = apply_filters( 'tts_export_json_options', JSON_PRETTY_PRINT );
+
+        if ( ! is_int( $options ) ) {
+            $options = JSON_PRETTY_PRINT;
+        }
+
+        $encoded = wp_json_encode( $export_data, $options );
+
+        if ( false === $encoded ) {
+            $error_message = function_exists( 'json_last_error_msg' ) ? json_last_error_msg() : 'Unknown error';
+            $error_message = sanitize_text_field( (string) $error_message );
+
+            return new WP_Error(
+                'tts_export_encoding_failed',
+                sprintf( __( 'Failed to encode export payload: %s', 'fp-publisher' ), $error_message )
+            );
+        }
+
+        if ( function_exists( 'json_last_error' ) ) {
+            $last_error = json_last_error();
+            if ( JSON_ERROR_NONE !== $last_error ) {
+                $error_message = function_exists( 'json_last_error_msg' ) ? json_last_error_msg() : 'Unknown error';
+                $error_message = sanitize_text_field( (string) $error_message );
+
+                return new WP_Error(
+                    'tts_export_encoding_failed',
+                    sprintf( __( 'Failed to encode export payload: %s', 'fp-publisher' ), $error_message )
+                );
+            }
+        }
+
+        /**
+         * Filter the encoded export payload prior to persistence.
+         *
+         * @since 1.0.0
+         *
+         * @param string $encoded     JSON encoded payload.
+         * @param array  $export_data Original export data.
+         */
+        $encoded = apply_filters( 'tts_export_encoded_payload', $encoded, $export_data );
+
+        if ( ! is_string( $encoded ) || '' === $encoded ) {
+            return new WP_Error(
+                'tts_export_encoding_failed',
+                __( 'Failed to encode export payload: invalid encoded data.', 'fp-publisher' )
+            );
+        }
+
+        return $encoded;
+    }
+
     /**
      * Import plugin settings and data.
      *

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-export-utils.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-export-utils.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/helpers/assertions.php';
+require_once __DIR__ . '/../includes/class-tts-advanced-utils.php';
+
+$tests = array(
+    'export_provides_preencoded_payload' => function () {
+        tts_reset_test_state();
+
+        $result = TTS_Advanced_Utils::export_data(
+            array(
+                'settings'        => false,
+                'social_apps'     => false,
+                'clients'         => false,
+                'posts'           => false,
+                'logs'            => false,
+                'analytics'       => false,
+                'include_secrets' => false,
+            )
+        );
+
+        tts_assert_true( $result['success'], 'Export should succeed when no data sets are requested.' );
+        tts_assert_true(
+            isset( $result['encoded'] ) && is_string( $result['encoded'] ),
+            'Export results must include a pre-encoded JSON payload.'
+        );
+        tts_assert_equals(
+            strlen( $result['encoded'] ),
+            $result['file_size'],
+            'The reported file size should match the encoded payload length.'
+        );
+    },
+    'export_returns_error_on_encoding_failure' => function () {
+        tts_reset_test_state();
+
+        $filter = function ( $payload ) {
+            $payload['data']['invalid'] = INF;
+            return $payload;
+        };
+
+        add_filter( 'tts_export_package', $filter, 10, 1 );
+
+        $result = TTS_Advanced_Utils::export_data();
+
+        tts_assert_false( $result['success'], 'Encoding failures should return a failed export response.' );
+        tts_assert_equals(
+            'tts_export_encoding_failed',
+            $result['error_code'],
+            'Encoding failures should surface a descriptive error code.'
+        );
+        tts_assert_contains(
+            'encode',
+            $result['error'],
+            'The error message should mention encoding.'
+        );
+    },
+    'export_validates_encoded_payload_filter' => function () {
+        tts_reset_test_state();
+
+        $filter = function ( $encoded, $payload ) {
+            unset( $encoded, $payload );
+
+            return array();
+        };
+
+        add_filter( 'tts_export_encoded_payload', $filter, 10, 2 );
+
+        $result = TTS_Advanced_Utils::export_data(
+            array(
+                'settings'        => false,
+                'social_apps'     => false,
+                'clients'         => false,
+                'posts'           => false,
+                'logs'            => false,
+                'analytics'       => false,
+                'include_secrets' => false,
+            )
+        );
+
+        tts_assert_false( $result['success'], 'Invalid encoded payload filters should fail the export.' );
+        tts_assert_equals(
+            'tts_export_encoding_failed',
+            $result['error_code'],
+            'Invalid encoded payloads should surface the encoding failed error code.'
+        );
+    },
+);
+
+$failures = 0;
+$messages = array();
+
+echo "Running export utility tests\n";
+
+foreach ( $tests as $name => $callback ) {
+    try {
+        $callback();
+        echo '.';
+    } catch ( Throwable $exception ) {
+        $failures++;
+        $messages[] = $name . ': ' . $exception->getMessage();
+        echo 'F';
+    }
+}
+
+echo "\n";
+
+if ( $failures > 0 ) {
+    foreach ( $messages as $message ) {
+        echo $message . "\n";
+    }
+    exit( 1 );
+}
+
+echo "All tests passed\n";


### PR DESCRIPTION
## Summary
- add a robust `encode_export_payload()` helper for `TTS_Advanced_Utils` that validates JSON encoding and exposes new filters for payload adjustments
- update the admin export handler to reuse the pre-encoded payload, report encoding issues, and log error codes before responding
- add export utility tests that cover success, encoding failures, and invalid encoded payload filters

## Testing
- php wp-content/plugins/trello-social-auto-publisher/tests/test-export-utils.php
- php wp-content/plugins/trello-social-auto-publisher/tests/test-admin-security.php

------
https://chatgpt.com/codex/tasks/task_e_68d449d42538832fbbf3948a5d9ab70e