### PR TITLE
Improve environment validation for production readiness

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/tests/test-environment.php
+++ b/wp-content/plugins/trello-social-auto-publisher/tests/test-environment.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/helpers/assertions.php';
+require_once __DIR__ . '/../trello-social-auto-publisher.php';
+
+$tests = array(
+    'flags_missing_extensions_via_filter' => function () {
+        tts_reset_test_state();
+
+        add_filter(
+            'tsap_extension_supported',
+            function ( $supported, $extension ) {
+                if ( in_array( $extension, array( 'curl', 'json', 'mbstring' ), true ) ) {
+                    return false;
+                }
+
+                return $supported;
+            },
+            10,
+            2
+        );
+
+        $issues = tsap_get_environment_issues();
+        $combined = implode( ' | ', $issues );
+
+        tts_assert_contains(
+            'The cURL PHP extension must be enabled to communicate with external services.',
+            $combined,
+            'Missing cURL support should be reported.'
+        );
+
+        tts_assert_contains(
+            'The JSON PHP extension must be enabled to encode and decode API responses.',
+            $combined,
+            'Missing JSON support should be reported.'
+        );
+
+        tts_assert_contains(
+            'The Mbstring PHP extension must be enabled to handle multibyte content safely.',
+            $combined,
+            'Missing Mbstring support should be reported.'
+        );
+
+        tts_reset_test_state();
+    },
+);
+
+$failures = 0;
+$messages = array();
+
+echo "Running environment requirement tests\n";
+
+foreach ( $tests as $name => $callback ) {
+    try {
+        $callback();
+        echo '.';
+    } catch ( Throwable $e ) {
+        $failures++;
+        $messages[] = $name . ': ' . $e->getMessage();
+        echo 'F';
+    }
+}
+
+echo "\n";
+
+if ( $failures > 0 ) {
+    foreach ( $messages as $message ) {
+        echo $message . "\n";
+    }
+    exit( 1 );
+}
+
+echo "All tests passed\n";

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -35,9 +35,9 @@ if ( ! function_exists( 'tsap_get_environment_issues' ) ) {
     function tsap_get_environment_issues() {
         $issues = array();
 
-        if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
+        if ( version_compare( PHP_VERSION, '8.1', '<' ) ) {
             /* translators: %s: current PHP version */
-            $issues[] = sprintf( __( 'FP Publisher requires PHP 7.4 or higher. Current version: %s.', 'fp-publisher' ), PHP_VERSION );
+            $issues[] = sprintf( __( 'FP Publisher requires PHP 8.1 or higher. Current version: %s.', 'fp-publisher' ), PHP_VERSION );
         }
 
         $wp_version = null;
@@ -53,8 +53,36 @@ if ( ! function_exists( 'tsap_get_environment_issues' ) ) {
             $issues[] = sprintf( __( 'FP Publisher requires WordPress 6.1 or higher. Current version: %s.', 'fp-publisher' ), $wp_version );
         }
 
-        if ( ! extension_loaded( 'openssl' ) || ! function_exists( 'openssl_cipher_iv_length' ) ) {
-            $issues[] = __( 'The OpenSSL PHP extension must be enabled to secure stored credentials.', 'fp-publisher' );
+        $required_extensions = array(
+            'curl'     => __( 'The cURL PHP extension must be enabled to communicate with external services.', 'fp-publisher' ),
+            'json'     => __( 'The JSON PHP extension must be enabled to encode and decode API responses.', 'fp-publisher' ),
+            'mbstring' => __( 'The Mbstring PHP extension must be enabled to handle multibyte content safely.', 'fp-publisher' ),
+            'openssl'  => __( 'The OpenSSL PHP extension must be enabled to secure stored credentials.', 'fp-publisher' ),
+        );
+
+        foreach ( $required_extensions as $extension => $message ) {
+            $supported = extension_loaded( $extension );
+
+            if ( 'openssl' === $extension ) {
+                $supported = $supported && function_exists( 'openssl_cipher_iv_length' );
+            }
+
+            if ( function_exists( 'apply_filters' ) ) {
+                /**
+                 * Allow overriding extension availability checks.
+                 *
+                 * This is primarily used for integration tests where PHP extensions
+                 * cannot be toggled dynamically.
+                 *
+                 * @param bool   $supported Whether the extension is considered available.
+                 * @param string $extension Extension name being evaluated.
+                 */
+                $supported = apply_filters( 'tsap_extension_supported', $supported, $extension );
+            }
+
+            if ( ! $supported ) {
+                $issues[] = $message;
+            }
         }
 
         if ( ! function_exists( 'as_schedule_single_action' ) ) {


### PR DESCRIPTION
## Summary
- raise the minimum PHP requirement to 8.1 and extend environment checks to cover cURL, JSON, and Mbstring extensions
- introduce a filterable extension detection helper so hosting constraints can be simulated during testing
- add a focused test suite that exercises the new environment validation logic

## Testing
- php tests/test-admin-security.php
- php tests/test-deactivation.php
- php tests/test-disable-trello.php
- php tests/test-environment.php
- php tests/test-export-utils.php
- php tests/test-i18n.php
- php tests/test-integration-hub-extensibility.php
- php tests/test-logger.php
- php tests/test-notify.php
- php tests/test-rest.php
- php tests/test-secure-storage.php
- php tests/test-security-audit.php
- php tests/test-service-container.php
- php tests/test-token-refresh.php
- php tests/test-uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68d532cb8c04832fa0544cfedc3d49eb