### PR TITLE
Wrap integration hub behind interface guard

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-integration-hub.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-integration-hub.php
@@ -9,9 +9,35 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+$contracts_file = __DIR__ . '/class-tts-operating-contracts.php';
+
+if ( file_exists( $contracts_file ) && ! interface_exists( 'TTS_Integration_Gateway_Interface' ) ) {
+    require_once $contracts_file;
+} elseif ( ! file_exists( $contracts_file ) && function_exists( 'error_log' ) ) {
+    error_log( 'FP Publisher: missing integration contracts file. Expected at ' . $contracts_file );
+}
+
+if ( ! interface_exists( 'TTS_Integration_Gateway_Interface' ) ) {
+    if ( function_exists( 'add_action' ) ) {
+        add_action( 'admin_notices', function () {
+            echo '<div class="error"><p>' .
+                esc_html__( 'FP Publisher could not load its integration contracts. Please reinstall the plugin to restore missing files.', 'fp-publisher' ) .
+                '</p></div>';
+        } );
+    }
+
+    if ( function_exists( 'error_log' ) ) {
+        error_log( 'FP Publisher: missing TTS_Integration_Gateway_Interface; Integration Hub not initialized.' );
+    }
+
+    return;
+}
+
 /**
  * Handles third-party integrations and API connections.
  */
+if ( interface_exists( 'TTS_Integration_Gateway_Interface' ) && ! class_exists( 'TTS_Integration_Hub' ) ) :
+
 class TTS_Integration_Hub implements TTS_Integration_Gateway_Interface {
 
     /**
@@ -3001,3 +3027,5 @@ class TTS_Integration_Hub implements TTS_Integration_Gateway_Interface {
         $this->telemetry_channel->record_event( $event );
     }
 }
+
+endif;


### PR DESCRIPTION
## Summary
- always resolve the integration contracts path before bootstrapping the hub and log when the file is missing
- short-circuit plugin execution with an admin notice if the gateway interface is still unavailable
- only declare the integration hub class when its gateway interface has been loaded to avoid activation fatals

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-integration-hub.php

------
https://chatgpt.com/codex/tasks/task_e_68d540e143b4832f85d3f0fee1cbd6fd