### PR TITLE
Improve notification delivery robustness

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-notify.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-notify.php
@@ -18,9 +18,39 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param int    $post_id Post ID.
  * @param string $status  Publication status.
  * @param string $channel Social channel.
+ *
+ * @return bool Whether at least one notification channel succeeded.
  */
 function tts_notify_publication( $post_id, $status, $channel ) {
-    $title   = get_the_title( $post_id );
+    $post_id = absint( $post_id );
+    $status  = sanitize_key( $status );
+    $channel = sanitize_key( $channel );
+
+    if ( '' === $status ) {
+        $status = 'unknown';
+    }
+
+    if ( '' === $channel ) {
+        $channel = 'general';
+    }
+
+    $title = '';
+
+    if ( function_exists( 'get_the_title' ) ) {
+        $title = (string) get_the_title( $post_id );
+    }
+
+    if ( '' === $title ) {
+        $post  = get_post( $post_id );
+        $title = $post && isset( $post->post_title ) ? (string) $post->post_title : '';
+    }
+
+    $title = wp_strip_all_tags( $title );
+
+    if ( '' === $title ) {
+        $title = sprintf( __( 'Post #%d', 'fp-publisher' ), $post_id );
+    }
+
     $message = sprintf(
         __( 'Post "%s" on %s: %s', 'fp-publisher' ),
         $title,
@@ -28,17 +58,69 @@ function tts_notify_publication( $post_id, $status, $channel ) {
         $status
     );
 
-    $webhook = get_option( 'tts_slack_webhook', '' );
-    if ( ! empty( $webhook ) ) {
-        wp_remote_post(
-            $webhook,
+    $payload = apply_filters(
+        'tts_notify_publication_payload',
+        array(
+            'post_id' => $post_id,
+            'status'  => $status,
+            'channel' => $channel,
+            'message' => $message,
+        ),
+        $post_id,
+        $status,
+        $channel
+    );
+
+    $sent    = false;
+    $webhook = trim( (string) get_option( 'tts_slack_webhook', '' ) );
+
+    if ( '' !== $webhook ) {
+        $response = wp_remote_post(
+            esc_url_raw( $webhook ),
             array(
                 'headers' => array( 'Content-Type' => 'application/json' ),
-                'body'    => wp_json_encode( array( 'text' => $message ) ),
+                'body'    => wp_json_encode( array( 'text' => $payload['message'] ) ),
                 'timeout' => 20,
             )
         );
-        return;
+
+        if ( is_wp_error( $response ) ) {
+            tts_notify_record_failure(
+                $post_id,
+                $channel,
+                $status,
+                'slack_http_error',
+                $response->get_error_message()
+            );
+        } else {
+            $status_code = (int) wp_remote_retrieve_response_code( $response );
+            if ( $status_code >= 200 && $status_code < 300 ) {
+                $sent = true;
+            } else {
+                tts_notify_record_failure(
+                    $post_id,
+                    $channel,
+                    $status,
+                    'slack_unexpected_status',
+                    array(
+                        'status' => $status_code,
+                        'body'   => wp_remote_retrieve_body( $response ),
+                    )
+                );
+            }
+        }
+    }
+
+    if ( $sent ) {
+        return true;
+    }
+
+    $recipient = apply_filters( 'tts_notify_publication_email', get_option( 'admin_email' ), $post_id, $status, $channel );
+    $recipient = sanitize_email( $recipient );
+
+    if ( '' === $recipient ) {
+        tts_notify_record_failure( $post_id, $channel, $status, 'email_invalid_recipient', $payload['message'] );
+        return false;
     }
 
     $subject = sprintf(
@@ -46,5 +128,44 @@ function tts_notify_publication( $post_id, $status, $channel ) {
         $channel,
         $status
     );
-    wp_mail( get_option( 'admin_email' ), $subject, $message );
+
+    $mail_sent = wp_mail( $recipient, $subject, $payload['message'] );
+
+    if ( ! $mail_sent ) {
+        tts_notify_record_failure( $post_id, $channel, $status, 'email_send_failed', $payload['message'] );
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Record a notification delivery failure for observability and audits.
+ *
+ * @param int          $post_id Post identifier.
+ * @param string       $channel Social channel identifier.
+ * @param string       $status  Publication status.
+ * @param string       $code    Failure code.
+ * @param string|array $details Additional context details.
+ */
+function tts_notify_record_failure( $post_id, $channel, $status, $code, $details ) {
+    $context = array(
+        'component' => 'notification',
+        'post_id'   => $post_id,
+        'channel'   => $channel,
+        'status'    => $status,
+        'code'      => $code,
+    );
+
+    if ( class_exists( 'TTS_Logger' ) ) {
+        TTS_Logger::log(
+            sprintf( 'Notification delivery failure: %s', $code ),
+            'warning',
+            array_merge( $context, array( 'details' => $details ) )
+        );
+    }
+
+    if ( function_exists( 'tts_log_event' ) ) {
+        tts_log_event( $post_id, $channel, 'notification_error', $code, $details );
+    }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/tests/bootstrap.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/bootstrap.php
@@ -819,6 +819,24 @@ if ( ! function_exists( 'wp_remote_get' ) ) {
     }
 }
 
+if ( ! function_exists( 'wp_remote_post' ) ) {
+    function wp_remote_post( $url, $args = array() ) {
+        $GLOBALS['tts_recorded_http_posts'][] = array(
+            'url'  => $url,
+            'args' => is_array( $args ) ? $args : array(),
+        );
+
+        if ( isset( $GLOBALS['tts_http_responses'][ $url ] ) ) {
+            return $GLOBALS['tts_http_responses'][ $url ];
+        }
+
+        return array(
+            'response' => array( 'code' => 200 ),
+            'body'     => '',
+        );
+    }
+}
+
 if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
     function wp_remote_retrieve_response_code( $response ) {
         if ( is_array( $response ) && isset( $response['response']['code'] ) ) {
@@ -836,6 +854,26 @@ if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
         }
 
         return '';
+    }
+}
+
+if ( ! function_exists( 'wp_mail' ) ) {
+    function wp_mail( $to, $subject, $message ) {
+        $GLOBALS['tts_sent_emails'][] = array(
+            'to'      => $to,
+            'subject' => $subject,
+            'message' => $message,
+        );
+
+        if ( isset( $GLOBALS['tts_mail_overrides'][ $to ] ) ) {
+            return (bool) $GLOBALS['tts_mail_overrides'][ $to ];
+        }
+
+        if ( isset( $GLOBALS['tts_mail_overrides']['*'] ) ) {
+            return (bool) $GLOBALS['tts_mail_overrides']['*'];
+        }
+
+        return true;
     }
 }
 
@@ -971,6 +1009,18 @@ if ( ! function_exists( 'sanitize_text_field' ) ) {
         $filtered = preg_replace( '/[\r\n\t ]+/', ' ', $filtered );
 
         return trim( (string) $filtered );
+    }
+}
+
+if ( ! function_exists( 'sanitize_email' ) ) {
+    function sanitize_email( $email ) {
+        $email = trim( (string) $email );
+
+        if ( '' === $email ) {
+            return '';
+        }
+
+        return filter_var( $email, FILTER_VALIDATE_EMAIL ) ? $email : '';
     }
 }
 
@@ -1436,6 +1486,9 @@ function tts_reset_test_state() {
     $GLOBALS['tts_loaded_textdomains']    = array();
     $GLOBALS['tts_loaded_plugin_textdomains'] = array();
     $GLOBALS['tts_unloaded_textdomains']  = array();
+    $GLOBALS['tts_sent_emails']           = array();
+    $GLOBALS['tts_mail_overrides']        = array();
+    $GLOBALS['tts_recorded_http_posts']   = array();
 
     if ( class_exists( 'TTS_Secure_Storage' ) && method_exists( 'TTS_Secure_Storage', 'reset_instance' ) ) {
         TTS_Secure_Storage::reset_instance();

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-notify.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-notify.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/helpers/assertions.php';
+require_once __DIR__ . '/../includes/tts-logger.php';
+require_once __DIR__ . '/../includes/tts-notify.php';
+
+$tests = array(
+    'falls_back_to_email_when_slack_fails' => function () {
+        tts_reset_test_state();
+
+        $post_id = 501;
+        $GLOBALS['tts_test_posts'][ $post_id ] = (object) array(
+            'ID'         => $post_id,
+            'post_title' => 'Example Post',
+        );
+
+        update_option( 'admin_email', 'admin@example.com' );
+        update_option( 'tts_slack_webhook', 'https://hooks.slack.com/services/test' );
+
+        $GLOBALS['tts_http_responses']['https://hooks.slack.com/services/test'] = new WP_Error(
+            'slack_error',
+            'Connection refused'
+        );
+
+        $result = tts_notify_publication( $post_id, ' SUCCESS ', ' Facebook  ' );
+
+        tts_assert_true( $result, 'Email fallback should report success when Slack delivery fails.' );
+        tts_assert_equals( 1, count( $GLOBALS['tts_sent_emails'] ), 'Email fallback should send one message.' );
+        tts_assert_equals( 'admin@example.com', $GLOBALS['tts_sent_emails'][0]['to'], 'Fallback email should use admin address.' );
+        tts_assert_contains( 'facebook', strtolower( $GLOBALS['tts_sent_emails'][0]['subject'] ), 'Subject should include sanitized channel.' );
+        tts_assert_contains( 'success', strtolower( $GLOBALS['tts_sent_emails'][0]['subject'] ), 'Subject should include sanitized status.' );
+        tts_assert_contains( 'facebook', strtolower( $GLOBALS['tts_sent_emails'][0]['message'] ), 'Message should include sanitized channel.' );
+
+        tts_assert_equals( 1, count( $GLOBALS['tts_recorded_http_posts'] ), 'Slack request should be attempted once.' );
+        $payload = json_decode( $GLOBALS['tts_recorded_http_posts'][0]['args']['body'], true );
+        tts_assert_equals(
+            'Post "Example Post" on facebook: success',
+            $payload['text'],
+            'Slack payload should contain sanitized message.'
+        );
+    },
+    'returns_true_when_slack_succeeds_without_email' => function () {
+        tts_reset_test_state();
+
+        $post_id = 777;
+        $GLOBALS['tts_test_posts'][ $post_id ] = (object) array(
+            'ID'         => $post_id,
+            'post_title' => 'Story Title',
+        );
+
+        update_option( 'tts_slack_webhook', 'https://hooks.slack.com/services/success' );
+
+        $GLOBALS['tts_http_responses']['https://hooks.slack.com/services/success'] = array(
+            'response' => array( 'code' => 200 ),
+            'body'     => 'ok',
+        );
+
+        $result = tts_notify_publication( $post_id, 'queued', ' instagram ' );
+
+        tts_assert_true( $result, 'Successful Slack delivery should report success.' );
+        tts_assert_equals( 0, count( $GLOBALS['tts_sent_emails'] ), 'Email fallback should not run when Slack succeeds.' );
+        tts_assert_equals( 1, count( $GLOBALS['tts_recorded_http_posts'] ), 'Exactly one Slack request should be recorded.' );
+
+        $payload = json_decode( $GLOBALS['tts_recorded_http_posts'][0]['args']['body'], true );
+        tts_assert_equals(
+            'Post "Story Title" on instagram: queued',
+            $payload['text'],
+            'Slack payload should include sanitized status and channel.'
+        );
+    },
+);
+
+$failures = 0;
+$messages = array();
+
+echo "Running notification tests\n";
+
+foreach ( $tests as $name => $callback ) {
+    try {
+        $callback();
+        echo '.';
+    } catch ( Throwable $exception ) {
+        $failures++;
+        $messages[] = $name . ': ' . $exception->getMessage();
+        echo 'F';
+    }
+}
+
+echo "\n";
+
+if ( $failures > 0 ) {
+    foreach ( $messages as $message ) {
+        echo $message . "\n";
+    }
+    exit( 1 );
+}
+
+echo "All tests passed\n";


### PR DESCRIPTION
## Summary
- sanitize and harden notification publishing with Slack fallback logging and email validation
- extend the test harness with HTTP POST/email stubs and reset helpers for deterministic assertions
- add unit coverage validating Slack failures fall back to email and successful Slack notifications skip email

## Testing
- for test in tests/test-*.php; do php $test || exit 1; done

------
https://chatgpt.com/codex/tasks/task_e_68d45d735bf0832f98817c1ee19823b8