### PR TITLE
Sanitize REST status logs and add coverage

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
@@ -174,19 +174,179 @@ class TTS_REST {
             return new WP_Error( 'invalid_post', __( 'Invalid post ID.', 'fp-publisher' ), array( 'status' => 404 ) );
         }
 
-        $post_status      = get_post_status( $id );
-        $published_status = get_post_meta( $id, '_published_status', true );
+        $post_status_raw      = get_post_status( $id );
+        $published_status_raw = get_post_meta( $id, '_published_status', true );
+
+        $post_status = '';
+        if ( false !== $post_status_raw && null !== $post_status_raw ) {
+            $post_status = sanitize_text_field( (string) $post_status_raw );
+        }
+
+        $published_status = '';
+        if ( ! empty( $published_status_raw ) ) {
+            $published_status = sanitize_text_field( (string) $published_status_raw );
+        }
 
         $table = $wpdb->prefix . 'tts_logs';
         $logs  = $wpdb->get_results( $wpdb->prepare( "SELECT channel, status, message, response, created_at FROM {$table} WHERE post_id = %d ORDER BY id DESC", $id ), ARRAY_A );
+
+        $sanitized_logs = array();
+
+        if ( is_array( $logs ) ) {
+            foreach ( $logs as $log_entry ) {
+                if ( is_object( $log_entry ) ) {
+                    $log_entry = (array) $log_entry;
+                }
+
+                if ( ! is_array( $log_entry ) ) {
+                    continue;
+                }
+
+                $sanitized_logs[] = $this->sanitize_log_entry( $log_entry );
+            }
+        }
 
         return rest_ensure_response(
             array(
                 'post_status'       => $post_status,
                 '_published_status' => $published_status,
-                'logs'              => $logs,
+                'logs'              => $sanitized_logs,
             )
         );
+    }
+
+    /**
+     * Sanitize a single log entry retrieved from the database.
+     *
+     * @param array<string, mixed> $log_entry Raw log entry array.
+     *
+     * @return array<string, mixed> Sanitized log data.
+     */
+    private function sanitize_log_entry( array $log_entry ) {
+        $channel    = isset( $log_entry['channel'] ) ? $this->sanitize_channel_value( $log_entry['channel'] ) : '';
+        $status     = isset( $log_entry['status'] ) ? sanitize_key( sanitize_text_field( (string) $log_entry['status'] ) ) : '';
+        $message    = isset( $log_entry['message'] ) ? sanitize_textarea_field( (string) $log_entry['message'] ) : '';
+        $response   = isset( $log_entry['response'] ) ? $this->sanitize_log_response_field( $log_entry['response'] ) : '';
+        $created_at = isset( $log_entry['created_at'] ) ? sanitize_text_field( (string) $log_entry['created_at'] ) : '';
+
+        return array(
+            'channel'    => $channel,
+            'status'     => $status,
+            'message'    => $message,
+            'response'   => $response,
+            'created_at' => $created_at,
+        );
+    }
+
+    /**
+     * Normalize and sanitize channel values for REST output.
+     *
+     * @param mixed $channel Raw channel value.
+     *
+     * @return string
+     */
+    private function sanitize_channel_value( $channel ) {
+        if ( empty( $channel ) ) {
+            return '';
+        }
+
+        $channel_value = strtolower( sanitize_text_field( (string) $channel ) );
+
+        if ( '' === $channel_value ) {
+            return '';
+        }
+
+        $channel_value = preg_replace( '/[^a-z0-9_\-]+/', '', $channel_value );
+
+        $known_channels = array( 'facebook', 'instagram', 'youtube', 'tiktok', 'linkedin', 'twitter', 'blog' );
+
+        foreach ( $known_channels as $known_channel ) {
+            if ( false !== strpos( $channel_value, $known_channel ) ) {
+                return $known_channel;
+            }
+        }
+
+        return sanitize_key( $channel_value );
+    }
+
+    /**
+     * Sanitize the response field of a log entry.
+     *
+     * @param mixed $response Raw response data.
+     *
+     * @return mixed
+     */
+    private function sanitize_log_response_field( $response ) {
+        if ( is_string( $response ) ) {
+            $decoded = json_decode( $response, true );
+
+            if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+                $sanitized = $this->sanitize_nested_log_value( $decoded );
+                $encoded   = wp_json_encode( $sanitized );
+
+                if ( false !== $encoded ) {
+                    return $encoded;
+                }
+            }
+
+            return sanitize_textarea_field( $response );
+        }
+
+        if ( is_array( $response ) || is_object( $response ) ) {
+            return $this->sanitize_nested_log_value( $response );
+        }
+
+        if ( null === $response ) {
+            return '';
+        }
+
+        if ( is_bool( $response ) ) {
+            return $response;
+        }
+
+        if ( is_int( $response ) || is_float( $response ) ) {
+            return $response;
+        }
+
+        return sanitize_textarea_field( (string) $response );
+    }
+
+    /**
+     * Recursively sanitize nested log data structures.
+     *
+     * @param mixed $value Raw value.
+     *
+     * @return mixed
+     */
+    private function sanitize_nested_log_value( $value ) {
+        if ( is_array( $value ) ) {
+            $sanitized = array();
+
+            foreach ( $value as $key => $nested_value ) {
+                $sanitized_key = is_string( $key ) ? sanitize_key( $key ) : $key;
+                $sanitized[ $sanitized_key ] = $this->sanitize_nested_log_value( $nested_value );
+            }
+
+            return $sanitized;
+        }
+
+        if ( is_object( $value ) ) {
+            return $this->sanitize_nested_log_value( (array) $value );
+        }
+
+        if ( null === $value ) {
+            return '';
+        }
+
+        if ( is_bool( $value ) ) {
+            return $value;
+        }
+
+        if ( is_int( $value ) || is_float( $value ) ) {
+            return $value;
+        }
+
+        return sanitize_textarea_field( (string) $value );
     }
 }
 

--- a/wp-content/plugins/trello-social-auto-publisher/tests/bootstrap.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/bootstrap.php
@@ -28,6 +28,10 @@ if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
     define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
 }
 
+if ( ! defined( 'ARRAY_A' ) ) {
+    define( 'ARRAY_A', 'ARRAY_A' );
+}
+
 // Provide deterministic encryption material for tests.
 putenv( 'TTS_ENCRYPTION_KEY=YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI=' );
 
@@ -1026,7 +1030,14 @@ if ( ! function_exists( 'sanitize_email' ) ) {
 
 if ( ! function_exists( 'sanitize_textarea_field' ) ) {
     function sanitize_textarea_field( $text ) {
-        return is_string( $text ) ? trim( preg_replace( "/[\r\0\x0B\f]/", '', $text ) ) : $text;
+        if ( ! is_string( $text ) ) {
+            return $text;
+        }
+
+        $filtered = sanitize_text_field( $text );
+        $filtered = preg_replace( "/[\r\0\x0B\f]/", '', $filtered );
+
+        return trim( $filtered );
     }
 }
 
@@ -1193,6 +1204,18 @@ if ( ! function_exists( 'delete_post_meta' ) ) {
 if ( ! function_exists( 'get_post' ) ) {
     function get_post( $post_id ) {
         return $GLOBALS['tts_test_posts'][ $post_id ] ?? null;
+    }
+}
+
+if ( ! function_exists( 'get_post_status' ) ) {
+    function get_post_status( $post_id ) {
+        $post = get_post( $post_id );
+
+        if ( is_object( $post ) && isset( $post->post_status ) ) {
+            return $post->post_status;
+        }
+
+        return false;
     }
 }
 

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-rest.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-rest.php
@@ -138,6 +138,48 @@ $tests = array(
         tts_assert_true( is_wp_error( $response ), 'Trashed posts cannot be published.' );
         tts_assert_equals( 'invalid_post_status', $response->get_error_code(), 'Trashed posts should trigger invalid_post_status.' );
     },
+    'status_sanitizes_log_entries' => function () {
+        tts_reset_test_state();
+
+        $post_id = 505;
+        $GLOBALS['tts_test_posts'][ $post_id ] = (object) array(
+            'ID'         => $post_id,
+            'post_type'  => 'tts_social_post',
+            'post_status'=> 'publish',
+        );
+
+        update_post_meta( $post_id, '_published_status', '<strong>sent</strong>' );
+
+        $GLOBALS['tts_test_wpdb_results'] = array(
+            array(
+                'channel'    => '<script>facebook</script>',
+                'status'     => '<b>success</b>',
+                'message'    => '<em>Published!</em>',
+                'response'   => '{"detail":"<span>ok</span>","code":200}',
+                'created_at' => '2024-01-01 12:00:00<script>',
+            ),
+        );
+
+        $rest     = new TTS_REST();
+        $request  = new WP_REST_Request( 'GET', array( 'id' => $post_id ) );
+        $response = $rest->status( $request );
+
+        tts_assert_true( $response instanceof WP_REST_Response, 'Status endpoint should return a WP_REST_Response.' );
+
+        $data = $response->get_data();
+
+        tts_assert_equals( 'publish', $data['post_status'], 'Post status should be preserved after sanitization.' );
+        tts_assert_equals( 'sent', $data['_published_status'], 'Published status should strip markup.' );
+        tts_assert_equals( 1, count( $data['logs'] ), 'Exactly one log entry should be returned.' );
+
+        $log = $data['logs'][0];
+
+        tts_assert_equals( 'facebook', $log['channel'], 'Channel names should be normalized and sanitized.' );
+        tts_assert_equals( 'success', $log['status'], 'Status values should be sanitized.' );
+        tts_assert_equals( 'Published!', $log['message'], 'Log messages should be stripped of HTML.' );
+        tts_assert_equals( '{"detail":"ok","code":200}', $log['response'], 'JSON responses should be sanitized and re-encoded.' );
+        tts_assert_equals( '2024-01-01 12:00:00', $log['created_at'], 'Timestamps should not include unsafe characters.' );
+    },
 );
 
 $failures = 0;


### PR DESCRIPTION
## Summary
- sanitize REST API status responses by normalizing post state metadata and scrubbing log payloads before returning them
- add helper utilities to sanitize nested log structures and normalize channel values
- extend the lightweight test harness and REST tests to cover sanitized status output

## Testing
- php tests/test-admin-security.php
- php tests/test-deactivation.php
- php tests/test-disable-trello.php
- php tests/test-export-utils.php
- php tests/test-i18n.php
- php tests/test-integration-hub-extensibility.php
- php tests/test-logger.php
- php tests/test-notify.php
- php tests/test-rest.php
- php tests/test-secure-storage.php
- php tests/test-security-audit.php
- php tests/test-service-container.php
- php tests/test-token-refresh.php
- php tests/test-uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68d4e72d54e4832f8a27b26061a97755