### PR TITLE
Harden log page capability checks

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-log-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-log-page.php
@@ -29,6 +29,10 @@ class TTS_Log_Page {
      * Render the log page.
      */
     public function render_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'You are not allowed to access the FP Publisher logs.', 'fp-publisher' ) );
+        }
+
         $table = new TTS_Log_Table();
         $table->process_actions();
         $table->prepare_items();
@@ -200,6 +204,10 @@ class TTS_Log_Table extends WP_List_Table {
      * Handle row actions.
      */
     public function process_actions() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'You are not allowed to manage FP Publisher logs.', 'fp-publisher' ) );
+        }
+
         if ( isset( $_GET['action'], $_GET['log'] ) && 'delete' === $_GET['action'] ) {
             $log_id = absint( $_GET['log'] );
             check_admin_referer( 'tts_delete_log_' . $log_id );

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-admin-security.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-admin-security.php
@@ -5,6 +5,7 @@ require __DIR__ . '/bootstrap.php';
 require __DIR__ . '/helpers/assertions.php';
 require_once __DIR__ . '/../includes/class-tts-advanced-utils.php';
 require_once __DIR__ . '/../includes/class-tts-rest.php';
+require_once __DIR__ . '/../admin/class-tts-log-page.php';
 
 $tests = array(
     'ajax_export_rejects_invalid_nonce' => function () {
@@ -195,6 +196,43 @@ $tests = array(
 
         $result = $rest->permissions_check( $valid_request );
         tts_assert_true( true === $result, 'Proper capabilities and nonce should allow REST access.' );
+    },
+    'log_page_requires_manage_options' => function () {
+        tts_reset_test_state();
+
+        $log_page = new TTS_Log_Page();
+
+        try {
+            $log_page->render_page();
+            tts_assert_true( false, 'Rendering the log page without capabilities should trigger wp_die.' );
+        } catch ( RuntimeException $e ) {
+            tts_assert_equals(
+                'You are not allowed to access the FP Publisher logs.',
+                $e->getMessage(),
+                'The log page should block unauthorized access with a descriptive message.'
+            );
+        }
+    },
+    'log_deletion_requires_manage_options' => function () {
+        tts_reset_test_state();
+
+        $_GET = array(
+            'action' => 'delete',
+            'log'    => '15',
+        );
+
+        $table = new TTS_Log_Table();
+
+        try {
+            $table->process_actions();
+            tts_assert_true( false, 'Deleting logs without capabilities should not be allowed.' );
+        } catch ( RuntimeException $e ) {
+            tts_assert_equals(
+                'You are not allowed to manage FP Publisher logs.',
+                $e->getMessage(),
+                'Unauthorized log deletions should be blocked with a descriptive message.'
+            );
+        }
     },
 );
 


### PR DESCRIPTION
## Summary
- ensure the FP Publisher log screen verifies manage_options capability before rendering or deleting entries
- terminate unauthorized log deletions with wp_die to avoid bypassing admin menu capability constraints
- extend admin security tests to cover the new access guards on the log page and deletion actions

## Testing
- `cd wp-content/plugins/trello-social-auto-publisher && for file in tests/test-*.php; do   echo "Running $file";   php $file || exit 1; done`


------
https://chatgpt.com/codex/tasks/task_e_68d5046e1b38832fa95cd48938b116d8