### PR TITLE
Handle Trello-disabled saves by falling back to manual content

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-content-source.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-content-source.php
@@ -183,6 +183,15 @@ class TTS_Content_Source {
         
         $source = get_post_meta( $post->ID, '_tts_content_source', true );
 
+        $show_trello_disabled_notice = false;
+        $trello_notice_state         = '';
+        $stored_notice       = get_post_meta( $post->ID, '_tts_trello_disabled_notice', true );
+        if ( is_string( $stored_notice ) && '' !== $stored_notice ) {
+            $trello_notice_state        = $stored_notice;
+            $show_trello_disabled_notice = true;
+            delete_post_meta( $post->ID, '_tts_trello_disabled_notice' );
+        }
+
         if ( empty( $source ) ) {
             $requested_source = $this->get_requested_source();
             if ( '' !== $requested_source ) {
@@ -191,11 +200,13 @@ class TTS_Content_Source {
         }
 
         $trello_enabled = (bool) get_option( 'tts_trello_enabled', 1 );
-        $show_trello_disabled_notice = false;
 
         if ( ! $trello_enabled && 'trello' === $source ) {
             $source                     = 'manual';
             $show_trello_disabled_notice = true;
+            if ( '' === $trello_notice_state ) {
+                $trello_notice_state = 'disabled';
+            }
         }
 
         $source_reference = get_post_meta( $post->ID, '_tts_source_reference', true );
@@ -219,7 +230,13 @@ class TTS_Content_Source {
         echo '</select>';
 
         if ( $show_trello_disabled_notice ) {
-            echo '<p class="description tts-content-source-warning">' . esc_html__( 'Trello integration is disabled. Manual creation will be used for this post unless you choose another source.', 'fp-publisher' ) . '</p>';
+            $notice_message = __( 'Trello integration is disabled. Manual creation will be used for this post unless you choose another source.', 'fp-publisher' );
+
+            if ( 'converted' === $trello_notice_state ) {
+                $notice_message = __( 'Your Trello selection was converted to Manual because the Trello integration was disabled when the post was saved.', 'fp-publisher' );
+            }
+
+            echo '<p class="description tts-content-source-warning">' . esc_html( $notice_message ) . '</p>';
         }
         echo '</td>';
         echo '</tr>';
@@ -262,8 +279,22 @@ class TTS_Content_Source {
             }
         }
 
+        $trello_notice_flag = '';
+        $trello_enabled     = (bool) get_option( 'tts_trello_enabled', 1 );
+
+        if ( null !== $source && 'trello' === $source && ! $trello_enabled ) {
+            $source              = 'manual';
+            $trello_notice_flag  = 'converted';
+        }
+
         if ( null !== $source && ( '' === $source || array_key_exists( $source, self::SOURCES ) ) ) {
             update_post_meta( $post_id, '_tts_content_source', $source );
+        }
+
+        if ( 'converted' === $trello_notice_flag ) {
+            update_post_meta( $post_id, '_tts_trello_disabled_notice', $trello_notice_flag );
+        } else {
+            delete_post_meta( $post_id, '_tts_trello_disabled_notice' );
         }
 
         // Save source reference.

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-disable-trello.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-disable-trello.php
@@ -28,6 +28,57 @@ $tests = array(
         tts_assert_contains( 'value="manual" selected="selected"', $output, 'Manual option should be selected when Trello meta persists.' );
         tts_assert_contains( 'Trello integration is disabled', $output, 'A notice should explain the Trello fallback.' );
     },
+    'save_meta_falls_back_to_manual_when_trello_disabled' => function () {
+        tts_reset_test_state();
+
+        update_option( 'tts_trello_enabled', 0 );
+
+        $post_id = 314;
+        $GLOBALS['tts_current_user_caps'] = array(
+            'edit_post_' . $post_id => true,
+        );
+
+        $_POST = array(
+            'tts_content_source_nonce' => 'nonce-tts_content_source_meta',
+            'tts_content_source'       => 'trello',
+            'tts_source_reference'     => 'CARD-314',
+        );
+
+        $content_source = new TTS_Content_Source();
+        $content_source->save_content_source_meta( $post_id );
+
+        tts_assert_equals(
+            'manual',
+            get_post_meta( $post_id, '_tts_content_source', true ),
+            'Trello selections should fall back to manual when the integration is disabled.'
+        );
+
+        tts_assert_equals(
+            'converted',
+            get_post_meta( $post_id, '_tts_trello_disabled_notice', true ),
+            'Fallbacks should set a one-time notice flag so the editor can inform the user.'
+        );
+
+        $post = (object) array( 'ID' => $post_id );
+
+        ob_start();
+        $content_source->render_content_source_metabox( $post );
+        $output = ob_get_clean();
+
+        tts_assert_contains(
+            'converted to Manual',
+            $output,
+            'The metabox should explain why the Trello selection was converted.'
+        );
+
+        tts_assert_equals(
+            '',
+            get_post_meta( $post_id, '_tts_trello_disabled_notice', true ),
+            'Rendering the metabox should clear the notice flag.'
+        );
+
+        unset( $_POST );
+    },
     'content_management_tabs_hide_trello' => function () {
         tts_reset_test_state();
 


### PR DESCRIPTION
## Summary
- convert Trello content source selections to Manual when the integration is disabled and persist a one-time notice for editors
- surface a clearer metabox notice explaining the automatic fallback and ensure stored flags are cleared after display
- add regression coverage for the Trello-disabled save path to confirm the metabox messaging and notice lifecycle

## Testing
- php tests/test-disable-trello.php
- for test in tests/test-*.php; do php "$test" || break; done

------
https://chatgpt.com/codex/tasks/task_e_68d45635d594832f91c02bffb9b5cfe0