### PR TITLE
Harden REST endpoints with strict post id validation

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-rest.php
@@ -25,23 +25,32 @@ class TTS_REST {
      * Register REST API routes.
      */
     public function register_routes() {
+        $args = array(
+            'args'                 => $this->get_post_id_route_args(),
+            'permission_callback'  => array( $this, 'permissions_check' ),
+        );
+
         register_rest_route(
             'tts/v1',
             '/post/(?P<id>\d+)/publish',
-            array(
-                'methods'             => 'POST',
-                'callback'            => array( $this, 'publish' ),
-                'permission_callback' => array( $this, 'permissions_check' ),
+            array_merge(
+                $args,
+                array(
+                    'methods'  => 'POST',
+                    'callback' => array( $this, 'publish' ),
+                )
             )
         );
 
         register_rest_route(
             'tts/v1',
             '/post/(?P<id>\d+)/status',
-            array(
-                'methods'             => 'GET',
-                'callback'            => array( $this, 'status' ),
-                'permission_callback' => array( $this, 'permissions_check' ),
+            array_merge(
+                $args,
+                array(
+                    'methods'  => 'GET',
+                    'callback' => array( $this, 'status' ),
+                )
             )
         );
     }
@@ -54,7 +63,11 @@ class TTS_REST {
      * @return bool
      */
     public function permissions_check( WP_REST_Request $request ) {
-        $post_id = intval( $request['id'] );
+        $post_id = $this->resolve_post_id( $request );
+
+        if ( is_wp_error( $post_id ) ) {
+            return $post_id;
+        }
 
         if ( ! $this->verify_rest_nonce( $request ) ) {
             return new WP_Error( 'rest_forbidden', __( 'Invalid REST nonce.', 'fp-publisher' ), array( 'status' => 403 ) );
@@ -102,7 +115,11 @@ class TTS_REST {
      * @return WP_REST_Response
      */
     public function publish( WP_REST_Request $request ) {
-        $id = intval( $request['id'] );
+        $id = $this->resolve_post_id( $request );
+
+        if ( is_wp_error( $id ) ) {
+            return $id;
+        }
 
         if ( $id <= 0 ) {
             return new WP_Error( 'invalid_post', __( 'Invalid post ID.', 'fp-publisher' ), array( 'status' => 404 ) );
@@ -168,7 +185,12 @@ class TTS_REST {
     public function status( WP_REST_Request $request ) {
         global $wpdb;
 
-        $id   = intval( $request['id'] );
+        $id = $this->resolve_post_id( $request );
+
+        if ( is_wp_error( $id ) ) {
+            return $id;
+        }
+
         $post = get_post( $id );
         if ( ! $post ) {
             return new WP_Error( 'invalid_post', __( 'Invalid post ID.', 'fp-publisher' ), array( 'status' => 404 ) );
@@ -347,6 +369,70 @@ class TTS_REST {
         }
 
         return sanitize_textarea_field( (string) $value );
+    }
+
+    /**
+     * Schema for REST route post ID argument.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function get_post_id_route_args() {
+        return array(
+            'id' => array(
+                'description'       => __( 'The unique identifier of the social post.', 'fp-publisher' ),
+                'type'              => 'integer',
+                'required'          => true,
+                'sanitize_callback' => 'absint',
+                'validate_callback' => array( $this, 'validate_post_id_argument' ),
+            ),
+        );
+    }
+
+    /**
+     * Validate the REST argument for a post identifier.
+     *
+     * @param mixed            $value   Raw value.
+     * @param WP_REST_Request  $request Request instance.
+     * @param string           $param   Parameter name.
+     *
+     * @return true|WP_Error
+     */
+    public function validate_post_id_argument( $value, $request, $param ) {
+        unset( $request );
+
+        $id = absint( $value );
+
+        if ( $id < 1 ) {
+            return new WP_Error(
+                'rest_invalid_param',
+                __( 'The post ID must be a positive integer.', 'fp-publisher' ),
+                array(
+                    'status' => 400,
+                    'param'  => $param,
+                )
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolve and sanitize the post ID from a REST request.
+     *
+     * @param WP_REST_Request $request Request instance.
+     *
+     * @return int|WP_Error
+     */
+    private function resolve_post_id( WP_REST_Request $request ) {
+        $raw = $request->get_param( 'id' );
+
+        $id = absint( is_array( $raw ) ? reset( $raw ) : $raw );
+
+        if ( $id < 1 ) {
+            return new WP_Error( 'invalid_post', __( 'Invalid post ID.', 'fp-publisher' ), array( 'status' => 404 ) );
+        }
+
+        return $id;
     }
 }
 

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-rest.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-rest.php
@@ -6,6 +6,47 @@ require __DIR__ . '/helpers/assertions.php';
 require_once __DIR__ . '/../includes/class-tts-rest.php';
 
 $tests = array(
+    'register_routes_define_argument_schema' => function () {
+        tts_reset_test_state();
+
+        $rest = new TTS_REST();
+        $rest->register_routes();
+
+        $routes = $GLOBALS['tts_registered_rest_routes'];
+        tts_assert_true( ! empty( $routes ), 'Registering routes should populate the global registry.' );
+
+        $publish_route = null;
+        $status_route  = null;
+
+        foreach ( $routes as $route ) {
+            if ( '/post/(?P<id>\d+)/publish' === $route['route'] ) {
+                $publish_route = $route;
+            }
+
+            if ( '/post/(?P<id>\d+)/status' === $route['route'] ) {
+                $status_route = $route;
+            }
+        }
+
+        tts_assert_true( is_array( $publish_route ), 'The publish endpoint must be registered.' );
+        tts_assert_true( is_array( $status_route ), 'The status endpoint must be registered.' );
+
+        $publish_args = $publish_route['args']['args'] ?? array();
+        $status_args  = $status_route['args']['args'] ?? array();
+
+        foreach ( array( $publish_args, $status_args ) as $arg_schema ) {
+            tts_assert_true( isset( $arg_schema['id'] ), 'Routes must expose an id argument schema.' );
+
+            $id_args = $arg_schema['id'];
+
+            tts_assert_equals( 'integer', $id_args['type'], 'The id argument should declare an integer type.' );
+            tts_assert_equals( 'absint', $id_args['sanitize_callback'], 'The id argument should sanitize using absint.' );
+            tts_assert_true(
+                is_array( $id_args['validate_callback'] ) && count( $id_args['validate_callback'] ) === 2,
+                'The id argument should expose a callable validate callback.'
+            );
+        }
+    },
     'publish_returns_error_for_invalid_post' => function () {
         tts_reset_test_state();
 
@@ -138,6 +179,16 @@ $tests = array(
         tts_assert_true( is_wp_error( $response ), 'Trashed posts cannot be published.' );
         tts_assert_equals( 'invalid_post_status', $response->get_error_code(), 'Trashed posts should trigger invalid_post_status.' );
     },
+    'publish_rejects_non_numeric_ids' => function () {
+        tts_reset_test_state();
+
+        $rest     = new TTS_REST();
+        $request  = new WP_REST_Request( 'POST', array( 'id' => 'not-a-number' ) );
+        $response = $rest->publish( $request );
+
+        tts_assert_true( is_wp_error( $response ), 'Non numeric identifiers should be rejected.' );
+        tts_assert_equals( 'invalid_post', $response->get_error_code(), 'Non numeric identifiers should return invalid_post.' );
+    },
     'status_sanitizes_log_entries' => function () {
         tts_reset_test_state();
 
@@ -179,6 +230,16 @@ $tests = array(
         tts_assert_equals( 'Published!', $log['message'], 'Log messages should be stripped of HTML.' );
         tts_assert_equals( '{"detail":"ok","code":200}', $log['response'], 'JSON responses should be sanitized and re-encoded.' );
         tts_assert_equals( '2024-01-01 12:00:00', $log['created_at'], 'Timestamps should not include unsafe characters.' );
+    },
+    'status_rejects_invalid_post_ids' => function () {
+        tts_reset_test_state();
+
+        $rest     = new TTS_REST();
+        $request  = new WP_REST_Request( 'GET', array( 'id' => 0 ) );
+        $response = $rest->status( $request );
+
+        tts_assert_true( is_wp_error( $response ), 'Invalid identifiers should not reach the status handler.' );
+        tts_assert_equals( 'invalid_post', $response->get_error_code(), 'Invalid identifiers should return invalid_post.' );
     },
 );
 


### PR DESCRIPTION
## Summary
- add REST route argument schema for social post identifiers with sanitize and validation callbacks
- centralize REST request post ID normalization and reuse it across permission, publish and status handlers
- extend REST API unit tests to cover argument registration and invalid identifier handling

## Testing
- php wp-content/plugins/trello-social-auto-publisher/tests/test-rest.php

------
https://chatgpt.com/codex/tasks/task_e_68d4fa0044dc832f8f76e95d9f84cb44