### PR TITLE
Improve social app settings sanitization

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -3057,19 +3057,91 @@ class TTS_Admin {
         }
 
         $social_apps = isset( $_POST['social_apps'] ) ? $_POST['social_apps'] : array();
-        $sanitized_apps = array();
 
-        foreach ( $social_apps as $platform => $settings ) {
-            $platform = sanitize_key( $platform );
-            $sanitized_apps[$platform] = array();
-
-            foreach ( $settings as $key => $value ) {
-                $key = sanitize_key( $key );
-                $sanitized_apps[$platform][$key] = sanitize_text_field( $value );
-            }
+        if ( ! is_array( $social_apps ) ) {
+            update_option( 'tts_social_apps', array() );
+            return;
         }
 
+        $social_apps    = wp_unslash( $social_apps );
+        $sanitized_apps = $this->sanitize_social_app_settings_array( $social_apps );
+
         update_option( 'tts_social_apps', $sanitized_apps );
+    }
+
+    /**
+     * Sanitize the submitted social app credentials payload.
+     *
+     * @param array $social_apps Raw social app settings keyed by platform.
+     * @return array Sanitized settings.
+     */
+    private function sanitize_social_app_settings_array( array $social_apps ) {
+        $sanitized = array();
+
+        foreach ( $social_apps as $platform => $settings ) {
+            if ( ! is_string( $platform ) ) {
+                continue;
+            }
+
+            $platform_key = sanitize_key( $platform );
+
+            if ( '' === $platform_key ) {
+                continue;
+            }
+
+            if ( is_object( $settings ) ) {
+                $settings = (array) $settings;
+            }
+
+            if ( ! is_array( $settings ) ) {
+                $sanitized[ $platform_key ] = array();
+                continue;
+            }
+
+            $sanitized[ $platform_key ] = $this->sanitize_social_app_fields( $settings );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Recursively sanitize a set of social app credential fields.
+     *
+     * @param array $fields Raw credential fields.
+     * @return array Sanitized credential fields.
+     */
+    private function sanitize_social_app_fields( $fields ) {
+        if ( is_object( $fields ) ) {
+            $fields = (array) $fields;
+        }
+
+        if ( ! is_array( $fields ) ) {
+            return array();
+        }
+
+        $sanitized = array();
+
+        foreach ( $fields as $key => $value ) {
+            if ( is_string( $key ) ) {
+                $clean_key = sanitize_key( $key );
+
+                if ( '' === $clean_key ) {
+                    continue;
+                }
+            } else {
+                $clean_key = $key;
+            }
+
+            if ( is_array( $value ) || is_object( $value ) ) {
+                $clean_value = $this->sanitize_social_app_fields( $value );
+            } else {
+                $clean_value = sanitize_text_field( stripslashes( wp_unslash( (string) $value ) ) );
+            }
+
+            $sanitized[ $clean_key ] = $clean_value;
+        }
+
+        return $sanitized;
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-admin-security.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-admin-security.php
@@ -197,6 +197,87 @@ $tests = array(
         $result = $rest->permissions_check( $valid_request );
         tts_assert_true( true === $result, 'Proper capabilities and nonce should allow REST access.' );
     },
+    'save_social_app_settings_sanitizes_nested_payload' => function () {
+        tts_reset_test_state();
+
+        $GLOBALS['tts_current_user_caps'] = array(
+            'manage_options' => true,
+        );
+
+        $admin = new TTS_Admin();
+
+        $_POST = array(
+            'social_apps' => array(
+                ' facebook ' => array(
+                    'app_id'      => "  ABC\\'123  ",
+                    'app_secret'  => '<strong>secret</strong>',
+                    'webhooks'    => array(
+                        'callback_url ' => ' https://example.com/callback ',
+                        'events'        => array( ' mentions ', 'comments ' ),
+                    ),
+                    'invalid key!' => array( 'should_drop' => '<b>value</b>' ),
+                ),
+                'invalid platform!' => array(
+                    'app_id' => 'ignored',
+                ),
+            ),
+        );
+
+        $method = new ReflectionMethod( TTS_Admin::class, 'save_social_app_settings' );
+        $method->setAccessible( true );
+        $method->invoke( $admin );
+
+        $stored = get_option( 'tts_social_apps', array() );
+
+        tts_assert_true(
+            isset( $stored['facebook'] ),
+            'Sanitized settings should retain the Facebook platform.'
+        );
+
+        tts_assert_false(
+            isset( $stored['invalid_platform'] ),
+            'Platforms with invalid keys should be discarded.'
+        );
+
+        $facebook = $stored['facebook'];
+
+        tts_assert_equals(
+            "ABC'123",
+            $facebook['app_id'],
+            'App IDs should be unslashed and sanitized.'
+        );
+
+        tts_assert_equals(
+            'secret',
+            $facebook['app_secret'],
+            'Secrets should be stripped of HTML markup.'
+        );
+
+        tts_assert_true(
+            isset( $facebook['webhooks']['callback_url'] ),
+            'Nested webhook configuration should be preserved.'
+        );
+
+        tts_assert_equals(
+            'https://example.com/callback',
+            $facebook['webhooks']['callback_url'],
+            'Callback URLs should be trimmed and sanitized.'
+        );
+
+        tts_assert_equals(
+            array( 'mentions', 'comments' ),
+            array_values( $facebook['webhooks']['events'] ),
+            'Event lists should remain arrays of sanitized strings.'
+        );
+
+        $serialized = wp_json_encode( $stored );
+        tts_assert_false(
+            false !== strpos( $serialized, 'Array' ),
+            'Nested values must not collapse into the literal string "Array".'
+        );
+
+        unset( $_POST );
+    },
     'log_page_requires_manage_options' => function () {
         tts_reset_test_state();
 


### PR DESCRIPTION
## Summary
- harden `TTS_Admin::save_social_app_settings()` by rejecting non-array payloads and delegating to a recursive sanitizer for keys/values
- add helper methods to normalize nested social credential structures and strip slashes from stored secrets
- cover the new behaviour with an admin security regression test exercising nested data sanitization

## Testing
- `cd wp-content/plugins/trello-social-auto-publisher && for file in tests/test-*.php; do echo "Running $file"; php "$file" || break; done`


------
https://chatgpt.com/codex/tasks/task_e_68d51c3e993c832f8be3da0c5d8e8312