### PR TITLE
Add wizard credential validation and inline token tests

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,49 @@
+name: Build Release Package
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Generate distributable artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer
+          extensions: mbstring, json
+
+      - name: Make packaging script executable
+        run: chmod +x wp-content/plugins/trello-social-auto-publisher/tools/build-release-package.sh
+
+      - name: Build release package
+        run: bash wp-content/plugins/trello-social-auto-publisher/tools/build-release-package.sh
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fp-publisher-release-${{ github.run_number }}
+          path: build/release/artifacts/
+          retention-days: 14
+
+      - name: Attach artifacts to tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            build/release/artifacts/trello-social-auto-publisher-*.zip
+            build/release/artifacts/checksums.txt
+            build/release/artifacts/manifest.json
+            build/release/artifacts/release-notes.md
+          body_path: build/release/artifacts/release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,0 +1,30 @@
+name: Plugin Quality Checks
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Run plugin test suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+          tools: composer
+
+      - name: Validate Composer configuration
+        run: composer validate --no-check-publish
+
+      - name: Execute plugin tests
+        run: composer test

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Plugin WordPress per l'automazione della pubblicazione sui social e sui blog a p
 - [Automazioni e workflow](#automazioni-e-workflow)
 - [Sicurezza, qualità e compliance](#sicurezza-qualità-e-compliance)
 - [Performance e monitoraggio](#performance-e-monitoraggio)
+- [Strumenti da riga di comando](#strumenti-da-riga-di-comando)
+- [Qualità e test automatici](#qualità-e-test-automatici)
 - [Documentazione di riferimento](#documentazione-di-riferimento)
 - [Storico versioni](#storico-versioni)
 - [Supporto](#supporto)
@@ -26,6 +28,23 @@ FP Publisher centralizza la gestione dei contenuti provenienti da Trello e da so
 2. Apri l'ultima esecuzione completata del workflow **Build WordPress Plugin**.
 3. Scarica l'artifact `fp-publisher-wordpress-plugin-latest`.
 4. Carica il file ZIP in **WordPress Admin → Plugin → Aggiungi nuovo → Carica plugin**.
+5. In alternativa avvia il workflow [Build Release Package](https://github.com/franpass87/FP-Publisher/actions/workflows/release-package.yml) per ottenere automaticamente ZIP firmato, checksum, manifest e note di rilascio.
+
+### Genera un pacchetto in locale
+Per creare un pacchetto firmato direttamente dall'ambiente di sviluppo esegui:
+
+```bash
+chmod +x wp-content/plugins/trello-social-auto-publisher/tools/build-release-package.sh
+wp-content/plugins/trello-social-auto-publisher/tools/build-release-package.sh
+```
+
+Lo script produce:
+- `build/release/trello-social-auto-publisher-<versione>.zip`
+- `build/release/artifacts/checksums.txt`
+- `build/release/artifacts/release-notes.md`
+- `build/release/artifacts/manifest.json`
+
+Il numero di versione viene letto automaticamente dall'header del plugin o, in sua assenza, generato con timestamp.
 
 ### Requisiti
 - WordPress 6.0 o superiore.
@@ -36,11 +55,14 @@ FP Publisher centralizza la gestione dei contenuti provenienti da Trello e da so
 ## Funzionalità principali
 - **Dashboard operativa:** statistiche aggregate, attività recenti e scorciatoie verso le sezioni chiave.
 - **Clienti e credenziali:** gestione multi-cliente con metabox dedicati per secret, token e mappature Trello → canali social.
-- **Client Wizard:** onboarding guidato con verifica webhook, configurazione API e mappatura delle liste.
+- **Client Wizard:** onboarding guidato con checklist dinamica, percentuale di completamento, suggerimenti contestuali, test immediati delle credenziali Trello/social e reset rapido dei progressi.
+- **Pacchetti Quickstart:** preset Trello/social/blog con validazione ambiente (pronto/attenzione/bloccato), anteprima delle sovrascritture, template Trello scaricabili, link ai percorsi guidati e prefill automatico delle impostazioni nel wizard.
+- **Modalità di utilizzo personalizzate:** scegli tra profilo Standard, Avanzato o Enterprise dalle impostazioni per mostrare solo le funzionalità necessarie e abilitare i moduli avanzati quando servono.
 - **Calendario editoriale:** vista mensile con stati di pubblicazione, canale, orario e conteggio dei contenuti.
 - **Gestione post social:** filtri per cliente/stato, approvazioni massime, pubblicazione immediata e dettagli dei log.
 - **Analytics:** aggregazione delle metriche dei canali, grafico interattivo (Chart.js) ed esportazione CSV.
 - **Health Status:** controllo quotidiano di token, hook Trello, Action Scheduler, requisiti WordPress e retention log configurabile.
+- **Sintesi componenti critici:** dashboard e CLI evidenziano token mancanti, webhook in errore, quote API e cron non pianificati con link rapidi alla remediation.
 - **Blog WordPress:** pubblicazione automatica di articoli con gestione featured image, SEO, WPML, link dinamici e hashtag di default per ogni canale.
 
 ## Configurazione dei canali
@@ -90,7 +112,45 @@ Parametri supportati: `post_type`, `post_status`, `author_id`, `category_id`, `l
 ## Performance e monitoraggio
 - Cache multilivello (transient, object cache, browser) e query ottimizzate descritte in [OPTIMIZATION_GUIDE.md](OPTIMIZATION_GUIDE.md).
 - Script `./optimize-assets.sh` per generare asset minificati ready-for-production.
-- Dashboard con metriche in tempo reale, performance monitor e controlli di stato dei servizi esterni.
+- Dashboard con metriche in tempo reale, performance monitor, controllo salute token (mancanti/in scadenza/senza scadenza) e controlli di stato dei servizi esterni.
+
+## Strumenti da riga di comando
+FP Publisher espone comandi [WP-CLI](https://wp-cli.org/) per eseguire diagnosi e validazioni anche su ambienti headless.
+
+### Controllo salute
+```bash
+wp tts health
+```
+- Senza parametri recupera l'ultimo snapshot memorizzato.
+- Aggiungi `--force` per lanciare immediatamente una nuova scansione e ricevere l'elenco aggiornato delle azioni consigliate.
+- L'output include la tabella *Stato componenti critici* con token, webhook, quote e cron da monitorare.
+
+### Pacchetti Quickstart
+```bash
+wp tts quickstart --list
+wp tts quickstart --slug=social_starter
+```
+- `--list` mostra slug, profilo richiesto e descrizione dei preset disponibili.
+- `--slug=<pacchetto>` produce la tabella dei prerequisiti (token, mapping, blog) e riepiloga mapping/template/UTM che verrebbero applicati.
+
+Consulta [docs/guides/cli-automation.md](docs/guides/cli-automation.md) per scenari avanzati e best practice di integrazione nei runbook operativi.
+
+## Qualità e test automatici
+
+Per mantenere il plugin stabile e pronto alla distribuzione è disponibile un test suite automatizzato che copre sicurezza, integrazione Trello, token e REST API. Il repository esegue lo stesso flusso in GitHub Actions ad ogni push o pull request tramite il workflow **Plugin Quality Checks**.
+
+### Esegui i test in locale
+
+1. Assicurati di avere PHP 8.1 o superiore e Composer installati.
+2. Dalla root del progetto avvia:
+
+   ```bash
+   composer test
+   ```
+
+Lo script `tools/run-tests.sh` avvia in sequenza ogni file `tests/test-*.php` e interrompe la procedura se uno dei check fallisce, indicando il file responsabile.
+
+> Suggerimento: integra `composer test` nelle pipeline di CI/CD interne per bloccare merge o deploy quando falliscono le verifiche automatiche.
 
 ## Documentazione di riferimento
 - [MENU_STRUCTURE.md](MENU_STRUCTURE.md): struttura aggiornata del menu WordPress e benefici UX.
@@ -99,6 +159,12 @@ Parametri supportati: `post_type`, `post_status`, `author_id`, `category_id`, `l
 - [SECURITY_IMPROVEMENTS.md](SECURITY_IMPROVEMENTS.md): audit di sicurezza e miglioramenti qualitativi.
 - [SOCIAL_MEDIA_SETUP.md](SOCIAL_MEDIA_SETUP.md): checklist operative per i singoli canali.
 - [ENTERPRISE_FEATURES.md](ENTERPRISE_FEATURES.md): funzionalità avanzate per team e scenari enterprise.
+- Percorsi guidati:
+  - [Onboarding clienti](docs/journeys/client-onboarding.md)
+  - [Setup rapido](docs/guides/quick-start.md)
+  - [Operazioni giornaliere](docs/guides/daily-operations.md)
+  - [Quality Assurance automatizzata](docs/guides/quality-assurance.md)
+  - [Troubleshooting](docs/guides/troubleshooting.md)
 
 ## Storico versioni
 Consulta il [CHANGELOG.md](CHANGELOG.md) per il dettaglio completo delle release. In sintesi:

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "fp-publisher/trello-social-auto-publisher",
+    "description": "Operational tooling and automation for the Trello Social Auto Publisher plugin.",
+    "type": "project",
+    "license": "GPL-2.0-or-later",
+    "require": {},
+    "require-dev": {},
+    "scripts": {
+        "test": "bash tools/run-tests.sh"
+    }
+}

--- a/docs/guides/cli-automation.md
+++ b/docs/guides/cli-automation.md
@@ -1,0 +1,53 @@
+# Percorso guidato · Automazione da riga di comando
+
+Questa guida raccoglie gli scenari operativi per utilizzare i comandi WP-CLI di FP Publisher in modo sicuro e ripetibile. Puoi integrare questi step nei runbook di manutenzione, nei cron server-side o in pipeline CI/CD per validare l'ambiente senza dover accedere alla dashboard WordPress.
+
+## Prerequisiti
+- Accesso SSH al server con WordPress installato.
+- WP-CLI configurato e funzionante (`wp --info`).
+- Utente WordPress con capability `manage_options` per eseguire i comandi.
+
+## Controllare lo stato del sistema
+Esegui il comando `health` per ottenere lo stato aggregato di database, token e API.
+
+```bash
+wp tts health --path=/var/www/html
+```
+
+Output chiave:
+- **Punteggio salute** (0–100) basato sui check principali.
+- Tabella con stato (`ok`, `warning`, `blocked`) e messaggio per ogni componente monitorato.
+- Tabella delle **Azioni consigliate** con link diretti alle pagine WP-Admin da visitare.
+
+> Suggerimento: schedula `wp tts health --force` ogni ora tramite cron per rigenerare lo snapshot e archivia l'output in un log centralizzato.
+
+## Validare un pacchetto Quickstart
+Prima di applicare un preset da interfaccia grafica verifica che tutti i prerequisiti siano soddisfatti:
+
+```bash
+wp tts quickstart --slug=enterprise_control --path=/var/www/html
+```
+
+Il comando restituisce:
+- Profilo richiesto vs profilo attivo, con avviso se non combaciano.
+- Tabella dei prerequisiti (token mancanti, Trello disattivato, mapping non configurato).
+- Elenco delle modifiche che il pacchetto introdurrebbe (mapping Trello, template social, parametri UTM, prefill blog).
+
+Per ottenere l'elenco degli slug disponibili:
+
+```bash
+wp tts quickstart --list
+```
+
+## Integrazione in pipeline CI/CD
+1. Aggiungi uno step al deploy che esegue `wp tts health --force`. Fallisci la pipeline se il punteggio scende sotto una soglia (es. 70) analizzando l'output testuale o parseando la tabella con uno script dedicato.
+2. Inserisci `wp tts quickstart --slug=<preset>` in stage di QA per garantire che l'ambiente di staging sia pronto prima di testare un nuovo onboarding.
+3. Notifica su Slack: pipe l'output dei comandi verso uno script che invia un messaggio al canale on-call quando vengono rilevate azioni consigliate con severità `warning`.
+
+## Best practice
+- Versiona i comandi CLI nei runbook interni così da allineare il team sulle operazioni supportate.
+- Esegui i comandi con il flag `--path` esplicito quando lavori su installazioni con più siti.
+- Se automatizzi tramite cron, redirigi `STDOUT` e `STDERR` verso file diversi per facilitare l'analisi degli errori.
+- Mantieni WP-CLI aggiornato per beneficiare delle ultime patch di sicurezza e compatibilità.
+
+Con questi strumenti puoi monitorare lo stato della piattaforma e convalidare le configurazioni Quickstart senza accedere manualmente al backend, riducendo tempi di intervento e rischio di errore umano.

--- a/docs/guides/daily-operations.md
+++ b/docs/guides/daily-operations.md
@@ -1,0 +1,32 @@
+# Percorso guidato · Operazioni giornaliere
+
+Questa traccia raccoglie le attività ricorrenti per mantenere operativo FP Publisher lungo la settimana. Se devi configurare un nuovo team o cliente parti dal [Percorso onboarding clienti](../journeys/client-onboarding.md) e torna qui per le attività di mantenimento.
+
+## Ogni mattina
+- Apri la **Dashboard**: controlla il widget "Stato rapido di pubblicazione", le nuove segnalazioni sui token social e le **Azioni consigliate**.
+- Usa la sezione **Quick Actions** per accedere rapidamente al calendario o ai log.
+- Verifica il widget **System Status** per assicurarti che i job pianificati siano ancora in stato 🟢.
+
+> Suggerimento: adatta la UI al tuo team passando da **Impostazioni → Modalità di utilizzo**. Il profilo Standard riduce le informazioni visibili, mentre Avanzato ed Enterprise abilitano monitoraggio esteso e strumenti aggiuntivi.
+
+## Pianificazione e produzione
+1. **Calendario** → trascina i contenuti importati da Trello per assegnare data e ora.
+2. **Social Posts** → approva o modifica i messaggi generati dai template.
+3. Per i canali video (YouTube/TikTok) assicurati che i media rispettino i requisiti indicati in [SOCIAL_MEDIA_SETUP.md](../SOCIAL_MEDIA_SETUP.md).
+
+## Monitoraggio
+- Consulta la sezione **System Monitoring** (profilo Avanzato/Enterprise) per verificare performance DB, API e log errori.
+- In modalità Standard, utilizza lo snapshot compatto e il log dei suggerimenti; i messaggi includono ora le remediation automatizzate per token mancanti, in scadenza o senza data di validità.
+- Scarica i report giornalieri da **Analytics** per confrontare engagement e conversioni UTM.
+- Se lavori da terminale esegui `wp tts health --force` per aggiornare lo snapshot prima della riunione mattutina e condividi le azioni consigliate con il team.
+
+## Manutenzione settimanale
+- In **Pacchetti Quickstart** esporta le impostazioni correnti prima di applicare nuove modifiche.
+- Esegui il widget **Connection Testing** per rinnovare token prossimi alla scadenza. La checklist dei token dalla dashboard ti indica i clienti prioritari.
+- Avvia gli strumenti in **Advanced Tools** (Enterprise) per backup, pulizia log e reportistica.
+
+## Escalation
+Se il widget System Status segnala attività non pianificate o errori ricorrenti:
+1. Apri **Log** per identificare i canali coinvolti.
+2. Consulta il percorso [Troubleshooting](troubleshooting.md) per le procedure di remediation.
+3. Escala al team tecnico con il report generato automaticamente in **Advanced Tools → System Report**.

--- a/docs/guides/quality-assurance.md
+++ b/docs/guides/quality-assurance.md
@@ -1,0 +1,45 @@
+# Percorso guidato · Quality Assurance automatizzata
+
+Questo percorso illustra come mantenere alta la qualità del plugin automatizzando i test e integrandoli nei flussi di lavoro quotidiani.
+
+## Obiettivi del percorso
+- Validare rapidamente le funzionalità chiave (token, API Trello, sicurezza, REST) prima di ogni rilascio.
+- Offrire un flusso unificato per team di sviluppo e operations, riducendo errori manuali.
+- Documentare l'integrazione con GitHub Actions e pipeline esterne.
+
+## Prerequisiti
+- PHP 8.1 o superiore disponibile in locale o nell'ambiente CI.
+- [Composer](https://getcomposer.org/) installato.
+- Accesso al repository FP Publisher.
+
+## Eseguire i test in locale
+1. Clona il repository e posizionati nella root del progetto.
+2. Lancia il comando:
+
+   ```bash
+   composer test
+   ```
+
+3. Il runner `tools/run-tests.sh` avvia tutti i file `tests/test-*.php` e interrompe la procedura se uno dei check restituisce exit code diverso da zero.
+4. In caso di fallimento, il terminale mostra quale file ha generato l'errore insieme ai messaggi restituiti dai test.
+
+> Suggerimento: esegui `composer test` prima di aprire una pull request per intercettare regressioni senza attendere la CI.
+
+## Monitorare i test con GitHub Actions
+- Il workflow **Plugin Quality Checks** (`.github/workflows/test-suite.yml`) gira automaticamente su push, pull request e avvi manuali.
+- Lo step `composer validate` assicura che la configurazione Composer sia coerente.
+- Lo step `composer test` replica il comportamento locale, così lo stato della pipeline riflette esattamente ciò che avviene in sviluppo.
+- Puoi ricevere notifiche automatiche (email, Slack, Teams) configurando i notificatori di GitHub Actions.
+
+## Integrazione in pipeline esterne
+1. Aggiungi uno step `composer test` ai tuoi workflow di deploy (GitLab CI, Jenkins, Bitbucket Pipelines) prima della fase di rilascio.
+2. Imposta la pipeline in modo che si interrompa se il comando restituisce exit code diverso da zero.
+3. Salva gli output dei test come artifact o log centralizzato per agevolare auditing e incident response.
+4. Facoltativo: esegui `composer validate --no-check-publish` per assicurarti che i file Composer siano consistenti anche fuori da GitHub.
+
+## Troubleshooting rapido
+- **Errore "Test directory not found"**: assicurati di lanciare il comando dalla root del repository e che il plugin contenga la cartella `wp-content/plugins/trello-social-auto-publisher/tests`.
+- **PHP non trovato**: verifica che `php` sia presente nel `PATH` della macchina o sostituiscilo con il percorso completo all'eseguibile.
+- **Permessi su `tools/run-tests.sh`**: se su sistemi Unix ricevi un errore di permessi, esegui `chmod +x tools/run-tests.sh`.
+
+Seguendo questo percorso mantieni allineati sviluppo, QA e operations, ottenendo feedback immediato sulle regressioni e aumentando la confidenza in ogni rilascio del plugin.

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -1,0 +1,39 @@
+# Percorso guidato · Setup rapido
+
+Questa guida riassume i passaggi indispensabili per portare FP Publisher dallo stato "nuova installazione" alla pubblicazione del primo contenuto.
+
+## 1. Preparazione account e credenziali
+- Attiva gli account richiesti (Trello, Meta, Google, TikTok) e raccogli API key/token.
+- Accedi a **Impostazioni → Connessioni social** per registrare app ID e secret.
+- Verifica i permessi OAuth consigliati (Facebook/Instagram `pages_manage_posts`, YouTube `youtube.upload`, ecc.).
+
+## 2. Scegli un pacchetto Quickstart
+1. Vai in **Clienti → Pacchetti Quickstart**.
+2. Seleziona il profilo più adatto (Starter Social, Editorial Suite, Enterprise Control). Puoi modificare la modalità attiva in **Impostazioni → Modalità di utilizzo** scegliendo tra Standard, Avanzato o Enterprise.
+3. Usa il pulsante **Anteprima modifiche** per confrontare mapping Trello, template e parametri UTM con la configurazione corrente prima di applicare il preset.
+4. Se il pacchetto mette a disposizione risorse aggiuntive, scarica il **template Trello** e apri il **percorso guidato** per seguire passo passo l'onboarding suggerito.
+5. Apri il pannello **Validazione ambiente**: ogni preset esegue controlli automatici su credenziali, webhook e configurazione blog. Gli stati possibili sono:
+   - 🟢 **Pronto**: puoi applicare il pacchetto senza ulteriori azioni.
+   - 🟠 **Attenzione**: alcuni elementi opzionali mancano ma non bloccano l'import.
+   - 🔴 **Bloccato**: risolvi i prerequisiti indicati prima di procedere.
+6. Conferma l'applicazione per precompilare mapping Trello, template copy e parametri UTM.
+
+> Suggerimento: dopo la validazione il pacchetto salva i risultati nella sessione. Il Client Wizard userà queste informazioni per mostrarti solo i passi che richiedono intervento.
+
+## 3. Configura il primo cliente
+1. Apri **Client Wizard**: la checklist ora evidenzia i blocchi critici, mostra percentuale di completamento e suggerisce le azioni da compiere in base alla validazione eseguita.
+2. Inserisci API Trello (se abilitate) e scegli la board da sincronizzare. Usa il pulsante **Verifica credenziali Trello** per testare key/token prima di salvare: il risultato viene mostrato in tempo reale.
+3. Seleziona i canali social, quindi compila le **Impostazioni blog**. Per ogni canale con OAuth completato puoi cliccare **Test token** e ricevere conferma immediata dell'accesso.
+4. Completa la mappatura Trello → canali e conferma il riepilogo. Puoi azzerare il progresso con **Reset checklist** in caso di errori.
+
+## 4. Esegui i controlli iniziali
+- Dalla **Dashboard** verifica lo snapshot "Stato rapido di pubblicazione".
+- Esegui **Test connessioni** per ogni canale con il widget dedicato.
+- Consulta il pannello **System Status** per assicurarti che cron e webhook siano pianificati e controlla la sezione **Token social** per eventuali scadenze imminenti.
+
+## 5. Pubblica il primo contenuto
+1. Apri **Social Posts → Nuovo** per creare un post utilizzando i template preimpostati.
+2. Carica media o allega contenuti Trello già mappati.
+3. Salva, approva e pianifica la pubblicazione.
+
+Con questi passaggi il team dispone di un flusso minimale ma funzionante. Per passare a scenari più complessi consulta il percorso "Operazioni giornaliere".

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,37 @@
+# Percorso guidato · Risoluzione problemi
+
+Utilizza questa checklist quando emergono anomalie su token, webhook o pubblicazioni fallite.
+
+## 1. Identifica il sintomo
+- Widget **System Status**: nota quali componenti risultano ⚠️/🔴 e controlla la sezione **Token social** per le scadenze.
+- La nuova sintesi **Componenti da monitorare** raggruppa token, webhook, quote API e cron mancanti indicando quante integrazioni sono coinvolte e fornendo link rapidi alla pagina corretta.
+- Dashboard → **Azioni consigliate**: annota le remediation suggerite (es. rinnova token in scadenza, completa credenziali mancanti).
+- Log → filtra per canale e data per raccogliere errori recenti.
+- In **Pacchetti Quickstart** usa **Anteprima modifiche** per verificare se un preset ha sovrascritto mapping, template o UTM prima dell'errore.
+
+## 2. Token e autenticazioni
+1. Se il suggerimento indica "Aggiorna i token scaduti" o "Completa i token mancanti":
+   - Apri **Connessioni social** e ripeti l'OAuth per il canale coinvolto.
+   - Dal **Client Wizard** usa il pulsante **Test token** sul canale appena riconnesso per confermare l'accesso senza uscire dal flusso di onboarding.
+   - In modalità Enterprise verifica anche il job pianificato `tts_refresh_tokens` nel riepilogo attività.
+2. Per errori quota API:
+   - Riduci temporaneamente la frequenza in **Publishing Status**.
+   - Coordina con il team per distribuire i post in fasce orarie diverse.
+
+## 3. Webhook e Trello
+- Se il widget mostra errori webhook, apri Trello e rinnova il webhook dalla board collegata. Gli avvisi includono ora la lista e il canale coinvolti.
+- In **Client Wizard** rivedi la mappatura Trello → canali assicurandoti che ogni lista abbia un canale valido.
+- Controlla che il cron `tts_hourly_health_check` sia pianificato (sezione attività pianificate).
+
+## 4. Problemi di scheduler o cron
+- In **System Status** verifica le attività contrassegnate come "Non pianificata".
+- Se necessario, salva nuovamente le impostazioni del plugin per forzare WordPress a rigenerare gli hook.
+- Su hosting gestiti abilita WP-Cron o pianifica un cron esterno che richiami `wp-cron.php` ogni 5 minuti.
+
+## 5. Escalation verso il team tecnico
+- Genera un **System Report** dagli **Advanced Tools** (profilo Enterprise).
+- Allegare il file `.log` scaricato da **Log → Esporta** con il canale interessato.
+- Indica le azioni già tentate (reset token, riattivazione webhook, ripianificazione job).
+- Allegare all'escalation anche l'output di `wp tts health --force` (che ora include la tabella *Stato componenti critici*) o `wp tts quickstart --slug=<preset>` se il problema deriva da un nuovo pacchetto.
+
+> Consiglio: mantieni aggiornato il documento di Runbook interno collegando questa guida ai task di on-call.

--- a/docs/journeys/client-onboarding.md
+++ b/docs/journeys/client-onboarding.md
@@ -1,0 +1,53 @@
+# Percorso onboarding clienti
+
+Questa guida aiuta a trasformare i pacchetti Quickstart in una configurazione completa e pronta all'uso. Ogni percorso combina la board Trello consigliata, la checklist del Client Wizard e le verifiche automatiche di FP Publisher.
+
+## Prima di iniziare
+
+1. Apri **Clienti → Pacchetti Quickstart** e scegli il preset più vicino al tuo modo di lavorare.
+2. Usa il pulsante **Scarica template Trello** per importare la board suggerita su Trello (File → Importa JSON → Modello di board).
+3. Premi **Anteprima modifiche** per verificare mapping, template e UTM che verranno precompilati.
+4. Dopo aver applicato il pacchetto, avvia il **Client Wizard**: ritroverai checklist, hint e sessione precompilata.
+
+> Suggerimento: puoi riaprire il percorso guidato direttamente dalla card del pacchetto o dalla pagina **Documentazione → Percorsi guidati**.
+
+## Starter Social
+
+- **Obiettivo**: avviare un nuovo brand con due canali social e pubblicazione blog semplificata.
+- **Importazione Trello**: il template include le liste *Idee → In approvazione → Pronto → Pubblicato* con etichette Facebook/Instagram.
+- **Wizard step-by-step**:
+  1. Inserisci API key/token Trello, usa **Verifica credenziali Trello** e seleziona la board appena importata.
+  2. Collega Facebook e Instagram dal passo "Canali": le etichette della board aiutano a capire dove finiranno le card. Dopo l'OAuth puoi cliccare **Test token** per verificare immediatamente la connessione.
+  3. Verifica la mappatura proposta (*Idee → draft*, *Pronto → scheduled* ecc.) e conferma la checklist.
+  4. Rivedi i template social generati e completa il riepilogo.
+- **Checklist finale**: assicurati che tutti i canali siano marcati come "connessi"; se mancano token il widget suggerirà i remediation dal monitoraggio.
+
+## Editorial Suite
+
+- **Obiettivo**: coordinare blog, video lunghi e short form per team editoriali.
+- **Importazione Trello**: la board propone colonne *Briefing*, *Produzione*, *Revisione*, *Pronto Social*, *Pubblicato* e un archivio dedicato.
+- **Wizard step-by-step**:
+  1. Nella sezione Trello seleziona la board e aggiungi checklist automatiche per script, grafiche e SEO.
+  2. Autorizza YouTube e TikTok oltre a Facebook/Instagram; usa **Test token** per convalidare le autorizzazioni e annota eventuali avvisi nella checklist.
+  3. Nel passo "Mapping" verifica che la lista *Pronto Social* sia agganciata allo stato **scheduled** per i canali social, mentre il blog resta collegato alle altre liste.
+  4. Incolla le impostazioni blog suggerite (post pending, autore dedicato, categoria editoriale) e controlla l'anteprima prima del salvataggio.
+- **Ottimizzazioni**: attiva il calendario editoriale e usa il pulsante **Apri percorso guidato** per rivedere la sequenza in futuro.
+
+## Enterprise Control
+
+- **Obiettivo**: gestire workflow complessi con audit trail, compliance e più approvatori.
+- **Importazione Trello**: la board aggiunge liste *Intake*, *Quality Assurance*, *Security Check*, *Ready to Launch*, *Live + Audit* con etichette per legal/compliance.
+- **Wizard step-by-step**:
+  1. Configura gli utenti WordPress richiesti dal preset (autore #5 o ruolo dedicato) prima di confermare l'anteprima.
+  2. Collega tutti i canali richiesti: la checklist evidenzia quali integrazioni non hanno token o scadenze registrate e i pulsanti **Test token** aiutano a certificare gli accessi enterprise.
+  3. Nel passo Trello, abbina le liste di audit agli stati **review** e **scheduled** per mantenere il controllo delle approvazioni.
+  4. Completa il riepilogo e registra nel campo note i referenti compliance: verranno riutilizzati nei log e nei report.
+- **Monitoraggio continuativo**: consulta il widget **System Status** per ricevere remediation automatiche e programma report giornalieri dal menu Monitoraggio.
+
+## Collegamenti utili
+
+- [Guida Quickstart](../guides/quick-start.md)
+- [Operatività quotidiana](../guides/daily-operations.md)
+- [Troubleshooting e remediation](../guides/troubleshooting.md)
+
+Per feedback o suggerimenti sui percorsi guidati apri una issue nel repository oppure compila la sezione feedback interna del plugin.

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_DIR="$ROOT_DIR/wp-content/plugins/trello-social-auto-publisher"
+TEST_DIR="$PLUGIN_DIR/tests"
+
+if [[ ! -d "$TEST_DIR" ]]; then
+    echo "Test directory not found: $TEST_DIR" >&2
+    exit 1
+fi
+
+mapfile -t test_files < <(find "$TEST_DIR" -maxdepth 1 -type f -name 'test-*.php' -print | sort)
+
+if [[ ${#test_files[@]} -eq 0 ]]; then
+    echo "No test files detected in $TEST_DIR" >&2
+    exit 1
+fi
+
+exit_code=0
+
+for test_file in "${test_files[@]}"; do
+    relative_path="${test_file#$ROOT_DIR/}"
+    echo "→ Running ${relative_path}"
+
+    if php "$test_file"; then
+        echo "✓ ${relative_path}"
+    else
+        echo "✗ ${relative_path}" >&2
+        exit_code=1
+    fi
+
+    echo ""
+done
+
+exit $exit_code

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -108,6 +108,14 @@ class TTS_Admin {
             'nonce_action' => 'tts_ajax_nonce',
             'capabilities' => array( 'tts_manage_integrations' ),
         ),
+        'ajax_validate_trello_credentials' => array(
+            'nonce_action' => 'tts_wizard',
+            'capabilities' => array( 'tts_manage_clients' ),
+        ),
+        'ajax_test_wizard_token' => array(
+            'nonce_action' => 'tts_wizard',
+            'capabilities' => array( 'tts_manage_clients' ),
+        ),
     );
 
     /**
@@ -257,6 +265,8 @@ class TTS_Admin {
         add_action( 'wp_ajax_tts_show_import_modal', array( $this, 'ajax_show_import_modal' ) );
         add_action( 'wp_ajax_tts_test_client_connections', array( $this, 'ajax_test_client_connections' ) );
         add_action( 'wp_ajax_tts_test_single_connection', array( $this, 'ajax_test_single_connection' ) );
+        add_action( 'wp_ajax_tts_validate_trello_credentials', array( $this, 'ajax_validate_trello_credentials' ) );
+        add_action( 'wp_ajax_tts_test_wizard_token', array( $this, 'ajax_test_wizard_token' ) );
         add_filter( 'manage_tts_social_post_posts_columns', array( $this, 'add_approved_column' ) );
         add_action( 'manage_tts_social_post_posts_custom_column', array( $this, 'render_approved_column' ), 10, 2 );
         add_filter( 'bulk_actions-edit-tts_social_post', array( $this, 'register_bulk_actions' ) );
@@ -394,6 +404,11 @@ class TTS_Admin {
                         'slug'     => 'fp-publisher-client-wizard',
                         'callback' => 'tts_render_client_wizard',
                     ),
+                    array(
+                        'title'    => __( 'Quickstart Packages', 'fp-publisher' ),
+                        'slug'     => 'fp-publisher-quickstart',
+                        'callback' => 'render_quickstart_packages_page',
+                    ),
                 ),
             ),
             array(
@@ -507,6 +522,101 @@ class TTS_Admin {
     }
 
     /**
+     * Return the active usage profile.
+     *
+     * @return string
+     */
+    private function get_usage_profile() {
+        $settings = get_option( 'tts_settings', array() );
+        $profile  = isset( $settings['usage_profile'] ) ? sanitize_key( $settings['usage_profile'] ) : 'standard';
+
+        $allowed = array( 'standard', 'advanced', 'enterprise' );
+        if ( ! in_array( $profile, $allowed, true ) ) {
+            $profile = 'standard';
+        }
+
+        return $profile;
+    }
+
+    /**
+     * Check if the active usage profile grants access to a capability tier.
+     *
+     * @param string $target Target profile tier.
+     * @return bool
+     */
+    private function usage_profile_allows( $target ) {
+        $order = array(
+            'standard'   => 1,
+            'advanced'   => 2,
+            'enterprise' => 3,
+        );
+
+        $current = $this->get_usage_profile();
+
+        if ( ! isset( $order[ $target ] ) || ! isset( $order[ $current ] ) ) {
+            return false;
+        }
+
+        return $order[ $current ] >= $order[ $target ];
+    }
+
+    /**
+     * Public helper to expose the localized label for a usage profile.
+     *
+     * @param string $profile Usage profile slug.
+     * @return string
+     */
+    public function get_usage_profile_label( $profile ) {
+        return $this->format_usage_profile_label( $profile );
+    }
+
+    /**
+     * Return a human readable label for a usage profile slug.
+     *
+     * @param string $profile Usage profile slug.
+     * @return string
+     */
+    private function format_usage_profile_label( $profile ) {
+        $labels = array(
+            'standard'   => __( 'Profilo Standard', 'fp-publisher' ),
+            'advanced'   => __( 'Profilo Avanzato', 'fp-publisher' ),
+            'enterprise' => __( 'Profilo Enterprise', 'fp-publisher' ),
+        );
+
+        $profile = sanitize_key( $profile );
+
+        if ( isset( $labels[ $profile ] ) ) {
+            return $labels[ $profile ];
+        }
+
+        return ucfirst( $profile );
+    }
+
+    /**
+     * Resolve an asset URL within the plugin directory.
+     *
+     * @param string $relative_path Relative path from the plugin root.
+     *
+     * @return string Asset URL or empty string when missing.
+     */
+    private function get_plugin_asset_url( $relative_path ) {
+        $relative_path = ltrim( (string) $relative_path, '/' );
+
+        if ( '' === $relative_path ) {
+            return '';
+        }
+
+        $base_path = trailingslashit( TSAP_PLUGIN_DIR );
+        $absolute  = $base_path . $relative_path;
+
+        if ( ! file_exists( $absolute ) ) {
+            return '';
+        }
+
+        return plugins_url( $relative_path, TSAP_PLUGIN_DIR . 'trello-social-auto-publisher.php' );
+    }
+
+    /**
      * Determine if a menu callback can be registered.
      *
      * @param string $method            Callback method name.
@@ -547,6 +657,235 @@ class TTS_Admin {
             'menu_title' => $menu_title,
             'method'     => $method,
         );
+    }
+
+
+    /**
+     * Evaluate environment readiness for a quickstart package.
+     *
+     * @param array<string, mixed> $package Quickstart definition.
+     * @return array<string, mixed>
+     */
+    private function assess_quickstart_package_readiness( array $package ) {
+        $status = 'ready';
+        $checks = array();
+
+        if ( ! empty( $package['column_mapping'] ) ) {
+            $trello_enabled = (bool) get_option( 'tts_trello_enabled', 1 );
+
+            if ( $trello_enabled ) {
+                $checks[] = array(
+                    'status'  => 'ok',
+                    'label'   => __( 'Trello abilitato', 'fp-publisher' ),
+                    'message' => __( 'La sincronizzazione Trello è pronta per ricevere le nuove mappature.', 'fp-publisher' ),
+                    'scope'   => 'trello',
+                );
+            } else {
+                $status   = 'blocked';
+                $checks[] = array(
+                    'status'  => 'blocked',
+                    'label'   => __( 'Abilita Trello', 'fp-publisher' ),
+                    'message' => __( 'Riattiva Trello nelle impostazioni generali prima di usare questo preset.', 'fp-publisher' ),
+                    'scope'   => 'trello',
+                );
+            }
+        }
+
+        $channels         = isset( $package['channels'] ) ? (array) $package['channels'] : array();
+        $channel_messages = array();
+
+        foreach ( $channels as $channel ) {
+            $channel       = sanitize_key( $channel );
+            $channel_label = ucfirst( $channel );
+            $connection    = $this->check_platform_connection_status( $channel );
+            $message       = isset( $connection['message'] ) ? $connection['message'] : '';
+
+            switch ( isset( $connection['status'] ) ? $connection['status'] : '' ) {
+                case 'not-configured':
+                    $status             = 'blocked';
+                    $channel_messages[] = array(
+                        'status'  => 'blocked',
+                        'label'   => sprintf( __( '%s: credenziali mancanti', 'fp-publisher' ), $channel_label ),
+                        'message' => $message ? $message : __( "Configura l'app dal pannello Connessioni social.", 'fp-publisher' ),
+                        'scope'   => 'channels',
+                        'channel' => $channel,
+                    );
+                    break;
+                case 'configured':
+                    if ( 'blocked' !== $status ) {
+                        $status = 'warning';
+                    }
+                    $channel_messages[] = array(
+                        'status'  => 'warning',
+                        'label'   => sprintf( __( "%s: collega l'account", 'fp-publisher' ), $channel_label ),
+                        'message' => $message ? $message : __( 'Apri il Client Wizard per completare la connessione OAuth.', 'fp-publisher' ),
+                        'scope'   => 'channels',
+                        'channel' => $channel,
+                    );
+                    break;
+                default:
+                    $checks[] = array(
+                        'status'  => 'ok',
+                        'label'   => sprintf( __( '%s: integrazione pronta', 'fp-publisher' ), $channel_label ),
+                        'message' => $message,
+                        'scope'   => 'channels',
+                        'channel' => $channel,
+                    );
+                    break;
+            }
+        }
+
+        if ( ! empty( $channel_messages ) ) {
+            $checks = array_merge( $checks, $channel_messages );
+        }
+
+        $blog_settings = isset( $package['blog_settings'] ) ? (string) $package['blog_settings'] : '';
+        if ( '' !== $blog_settings ) {
+            $blog_config   = $this->parse_quickstart_blog_settings( $blog_settings );
+            $blog_messages = array();
+
+            if ( isset( $blog_config['post_type'] ) && ! post_type_exists( $blog_config['post_type'] ) ) {
+                $status         = 'blocked';
+                $blog_messages[] = array(
+                    'status'  => 'blocked',
+                    'label'   => __( 'Post type inesistente', 'fp-publisher' ),
+                    'message' => sprintf( __( 'Il post type "%s" non è registrato in questo sito.', 'fp-publisher' ), $blog_config['post_type'] ),
+                    'scope'   => 'blog',
+                );
+            }
+
+            if ( isset( $blog_config['author_id'] ) ) {
+                $author_id = absint( $blog_config['author_id'] );
+                if ( $author_id && ! get_user_by( 'ID', $author_id ) ) {
+                    if ( 'blocked' !== $status ) {
+                        $status = 'warning';
+                    }
+                    $blog_messages[] = array(
+                        'status'  => 'warning',
+                        'label'   => __( 'Autore non trovato', 'fp-publisher' ),
+                        'message' => sprintf( __( "Crea o aggiorna l'utente #%d per assegnare i post.", 'fp-publisher' ), $author_id ),
+                        'scope'   => 'blog',
+                    );
+                }
+            }
+
+            if ( isset( $blog_config['category_id'] ) ) {
+                $category_id = absint( $blog_config['category_id'] );
+                if ( $category_id && ! get_term( $category_id, 'category' ) ) {
+                    if ( 'blocked' !== $status ) {
+                        $status = 'warning';
+                    }
+                    $blog_messages[] = array(
+                        'status'  => 'warning',
+                        'label'   => __( 'Categoria assente', 'fp-publisher' ),
+                        'message' => sprintf( __( 'La categoria #%d non è disponibile in questo WordPress.', 'fp-publisher' ), $category_id ),
+                        'scope'   => 'blog',
+                    );
+                }
+            }
+
+            if ( empty( $blog_messages ) ) {
+                $checks[] = array(
+                    'status'  => 'ok',
+                    'label'   => __( 'Preset blog valido', 'fp-publisher' ),
+                    'message' => __( 'Autore e tassonomie corrispondono a risorse disponibili.', 'fp-publisher' ),
+                    'scope'   => 'blog',
+                );
+            } else {
+                $checks = array_merge( $checks, $blog_messages );
+            }
+        } else {
+            if ( 'blocked' !== $status ) {
+                $status = 'warning';
+            }
+            $checks[] = array(
+                'status'  => 'warning',
+                'label'   => __( 'Compila le impostazioni blog', 'fp-publisher' ),
+                'message' => __( 'Il pacchetto non fornisce parametri blog: completali dal Client Wizard.', 'fp-publisher' ),
+                'scope'   => 'blog',
+            );
+        }
+
+        $checks = array_map( array( $this, 'sanitize_quickstart_check_entry' ), $checks );
+
+        if ( 'ready' === $status ) {
+            $summary = __( 'Tutti i prerequisiti risultano soddisfatti: puoi applicare il pacchetto in sicurezza.', 'fp-publisher' );
+        } elseif ( 'warning' === $status ) {
+            $summary = __( "Alcuni elementi richiedono attenzione ma non impediscono l'applicazione del preset.", 'fp-publisher' );
+        } else {
+            $summary = __( "Risolvi i requisiti bloccanti prima di procedere con l'applicazione.", 'fp-publisher' );
+        }
+
+        return array(
+            'status'  => $status,
+            'label'   => __( 'Validazione ambiente', 'fp-publisher' ),
+            'summary' => $summary,
+            'checks'  => $checks,
+        );
+    }
+
+    /**
+     * Sanitize quickstart checklist entries.
+     *
+     * @param array<string, mixed> $entry Raw entry.
+     * @return array<string, mixed>
+     */
+    private function sanitize_quickstart_check_entry( $entry ) {
+        $allowed_status = array( 'ok', 'warning', 'blocked', 'skipped' );
+
+        $status = isset( $entry['status'] ) ? sanitize_key( $entry['status'] ) : 'ok';
+        if ( ! in_array( $status, $allowed_status, true ) ) {
+            $status = 'ok';
+        }
+
+        $sanitized = array(
+            'status'  => $status,
+            'label'   => isset( $entry['label'] ) ? wp_strip_all_tags( $entry['label'], true ) : '',
+            'message' => isset( $entry['message'] ) ? wp_strip_all_tags( $entry['message'], true ) : '',
+        );
+
+        if ( isset( $entry['scope'] ) ) {
+            $sanitized['scope'] = sanitize_key( $entry['scope'] );
+        }
+
+        if ( isset( $entry['channel'] ) ) {
+            $sanitized['channel'] = sanitize_key( $entry['channel'] );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Parse the blog settings string into an associative array.
+     *
+     * @param string $settings Blog settings string.
+     * @return array<string, string>
+     */
+    private function parse_quickstart_blog_settings( $settings ) {
+        $result = array();
+
+        foreach ( explode( '|', $settings ) as $chunk ) {
+            $chunk = trim( $chunk );
+            if ( '' === $chunk ) {
+                continue;
+            }
+
+            $parts = explode( ':', $chunk, 2 );
+            if ( count( $parts ) < 2 ) {
+                continue;
+            }
+
+            $key   = sanitize_key( trim( $parts[0] ) );
+            $value = trim( $parts[1] );
+
+            if ( '' === $key || '' === $value ) {
+                continue;
+            }
+
+            $result[ $key ] = $value;
+        }
+
+        return $result;
     }
 
     /**
@@ -594,6 +933,7 @@ class TTS_Admin {
             'fp-publisher_page_fp-publisher-test-connections',
             'fp-publisher-clienti_page_fp-publisher-clienti',
             'fp-publisher-clienti_page_fp-publisher-client-wizard',
+            'fp-publisher-clienti_page_fp-publisher-quickstart',
             'fp-publisher-clienti_page_fp-publisher-social-posts'
         );
 
@@ -1371,18 +1711,29 @@ class TTS_Admin {
     public function render_dashboard_page() {
         echo '<div class="wrap">';
         echo '<h1>' . esc_html__( 'Social Auto Publisher Dashboard', 'fp-publisher' ) . '</h1>';
-        
+
+        $profile = $this->get_usage_profile();
+        if ( 'standard' === $profile ) {
+            echo '<div class="notice notice-info"><p>' . esc_html__( 'Modalità Standard attiva: mostriamo solo i widget essenziali per monitorare le pubblicazioni.', 'fp-publisher' ) . '</p></div>';
+        } elseif ( 'enterprise' === $profile ) {
+            echo '<div class="notice notice-info"><p>' . esc_html__( 'Modalità Enterprise: controlli avanzati, audit e strumenti di remediation sono abilitati.', 'fp-publisher' ) . '</p></div>';
+        }
+
         // Add notification area
         echo '<div id="tts-notification-area" style="margin: 15px 0;"></div>';
-        
+
         // Health status banner (if there are issues)
         $this->render_health_status_banner();
         
         // Quick stats cards
         $this->render_dashboard_stats();
-        
+
         // Enhanced monitoring section
-        $this->render_monitoring_dashboard();
+        if ( $this->usage_profile_allows( 'advanced' ) ) {
+            $this->render_monitoring_dashboard();
+        } else {
+            $this->render_standard_health_snapshot( $profile );
+        }
         
         // Recent activity and actions
         echo '<div class="tts-dashboard-sections">';
@@ -1391,14 +1742,16 @@ class TTS_Admin {
         echo '</div>';
         
         echo '<div class="tts-dashboard-right">';
-        $this->render_quick_actions_section();
+        $this->render_quick_actions_section( $profile );
         $this->render_connection_test_widget();
-        $this->render_system_status_widget();
+        $this->render_system_status_widget( $profile );
         echo '</div>';
         echo '</div>';
-        
+
         // Advanced tools section
-        $this->render_advanced_tools_section();
+        if ( $this->usage_profile_allows( 'enterprise' ) ) {
+            $this->render_advanced_tools_section();
+        }
         
         // React component container for advanced features
         echo '<div id="tts-dashboard-root"></div>';
@@ -1455,6 +1808,59 @@ class TTS_Admin {
         echo '</div>';
         echo '</div>';
     }
+
+    /**
+     * Render condensed health overview for standard profile.
+     *
+     * @param string $profile Active usage profile.
+     */
+    private function render_standard_health_snapshot( $profile ) {
+        $health            = TTS_Monitoring::get_current_health_status();
+        $health_data       = get_option( 'tts_last_health_check', array() );
+        $suggestions       = TTS_Monitoring::get_remediation_suggestions( $health_data );
+        $actionable_items  = TTS_Monitoring::get_actionable_health_summary();
+        $open_issues       = array_filter(
+            $actionable_items,
+            static function ( $item ) {
+                return isset( $item['status'] ) && 'ok' !== $item['status'];
+            }
+        );
+
+        echo '<div class="tts-standard-health">';
+        echo '<h2>' . esc_html__( 'Stato rapido di pubblicazione', 'fp-publisher' ) . '</h2>';
+        echo '<p class="tts-health-score">' . esc_html__( 'Salute sistema', 'fp-publisher' ) . ': <strong>' . esc_html( ucfirst( $health['status'] ) ) . '</strong> (' . intval( $health['score'] ) . '/100)</p>';
+        if ( ! empty( $health['message'] ) ) {
+            echo '<p>' . esc_html( $health['message'] ) . '</p>';
+        }
+
+        if ( ! empty( $open_issues ) ) {
+            $this->render_actionable_health_summary( $open_issues, true );
+        }
+
+        if ( ! empty( $suggestions ) ) {
+            echo '<div class="tts-health-suggestions">';
+            echo '<strong>' . esc_html__( 'Azioni consigliate', 'fp-publisher' ) . '</strong>';
+            echo '<ul>';
+            foreach ( $suggestions as $suggestion ) {
+                echo '<li>' . esc_html( $suggestion['title'] ) . ' — ' . esc_html( $suggestion['description'] );
+                if ( ! empty( $suggestion['link'] ) ) {
+                    echo ' <a href="' . esc_url( $suggestion['link'] ) . '" class="button-link">' . esc_html__( 'Apri', 'fp-publisher' ) . '</a>';
+                }
+                echo '</li>';
+            }
+            echo '</ul>';
+            echo '</div>';
+        } else {
+            echo '<p>' . esc_html__( 'Nessuna azione pendente: sei pronto a pubblicare.', 'fp-publisher' ) . '</p>';
+        }
+
+        if ( 'standard' === $profile ) {
+            echo '<p class="description">' . esc_html__( 'Passa al profilo Avanzato per sbloccare monitoraggio in tempo reale e controlli granulari.', 'fp-publisher' ) . '</p>';
+        }
+
+        echo '</div>';
+    }
+
 
     /**
      * Render health score widget.
@@ -2006,154 +2412,314 @@ class TTS_Admin {
 
     /**
      * Render quick actions section.
+     *
+     * @param string $profile Active usage profile.
      */
-    private function render_quick_actions_section() {
+    private function render_quick_actions_section( $profile = 'standard' ) {
         echo '<div class="tts-dashboard-section">';
-        echo '<h2>' . esc_html__('Quick Actions', 'fp-publisher') . '</h2>';
+        echo '<h2>' . esc_html__( 'Quick Actions', 'fp-publisher' ) . '</h2>';
         echo '<div class="tts-quick-actions">';
-        
+
         $actions = array(
             array(
-                'title' => __('Add New Client', 'fp-publisher'),
-                'description' => __('Set up a new social media client', 'fp-publisher'),
-                'url' => admin_url('admin.php?page=fp-publisher-client-wizard'),
-                'icon' => 'dashicons-plus',
-                'color' => '#135e96'
+                'title'       => __( 'Add New Client', 'fp-publisher' ),
+                'description' => __( 'Set up a new social media client', 'fp-publisher' ),
+                'url'         => admin_url( 'admin.php?page=fp-publisher-client-wizard' ),
+                'icon'        => 'dashicons-plus',
+                'color'       => '#135e96',
+                'profiles'    => array( 'standard', 'advanced', 'enterprise' ),
             ),
             array(
-                'title' => __('View Calendar', 'fp-publisher'),
-                'description' => __('See scheduled posts in calendar view', 'fp-publisher'),
-                'url' => admin_url('admin.php?page=fp-publisher-calendar'),
-                'icon' => 'dashicons-calendar',
-                'color' => '#f56e28'
+                'title'       => __( 'View Calendar', 'fp-publisher' ),
+                'description' => __( 'See scheduled posts in calendar view', 'fp-publisher' ),
+                'url'         => admin_url( 'admin.php?page=fp-publisher-calendar' ),
+                'icon'        => 'dashicons-calendar',
+                'color'       => '#f56e28',
+                'profiles'    => array( 'standard', 'advanced', 'enterprise' ),
             ),
             array(
-                'title' => __('Check Health Status', 'fp-publisher'),
-                'description' => __('Monitor system health and tokens', 'fp-publisher'),
-                'url' => admin_url('admin.php?page=fp-publisher-health'),
-                'icon' => 'dashicons-heart',
-                'color' => '#00a32a'
+                'title'       => __( 'Check Health Status', 'fp-publisher' ),
+                'description' => __( 'Monitor system health and tokens', 'fp-publisher' ),
+                'url'         => admin_url( 'admin.php?page=fp-publisher-health' ),
+                'icon'        => 'dashicons-heart',
+                'color'       => '#00a32a',
+                'profiles'    => array( 'standard', 'advanced', 'enterprise' ),
             ),
             array(
-                'title' => __('View Analytics', 'fp-publisher'),
-                'description' => __('Analyze performance and engagement', 'fp-publisher'),
-                'url' => admin_url('admin.php?page=fp-publisher-analytics'),
-                'icon' => 'dashicons-chart-area',
-                'color' => '#7c3aed'
+                'title'       => __( 'Quickstart Packages', 'fp-publisher' ),
+                'description' => __( 'Import preset templates and mappings', 'fp-publisher' ),
+                'url'         => admin_url( 'admin.php?page=fp-publisher-quickstart' ),
+                'icon'        => 'dashicons-portfolio',
+                'color'       => '#6366f1',
+                'profiles'    => array( 'standard', 'advanced', 'enterprise' ),
             ),
             array(
-                'title' => __('Manage Posts', 'fp-publisher'),
-                'description' => __('View and manage all social posts', 'fp-publisher'),
-                'url' => admin_url('admin.php?page=fp-publisher-social-posts'),
-                'icon' => 'dashicons-admin-post',
-                'color' => '#2563eb'
+                'title'       => __( 'View Analytics', 'fp-publisher' ),
+                'description' => __( 'Analyze performance and engagement', 'fp-publisher' ),
+                'url'         => admin_url( 'admin.php?page=fp-publisher-analytics' ),
+                'icon'        => 'dashicons-chart-area',
+                'color'       => '#7c3aed',
+                'profiles'    => array( 'advanced', 'enterprise' ),
             ),
             array(
-                'title' => __('View Logs', 'fp-publisher'),
-                'description' => __('Check system logs and debugging info', 'fp-publisher'),
-                'url' => admin_url('admin.php?page=fp-publisher-log'),
-                'icon' => 'dashicons-list-view',
-                'color' => '#64748b'
-            )
+                'title'       => __( 'Manage Posts', 'fp-publisher' ),
+                'description' => __( 'View and manage all social posts', 'fp-publisher' ),
+                'url'         => admin_url( 'admin.php?page=fp-publisher-social-posts' ),
+                'icon'        => 'dashicons-admin-post',
+                'color'       => '#2563eb',
+                'profiles'    => array( 'advanced', 'enterprise' ),
+            ),
+            array(
+                'title'       => __( 'Audit & Logs', 'fp-publisher' ),
+                'description' => __( 'Controlla log, audit trail e backup', 'fp-publisher' ),
+                'url'         => admin_url( 'admin.php?page=fp-publisher-log' ),
+                'icon'        => 'dashicons-shield-alt',
+                'color'       => '#0f172a',
+                'profiles'    => array( 'enterprise' ),
+            ),
         );
-        
-        foreach ($actions as $action) {
-            echo '<a href="' . esc_url($action['url']) . '" class="tts-quick-action tts-tooltip" style="border-left: 4px solid ' . $action['color'] . ';">';
+
+        $visible_actions = array_filter(
+            $actions,
+            function ( $action ) use ( $profile ) {
+                if ( empty( $action['profiles'] ) ) {
+                    return true;
+                }
+                return in_array( $profile, $action['profiles'], true );
+            }
+        );
+
+        foreach ( $visible_actions as $action ) {
+            echo '<a href="' . esc_url( $action['url'] ) . '" class="tts-quick-action tts-tooltip" style="border-left: 4px solid ' . esc_attr( $action['color'] ) . ';">';
             echo '<div style="display: flex; align-items: center;">';
-            echo '<span class="dashicons ' . esc_attr($action['icon']) . '" style="color: ' . $action['color'] . '; margin-right: 12px; font-size: 20px;"></span>';
+            echo '<span class="dashicons ' . esc_attr( $action['icon'] ) . '" style="color: ' . esc_attr( $action['color'] ) . '; margin-right: 12px; font-size: 20px;"></span>';
             echo '<div>';
-            echo '<div style="font-weight: 600; margin-bottom: 2px;">' . esc_html($action['title']) . '</div>';
-            echo '<div style="font-size: 12px; color: #666;">' . esc_html($action['description']) . '</div>';
+            echo '<div style="font-weight: 600; margin-bottom: 2px;">' . esc_html( $action['title'] ) . '</div>';
+            echo '<div style="font-size: 12px; color: #666;">' . esc_html( $action['description'] ) . '</div>';
             echo '</div>';
             echo '</div>';
-            echo '<span class="tts-tooltiptext">' . esc_html($action['description']) . '</span>';
+            echo '<span class="tts-tooltiptext">' . esc_html( $action['description'] ) . '</span>';
             echo '</a>';
         }
-        
+
         echo '</div>';
         echo '</div>';
     }
 
+
     /**
-     * Render system status widget for dashboard.
+     * Render actionable health summary items.
+     *
+     * @param array<int, array<string, mixed>> $items   Summary items from monitoring.
+     * @param bool                              $compact Whether to render a compact layout.
      */
-    private function render_system_status_widget() {
-        echo '<div class="tts-dashboard-section">';
-        echo '<h2>' . esc_html__('System Status', 'fp-publisher') . '</h2>';
-        
-        // Check various system components
-        $status_checks = array();
-        
-        // Check WordPress requirements
-        $wp_version = get_bloginfo('version');
-        $status_checks['wordpress'] = array(
-            'name' => 'WordPress Version',
-            'status' => version_compare($wp_version, '5.0', '>=') ? 'success' : 'error',
-            'message' => 'WordPress ' . $wp_version
-        );
-        
-        // Check if Action Scheduler is available
-        $status_checks['scheduler'] = array(
-            'name' => 'Action Scheduler',
-            'status' => class_exists('ActionScheduler') ? 'success' : 'warning',
-            'message' => class_exists('ActionScheduler') ? 'Available' : 'Not available'
-        );
-        
-        // Check recent error logs
-        $recent_errors = get_posts(array(
-            'post_type' => 'tts_log',
-            'posts_per_page' => 1,
-            'meta_query' => array(
-                array(
-                    'key' => '_log_level',
-                    'value' => 'error',
-                    'compare' => '='
-                )
-            ),
-            'date_query' => array(
-                array(
-                    'after' => '24 hours ago'
-                )
-            )
-        ));
-        
-        $status_checks['errors'] = array(
-            'name' => 'Recent Errors',
-            'status' => empty($recent_errors) ? 'success' : 'warning',
-            'message' => empty($recent_errors) ? 'No errors in 24h' : count($recent_errors) . ' error(s) in 24h'
-        );
-        
-        // Overall health calculation
-        $success_count = 0;
-        foreach ($status_checks as $check) {
-            if ($check['status'] === 'success') $success_count++;
+    private function render_actionable_health_summary( array $items, $compact = false ) {
+        if ( empty( $items ) ) {
+            return;
         }
-        $health_percentage = round(($success_count / count($status_checks)) * 100);
-        
-        // Health indicator
-        echo '<div style="text-align: center; margin-bottom: 15px;">';
-        $health_color = $health_percentage >= 80 ? '#00a32a' : ($health_percentage >= 60 ? '#f56e28' : '#d63638');
-        echo '<div style="font-size: 24px; color: ' . $health_color . '; font-weight: bold;">';
-        echo $health_percentage . '% ' . esc_html__('Healthy', 'fp-publisher');
-        echo '</div>';
-        echo '</div>';
-        
-        // Status items
-        foreach ($status_checks as $key => $check) {
-            $icon_color = $check['status'] === 'success' ? '#00a32a' : ($check['status'] === 'warning' ? '#f56e28' : '#d63638');
-            echo '<div style="display: flex; align-items: center; margin-bottom: 8px;">';
-            echo '<span class="tts-status-indicator ' . $check['status'] . '" style="background: ' . $icon_color . ';"></span>';
-            echo '<span style="flex: 1;">' . esc_html($check['name']) . '</span>';
-            echo '<span style="color: #666; font-size: 12px;">' . esc_html($check['message']) . '</span>';
+
+        $status_icons = array(
+            'critical' => '🚨',
+            'warning'  => '⚠️',
+            'ok'       => '✅',
+        );
+
+        $status_classes = array(
+            'critical' => 'tts-status-critical',
+            'warning'  => 'tts-status-warning',
+            'ok'       => 'tts-status-ok',
+        );
+
+        $wrapper_classes = array( 'tts-actionable-summary' );
+        if ( $compact ) {
+            $wrapper_classes[] = 'tts-actionable-summary--compact';
+        }
+
+        echo '<div class="' . esc_attr( implode( ' ', $wrapper_classes ) ) . '">';
+
+        if ( ! $compact ) {
+            echo '<h4>' . esc_html__( 'Componenti da monitorare', 'fp-publisher' ) . '</h4>';
+        }
+
+        echo '<ul class="tts-actionable-list">';
+        foreach ( $items as $item ) {
+            $status = isset( $item['status'] ) ? $item['status'] : 'ok';
+            $icon   = isset( $status_icons[ $status ] ) ? $status_icons[ $status ] : 'ℹ️';
+            $class  = isset( $status_classes[ $status ] ) ? $status_classes[ $status ] : 'tts-status-ok';
+
+            echo '<li class="' . esc_attr( 'tts-actionable-item ' . $class ) . '">';
+            echo '<div class="tts-actionable-item-header">';
+            echo '<span class="tts-actionable-icon">' . esc_html( $icon ) . '</span>';
+
+            if ( isset( $item['count'] ) && (int) $item['count'] > 0 ) {
+                echo '<span class="tts-actionable-count">' . intval( $item['count'] ) . '</span>';
+            }
+
+            echo '<div class="tts-actionable-copy">';
+            echo '<strong>' . esc_html( isset( $item['label'] ) ? $item['label'] : __( 'Componente', 'fp-publisher' ) ) . '</strong>';
+
+            if ( ! empty( $item['description'] ) ) {
+                echo '<p>' . esc_html( $item['description'] ) . '</p>';
+            }
+
             echo '</div>';
+            echo '</div>';
+
+            if ( ! empty( $item['actions'] ) && is_array( $item['actions'] ) ) {
+                echo '<ul class="tts-actionable-actions">';
+                foreach ( $item['actions'] as $action ) {
+                    if ( empty( $action ) || ! is_array( $action ) ) {
+                        continue;
+                    }
+
+                    echo '<li>' . esc_html( isset( $action['description'] ) ? $action['description'] : '' );
+
+                    if ( ! empty( $action['url'] ) ) {
+                        echo ' <a class="button-link" href="' . esc_url( $action['url'] ) . '">' . esc_html__( 'Dettagli', 'fp-publisher' ) . '</a>';
+                    }
+
+                    echo '</li>';
+                }
+                echo '</ul>';
+            }
+
+            echo '</li>';
         }
-        
-        echo '<div style="margin-top: 15px;">';
-        echo '<a href="' . admin_url('admin.php?page=fp-publisher-health') . '" class="tts-btn small">View Detailed Status</a>';
-        echo '</div>';
-        
+        echo '</ul>';
         echo '</div>';
     }
+
+
+    /**
+     * Render system status widget for dashboard.
+     *
+     * @param string $profile Active usage profile.
+     */
+    private function render_system_status_widget( $profile = 'standard' ) {
+        echo '<div class="tts-dashboard-section">';
+        echo '<h2>' . esc_html__( 'System Status', 'fp-publisher' ) . '</h2>';
+
+        // Check various system components
+        $status_checks = array();
+        $health_data   = get_option( 'tts_last_health_check', array() );
+
+        // Check WordPress requirements
+        $wp_version = get_bloginfo( 'version' );
+        $status_checks['wordpress'] = array(
+            'name'    => 'WordPress Version',
+            'status'  => version_compare( $wp_version, '5.0', '>=' ) ? 'success' : 'error',
+            'message' => 'WordPress ' . $wp_version,
+        );
+
+        // Check if Action Scheduler is available
+        $status_checks['scheduler'] = array(
+            'name'    => 'Action Scheduler',
+            'status'  => class_exists( 'ActionScheduler' ) ? 'success' : 'warning',
+            'message' => class_exists( 'ActionScheduler' ) ? 'Available' : 'Not available',
+        );
+
+        // Check recent error logs
+        $recent_errors = get_posts( array(
+            'post_type'      => 'tts_log',
+            'posts_per_page' => 1,
+            'meta_query'     => array(
+                array(
+                    'key'   => '_log_level',
+                    'value' => 'error',
+                    'compare' => '=',
+                ),
+            ),
+            'date_query'     => array(
+                array(
+                    'after' => '24 hours ago',
+                ),
+            ),
+        ) );
+
+        $status_checks['errors'] = array(
+            'name'    => 'Recent Errors',
+            'status'  => empty( $recent_errors ) ? 'success' : 'warning',
+            'message' => empty( $recent_errors ) ? 'No errors in 24h' : count( $recent_errors ) . ' error(s) in 24h',
+        );
+
+        // Overall health calculation
+        $success_count = 0;
+        foreach ( $status_checks as $check ) {
+            if ( 'success' === $check['status'] ) {
+                $success_count++;
+            }
+        }
+        $health_percentage = round( ( $success_count / count( $status_checks ) ) * 100 );
+
+        // Health indicator
+        echo '<div style="text-align: center; margin-bottom: 15px;">';
+        $health_color = $health_percentage >= 80 ? '#00a32a' : ( $health_percentage >= 60 ? '#f56e28' : '#d63638' );
+        echo '<div style="font-size: 24px; color: ' . $health_color . '; font-weight: bold;">';
+        echo $health_percentage . '% ' . esc_html__( 'Healthy', 'fp-publisher' );
+        echo '</div>';
+        echo '</div>';
+
+        // Status items
+        foreach ( $status_checks as $key => $check ) {
+            $icon_color = 'success' === $check['status'] ? '#00a32a' : ( 'warning' === $check['status'] ? '#f56e28' : '#d63638' );
+            echo '<div style="display: flex; align-items: center; margin-bottom: 8px;">';
+            echo '<span class="tts-status-indicator ' . esc_attr( $check['status'] ) . '" style="background: ' . esc_attr( $icon_color ) . ';"></span>';
+            echo '<span style="flex: 1;">' . esc_html( $check['name'] ) . '</span>';
+            echo '<span style="color: #666; font-size: 12px;">' . esc_html( $check['message'] ) . '</span>';
+            echo '</div>';
+        }
+
+        $actionable_summary = TTS_Monitoring::get_actionable_health_summary();
+        if ( ! empty( $actionable_summary ) ) {
+            $this->render_actionable_health_summary( $actionable_summary );
+        }
+
+        // Scheduled tasks summary
+        $tasks = TTS_Monitoring::get_scheduled_task_summary();
+        if ( ! empty( $tasks ) ) {
+            echo '<div class="tts-scheduled-tasks">';
+            echo '<h4>' . esc_html__( 'Attività pianificate', 'fp-publisher' ) . '</h4>';
+            echo '<ul>';
+            foreach ( $tasks as $task ) {
+                $status    = 'scheduled' === $task['status'] ? '🟢' : '⚠️';
+                $next_run  = $task['next_run'];
+                $next_text = __( 'Non pianificata', 'fp-publisher' );
+
+                if ( $next_run ) {
+                    $next_text = human_time_diff( $next_run, time() );
+                }
+
+                echo '<li>' . esc_html( $status . ' ' . $task['label'] . ' · ' . $task['frequency'] . ' — ' . $next_text ) . '</li>';
+            }
+            echo '</ul>';
+            echo '</div>';
+        }
+
+        if ( $this->usage_profile_allows( 'advanced' ) ) {
+            $suggestions = TTS_Monitoring::get_remediation_suggestions( $health_data );
+            if ( ! empty( $suggestions ) ) {
+                echo '<div class="tts-remediation-hints">';
+                echo '<h4>' . esc_html__( 'Prossime azioni consigliate', 'fp-publisher' ) . '</h4>';
+                echo '<ul>';
+                foreach ( $suggestions as $suggestion ) {
+                    echo '<li>' . esc_html( $suggestion['title'] ) . ' — ' . esc_html( $suggestion['description'] );
+                    if ( ! empty( $suggestion['link'] ) ) {
+                        echo ' <a href="' . esc_url( $suggestion['link'] ) . '" class="button-link">' . esc_html__( 'Dettagli', 'fp-publisher' ) . '</a>';
+                    }
+                    echo '</li>';
+                }
+                echo '</ul>';
+                echo '</div>';
+            }
+        }
+
+        echo '<div style="margin-top: 15px;">';
+        echo '<a href="' . admin_url( 'admin.php?page=fp-publisher-health' ) . '" class="tts-btn small">' . esc_html__( 'View Detailed Status', 'fp-publisher' ) . '</a>';
+        echo '</div>';
+
+        echo '</div>';
+    }
+
 
     /**
      * Render the clients list page.
@@ -2247,7 +2813,1234 @@ class TTS_Admin {
     }
 
     /**
-     * Render the client creation wizard.
+     * Render the quickstart packages page.
+     */
+    public function render_quickstart_packages_page() {
+        if ( ! session_id() ) {
+            session_start();
+        }
+
+        $packages        = $this->get_quickstart_packages();
+        $active_prefill  = isset( $_SESSION['tts_quickstart_prefill'] ) ? $_SESSION['tts_quickstart_prefill'] : array();
+        $current_settings = get_option( 'tts_settings', array() );
+        $previewed_slug   = isset( $_GET['package_preview'] ) ? sanitize_key( wp_unslash( $_GET['package_preview'] ) ) : '';
+        $notice_message  = '';
+        $notice_type     = 'updated';
+        $current_profile = $this->get_usage_profile();
+        $base_quickstart_url = admin_url( 'admin.php?page=fp-publisher-quickstart' );
+
+        if ( isset( $_POST['tts_apply_package'] ) ) {
+            check_admin_referer( 'tts_apply_quickstart' );
+
+            $slug     = isset( $_POST['tts_package_slug'] ) ? sanitize_key( wp_unslash( $_POST['tts_package_slug'] ) ) : '';
+            $override = ! empty( $_POST['tts_override_existing'] );
+            $result   = $this->apply_quickstart_package( $slug, $override );
+
+            if ( is_wp_error( $result ) ) {
+                $notice_message = $result->get_error_message();
+                $notice_type    = 'error';
+            } else {
+                $notice_message = $result['message'];
+                $active_prefill = isset( $_SESSION['tts_quickstart_prefill'] ) ? $_SESSION['tts_quickstart_prefill'] : array();
+            }
+        }
+
+        echo '<div class="wrap tts-quickstart-packages">';
+        echo '<h1>' . esc_html__( 'Pacchetti Quickstart', 'fp-publisher' ) . '</h1>';
+        echo '<p class="description">' . esc_html__( 'Seleziona un pacchetto precostituito per popolare mapping Trello, template social e impostazioni blog prima di avviare il Client Wizard.', 'fp-publisher' ) . '</p>';
+        echo '<p class="description tts-active-profile">' . sprintf(
+            /* translators: %s: current usage profile label. */
+            esc_html__( 'Profilo attivo: %s', 'fp-publisher' ),
+            esc_html( $this->format_usage_profile_label( $current_profile ) )
+        ) . '</p>';
+        $quickstart_guide_url = admin_url( 'admin.php?page=fp-publisher-help#quickstart' );
+        printf(
+            '<p class="description">%s</p>',
+            sprintf(
+                wp_kses(
+                    __( 'Consulta la <a href="%s">Guida Quickstart</a> per esempi dettagliati e checklist complete.', 'fp-publisher' ),
+                    array( 'a' => array( 'href' => array() ) )
+                ),
+                esc_url( $quickstart_guide_url )
+            )
+        );
+        echo '<style>'
+            . '.tts-packages-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:24px;margin-top:20px;}'
+            . '.tts-package-card{background:#fff;border:1px solid #dcdcde;border-radius:8px;padding:20px;box-shadow:0 1px 1px rgb(0 0 0 / 4%);display:flex;flex-direction:column;}'
+            . '.tts-package-head{display:flex;justify-content:space-between;align-items:center;gap:8px;margin-bottom:10px;}'
+            . '.tts-package-profile{display:inline-flex;align-items:center;font-size:12px;font-weight:600;padding:2px 8px;border-radius:999px;background:#f6f7f7;color:#1d2327;text-transform:uppercase;letter-spacing:0.5px;}'
+            . '.tts-package-readiness{border:1px solid #e0e0e0;border-radius:6px;padding:12px;margin:16px 0;background:#f9fafb;}'
+            . '.tts-package-readiness.is-warning{border-color:#f56e28;background:#fff4e5;}'
+            . '.tts-package-readiness.is-blocked{border-color:#d63638;background:#fde7ea;}'
+            . '.tts-package-checklist{margin:10px 0 0;padding-left:0;list-style:none;}'
+            . '.tts-package-checklist li{display:flex;gap:8px;align-items:flex-start;margin-bottom:6px;}'
+            . '.tts-check-icon{font-size:18px;line-height:1;}'
+            . '.tts-check-message{display:block;font-size:13px;color:#50575e;}'
+            . '.tts-package-actions{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0 0;}'
+            . '.tts-package-preview{margin-top:12px;}'
+            . '.tts-package-preview summary{cursor:pointer;font-weight:600;}'
+            . '.tts-package-preview[open]{margin-bottom:10px;}'
+            . '.tts-package-preview.is-active{border:1px solid #2271b1;border-radius:6px;padding:8px 12px;background:#f0f6fc;}'
+            . '.tts-override-toggle{display:block;margin-top:12px;}'
+            . '.tts-profile-warning,.tts-readiness-warning{margin:8px 0 0;color:#d63638;}'
+            . '.tts-preview-section{margin-top:12px;padding-top:12px;border-top:1px solid #ececec;}'
+            . '.tts-preview-section:first-of-type{border-top:none;padding-top:0;margin-top:0;}'
+            . '.tts-preview-table{width:100%;border-collapse:collapse;margin-top:8px;}'
+            . '.tts-preview-table th,.tts-preview-table td{border-bottom:1px solid #ececec;padding:6px 8px;font-size:13px;text-align:left;vertical-align:top;}'
+            . '.tts-preview-table th{background:#f6f7f7;font-weight:600;}'
+            . '.tts-preview-badge{display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:600;letter-spacing:.3px;text-transform:uppercase;}'
+            . '.tts-preview-status-override{background:#fde7ea;color:#b52738;}'
+            . '.tts-preview-status-add{background:#e6f4ea;color:#1b5e20;}'
+            . '.tts-preview-status-match{background:#edf2fa;color:#1d3f72;}'
+            . '.tts-preview-meta{font-size:12px;color:#50575e;margin-top:4px;}'
+            . '.tts-preview-list{list-style:disc;margin:8px 0 0 18px;font-size:13px;color:#1d2327;}'
+            . '.tts-package-resources{margin-top:12px;padding:12px;border:1px dashed #c3c4c7;border-radius:6px;background:#f8f9fa;}'
+            . '.tts-package-resources strong{display:block;margin-bottom:6px;}'
+            . '.tts-package-resources .description{margin:0 0 12px;font-size:13px;color:#50575e;}'
+            . '.tts-package-links{display:flex;flex-wrap:wrap;gap:8px;}'
+            . '</style>';
+
+        if ( $notice_message ) {
+            printf( '<div class="notice notice-%1$s"><p>%2$s</p></div>', esc_attr( $notice_type ), esc_html( $notice_message ) );
+        }
+
+        if ( $previewed_slug && isset( $packages[ $previewed_slug ] ) ) {
+            echo '<div class="notice notice-info"><p>' . esc_html__( 'Anteprima attiva: scorri il pacchetto selezionato per verificare sovrascritture e nuovi elementi.', 'fp-publisher' ) . '</p></div>';
+        }
+
+        if ( ! empty( $active_prefill['package'] ) ) {
+            echo '<div class="notice notice-info"><p>' . sprintf(
+                /* translators: %s: quickstart package label. */
+                esc_html__( 'Pacchetto attivo: %s. I passaggi del wizard verranno precompilati di conseguenza.', 'fp-publisher' ),
+                '<strong>' . esc_html( isset( $active_prefill['label'] ) ? $active_prefill['label'] : $active_prefill['package'] ) . '</strong>'
+            ) . '</p></div>';
+        }
+
+        echo '<div class="tts-packages-grid">';
+        foreach ( $packages as $slug => $package ) {
+            $package_profile = isset( $package['profile'] ) ? sanitize_key( $package['profile'] ) : 'standard';
+            $profile_allowed = $this->usage_profile_allows( $package_profile );
+            $profile_label   = $this->format_usage_profile_label( $package_profile );
+            $readiness       = $this->assess_quickstart_package_readiness( $package );
+            $state_class     = isset( $readiness['status'] ) ? ' is-' . sanitize_html_class( $readiness['status'] ) : '';
+
+            echo '<div class="tts-package-card">';
+            echo '<div class="tts-package-head">';
+            echo '<h2>' . esc_html( $package['title'] ) . '</h2>';
+            echo '<span class="tts-package-profile tts-profile-' . esc_attr( $package_profile ) . '">' . esc_html( $profile_label ) . '</span>';
+            echo '</div>';
+            echo '<p>' . esc_html( $package['description'] ) . '</p>';
+
+            $preview       = $this->build_quickstart_preview( $package, $current_settings );
+            $is_previewed  = ( $previewed_slug === $slug );
+            $preview_url   = add_query_arg( array( 'package_preview' => $slug ), $base_quickstart_url );
+            $clear_preview = $base_quickstart_url;
+
+            if ( ! empty( $package['channels'] ) ) {
+                echo '<p><strong>' . esc_html__( 'Canali inclusi', 'fp-publisher' ) . ':</strong> ' . esc_html( implode( ', ', array_map( 'ucfirst', $package['channels'] ) ) ) . '</p>';
+            }
+
+            if ( ! empty( $preview['trello_guidelines'] ) ) {
+                echo '<div class="tts-package-section">';
+                echo '<strong>' . esc_html__( 'Board Trello consigliata', 'fp-publisher' ) . '</strong>';
+                echo '<ul>';
+                foreach ( $preview['trello_guidelines'] as $guideline ) {
+                    echo '<li>' . esc_html( $guideline ) . '</li>';
+                }
+                echo '</ul>';
+                echo '</div>';
+            }
+
+            $template_url = '';
+            if ( isset( $package['trello_template'] ) ) {
+                $template_url = $this->get_plugin_asset_url( $package['trello_template'] );
+            }
+
+            $journey_url = '';
+            if ( isset( $package['journey_doc'] ) ) {
+                $journey_doc = $package['journey_doc'];
+                if ( is_string( $journey_doc ) ) {
+                    $journey_url = $this->get_plugin_asset_url( $journey_doc );
+                } elseif ( is_array( $journey_doc ) ) {
+                    $journey_path   = isset( $journey_doc['path'] ) ? (string) $journey_doc['path'] : '';
+                    $journey_anchor = isset( $journey_doc['anchor'] ) ? (string) $journey_doc['anchor'] : '';
+                    $journey_url    = $this->get_plugin_asset_url( $journey_path );
+                    if ( $journey_url && '' !== $journey_anchor ) {
+                        $journey_anchor = '#' === $journey_anchor[0] ? $journey_anchor : '#' . ltrim( $journey_anchor, '#' );
+                        $journey_url   .= $journey_anchor;
+                    }
+                }
+            }
+
+            if ( $template_url || $journey_url ) {
+                echo '<div class="tts-package-resources">';
+                echo '<strong>' . esc_html__( 'Risorse collegate', 'fp-publisher' ) . '</strong>';
+                echo '<p class="description">' . esc_html__( 'Scarica la board di partenza o apri il percorso guidato per completare onboarding e checklist.', 'fp-publisher' ) . '</p>';
+                echo '<div class="tts-package-links">';
+                if ( $template_url ) {
+                    echo '<a class="button button-secondary" href="' . esc_url( $template_url ) . '" download>' . esc_html__( 'Scarica template Trello', 'fp-publisher' ) . '</a>';
+                }
+                if ( $journey_url ) {
+                    echo '<a class="button button-link" href="' . esc_url( $journey_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Apri percorso guidato', 'fp-publisher' ) . '</a>';
+                }
+                echo '</div>';
+                echo '</div>';
+            }
+
+            echo '<div class="tts-package-actions">';
+            echo '<a class="button button-secondary" href="' . esc_url( $preview_url ) . '">' . esc_html__( 'Anteprima modifiche', 'fp-publisher' ) . '</a>';
+            if ( $is_previewed ) {
+                echo '<a class="button-link" href="' . esc_url( $clear_preview ) . '">' . esc_html__( 'Nascondi anteprima', 'fp-publisher' ) . '</a>';
+            }
+            echo '</div>';
+
+            echo '<div class="tts-package-readiness' . esc_attr( $state_class ) . '">';
+            $status_label = isset( $readiness['label'] ) ? $readiness['label'] : '';
+            if ( $status_label ) {
+                echo '<strong>' . esc_html( $status_label ) . '</strong>';
+            }
+
+            if ( ! empty( $readiness['summary'] ) ) {
+                echo '<p>' . esc_html( $readiness['summary'] ) . '</p>';
+            }
+
+            if ( ! empty( $readiness['checks'] ) ) {
+                echo '<ul class="tts-package-checklist">';
+                foreach ( $readiness['checks'] as $check ) {
+                    $icon = '✅';
+                    if ( isset( $check['status'] ) ) {
+                        if ( 'warning' === $check['status'] ) {
+                            $icon = '⚠️';
+                        } elseif ( 'blocked' === $check['status'] ) {
+                            $icon = '❌';
+                        } elseif ( 'skipped' === $check['status'] ) {
+                            $icon = '➖';
+                        }
+                    }
+
+                    $label = isset( $check['label'] ) ? $check['label'] : '';
+                    $message = isset( $check['message'] ) ? $check['message'] : '';
+
+                    echo '<li>';
+                    echo '<span class="tts-check-icon">' . esc_html( $icon ) . '</span>';
+                    echo '<span class="tts-check-content">';
+                    if ( '' !== $label ) {
+                        echo '<strong>' . esc_html( $label ) . '</strong>';
+                    }
+                    if ( '' !== $message ) {
+                        echo '<span class="tts-check-message">' . esc_html( $message ) . '</span>';
+                    }
+                    echo '</span>';
+                    echo '</li>';
+                }
+                echo '</ul>';
+            }
+            echo '</div>';
+
+            $details_classes = 'tts-package-preview';
+            if ( $is_previewed ) {
+                $details_classes .= ' is-active';
+            }
+
+            echo '<details class="' . esc_attr( $details_classes ) . '"' . ( $is_previewed ? ' open' : '' ) . '>';
+            echo '<summary>' . esc_html__( 'Anteprima modifiche', 'fp-publisher' ) . '</summary>';
+
+            if ( ! empty( $preview['mapping']['overrides'] ) || ! empty( $preview['mapping']['added'] ) ) {
+                echo '<div class="tts-preview-section">';
+                echo '<h4>' . esc_html__( 'Mappature Trello proposte', 'fp-publisher' ) . '</h4>';
+                if ( $preview['mapping']['current_total'] > 0 && ! empty( $preview['mapping']['overrides'] ) ) {
+                    echo '<p class="tts-preview-meta">' . esc_html__( 'Le liste esistenti contrassegnate saranno aggiornate per allinearsi al pacchetto.', 'fp-publisher' ) . '</p>';
+                }
+                echo '<table class="tts-preview-table"><thead><tr>';
+                echo '<th>' . esc_html__( 'Lista', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Canale', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Stato', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Azione', 'fp-publisher' ) . '</th>';
+                echo '</tr></thead><tbody>';
+                foreach ( $preview['mapping']['overrides'] as $entry ) {
+                    $action_label    = __( 'Aggiorna esistente', 'fp-publisher' );
+                    $channel_label   = 'all' === $entry['channel'] ? __( 'Tutti', 'fp-publisher' ) : ucfirst( $entry['channel'] );
+                    $current_channel = isset( $entry['current_channel'] ) ? $entry['current_channel'] : '';
+                    $current_status  = isset( $entry['current_status'] ) ? $entry['current_status'] : '';
+                    echo '<tr>';
+                    echo '<td>' . esc_html( $entry['list'] ) . '</td>';
+                    echo '<td>' . esc_html( $channel_label ) . '</td>';
+                    echo '<td>' . esc_html( $entry['status'] ) . '</td>';
+                    echo '<td><span class="tts-preview-badge tts-preview-status-override">' . esc_html( $action_label ) . '</span>';
+                    if ( '' !== $current_status && $current_status !== $entry['status'] ) {
+                        echo '<div class="tts-preview-meta">' . sprintf( esc_html__( 'Stato attuale: %s', 'fp-publisher' ), esc_html( $current_status ) ) . '</div>';
+                    }
+                    if ( '' !== $current_channel && $current_channel !== $entry['channel'] ) {
+                        $current_channel_label = 'all' === $current_channel ? __( 'Tutti', 'fp-publisher' ) : ucfirst( $current_channel );
+                        echo '<div class="tts-preview-meta">' . sprintf( esc_html__( 'Canale attuale: %s', 'fp-publisher' ), esc_html( $current_channel_label ) ) . '</div>';
+                    }
+                    echo '</td></tr>';
+                }
+                foreach ( $preview['mapping']['added'] as $entry ) {
+                    $channel_label = 'all' === $entry['channel'] ? __( 'Tutti', 'fp-publisher' ) : ucfirst( $entry['channel'] );
+                    echo '<tr>';
+                    echo '<td>' . esc_html( $entry['list'] ) . '</td>';
+                    echo '<td>' . esc_html( $channel_label ) . '</td>';
+                    echo '<td>' . esc_html( $entry['status'] ) . '</td>';
+                    echo '<td><span class="tts-preview-badge tts-preview-status-add">' . esc_html__( 'Nuova mappatura', 'fp-publisher' ) . '</span></td>';
+                    echo '</tr>';
+                }
+                echo '</tbody></table>';
+                echo '</div>';
+            }
+
+            if ( ! empty( $preview['templates'] ) ) {
+                echo '<div class="tts-preview-section">';
+                echo '<h4>' . esc_html__( 'Template social', 'fp-publisher' ) . '</h4>';
+                echo '<table class="tts-preview-table"><thead><tr>';
+                echo '<th>' . esc_html__( 'Canale', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Nuovo contenuto', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Valore attuale', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Azione', 'fp-publisher' ) . '</th>';
+                echo '</tr></thead><tbody>';
+                foreach ( $preview['templates'] as $entry ) {
+                    $action_class = 'tts-preview-status-add';
+                    $action_label = __( 'Nuovo', 'fp-publisher' );
+                    if ( 'override' === $entry['action'] ) {
+                        $action_class = 'tts-preview-status-override';
+                        $action_label = __( 'Sovrascrive', 'fp-publisher' );
+                    } elseif ( 'match' === $entry['action'] ) {
+                        $action_class = 'tts-preview-status-match';
+                        $action_label = __( 'Invariato', 'fp-publisher' );
+                    }
+                    echo '<tr>';
+                    echo '<td>' . esc_html( $entry['channel_label'] ) . '</td>';
+                    echo '<td><code>' . esc_html( $entry['new'] ) . '</code></td>';
+                    echo '<td>' . ( '' !== $entry['current'] ? '<code>' . esc_html( $entry['current'] ) . '</code>' : '—' ) . '</td>';
+                    echo '<td><span class="tts-preview-badge ' . esc_attr( $action_class ) . '">' . esc_html( $action_label ) . '</span></td>';
+                    echo '</tr>';
+                }
+                echo '</tbody></table>';
+                echo '</div>';
+            }
+
+            if ( ! empty( $preview['utm'] ) ) {
+                echo '<div class="tts-preview-section">';
+                echo '<h4>' . esc_html__( 'Parametri UTM', 'fp-publisher' ) . '</h4>';
+                echo '<table class="tts-preview-table"><thead><tr>';
+                echo '<th>' . esc_html__( 'Canale', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Parametro', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Nuovo valore', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Valore attuale', 'fp-publisher' ) . '</th>';
+                echo '<th>' . esc_html__( 'Azione', 'fp-publisher' ) . '</th>';
+                echo '</tr></thead><tbody>';
+                foreach ( $preview['utm'] as $entry ) {
+                    $action_class = 'tts-preview-status-add';
+                    $action_label = __( 'Nuovo', 'fp-publisher' );
+                    if ( 'override' === $entry['action'] ) {
+                        $action_class = 'tts-preview-status-override';
+                        $action_label = __( 'Sovrascrive', 'fp-publisher' );
+                    } elseif ( 'match' === $entry['action'] ) {
+                        $action_class = 'tts-preview-status-match';
+                        $action_label = __( 'Invariato', 'fp-publisher' );
+                    }
+                    $channel_label = 'all' === $entry['channel'] ? __( 'Tutti', 'fp-publisher' ) : ucfirst( $entry['channel'] );
+                    echo '<tr>';
+                    echo '<td>' . esc_html( $channel_label ) . '</td>';
+                    echo '<td><code>' . esc_html( $entry['param'] ) . '</code></td>';
+                    echo '<td><code>' . esc_html( $entry['new'] ) . '</code></td>';
+                    $current_value = '' !== $entry['current'] ? '<code>' . esc_html( $entry['current'] ) . '</code>' : '—';
+                    echo '<td>' . $current_value . '</td>';
+                    echo '<td><span class="tts-preview-badge ' . esc_attr( $action_class ) . '">' . esc_html( $action_label ) . '</span></td>';
+                    echo '</tr>';
+                }
+                echo '</tbody></table>';
+                echo '</div>';
+            }
+
+            if ( ! empty( $preview['blog'] ) ) {
+                echo '<div class="tts-preview-section">';
+                echo '<h4>' . esc_html__( 'Prefill blog', 'fp-publisher' ) . '</h4>';
+                echo '<ul class="tts-preview-list">';
+                foreach ( $preview['blog'] as $key => $value ) {
+                    echo '<li><strong>' . esc_html( $key ) . '</strong>: ' . esc_html( $value ) . '</li>';
+                }
+                echo '</ul>';
+                echo '</div>';
+            }
+
+            if ( ! empty( $preview['notes'] ) ) {
+                echo '<div class="tts-preview-section"><em>' . esc_html( $preview['notes'] ) . '</em></div>';
+            }
+
+            echo '</details>';
+
+            echo '<form method="post" class="tts-package-form">';
+            wp_nonce_field( 'tts_apply_quickstart' );
+            echo '<input type="hidden" name="tts_package_slug" value="' . esc_attr( $slug ) . '" />';
+            echo '<label class="tts-override-toggle"><input type="checkbox" name="tts_override_existing" value="1" /> ' . esc_html__( 'Sovrascrivi impostazioni esistenti (template, mapping, UTM)', 'fp-publisher' ) . '</label>';
+
+            $button_attrs = array();
+            if ( 'blocked' === $readiness['status'] || ! $profile_allowed ) {
+                $button_attrs[] = 'disabled="disabled"';
+            }
+
+            $button_label = esc_html__( 'Applica pacchetto', 'fp-publisher' );
+            if ( ! $profile_allowed ) {
+                echo '<p class="description tts-profile-warning">' . sprintf(
+                    /* translators: %s: required usage profile label. */
+                    esc_html__( 'Richiede profilo %s o superiore.', 'fp-publisher' ),
+                    esc_html( $profile_label )
+                ) . '</p>';
+            }
+
+            if ( 'blocked' === $readiness['status'] ) {
+                echo '<p class="description tts-readiness-warning">' . esc_html__( 'Completa i requisiti contrassegnati in rosso prima di applicare il preset.', 'fp-publisher' ) . '</p>';
+            }
+
+            echo '<p><button type="submit" name="tts_apply_package" class="button button-primary" ' . implode( ' ', $button_attrs ) . '>' . $button_label . '</button></p>';
+            echo '</form>';
+
+            echo '</div>';
+        }
+        echo '</div>';
+
+        echo '<p style="margin-top:30px;">' . esc_html__( "Dopo l'applicazione apri il Client Wizard per completare la checklist guidata.", 'fp-publisher' ) . '</p>';
+
+        echo '</div>';
+    }
+
+    /**
+     * Expose quickstart packages for programmatic contexts (CLI/tests).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function get_quickstart_package_catalog() {
+        $packages = $this->get_quickstart_packages();
+        $catalog  = array();
+
+        foreach ( $packages as $slug => $package ) {
+            $catalog[] = array(
+                'slug'        => $slug,
+                'title'       => isset( $package['title'] ) ? (string) $package['title'] : $slug,
+                'profile'     => isset( $package['profile'] ) ? sanitize_key( $package['profile'] ) : 'standard',
+                'description' => isset( $package['description'] ) ? (string) $package['description'] : '',
+            );
+        }
+
+        return $catalog;
+    }
+
+    /**
+     * Return readiness information and preview details for a quickstart package.
+     *
+     * @param string               $slug     Package identifier.
+     * @param array<string, mixed> $settings Optional settings snapshot to compare.
+     *
+     * @return array<string, mixed>|WP_Error
+     */
+    public function get_quickstart_package_overview( $slug, $settings = null ) {
+        $slug     = sanitize_key( $slug );
+        $packages = $this->get_quickstart_packages();
+
+        if ( ! isset( $packages[ $slug ] ) ) {
+            return new WP_Error( 'tts-invalid-package', __( 'Pacchetto non disponibile.', 'fp-publisher' ) );
+        }
+
+        $package = $packages[ $slug ];
+        $profile = isset( $package['profile'] ) ? sanitize_key( $package['profile'] ) : 'standard';
+
+        if ( null === $settings ) {
+            $settings = get_option( 'tts_settings', array() );
+        }
+
+        if ( ! is_array( $settings ) ) {
+            $settings = array();
+        }
+
+        $readiness = $this->assess_quickstart_package_readiness( $package );
+        $preview   = $this->build_quickstart_preview( $package, $settings );
+
+        return array(
+            'slug'             => $slug,
+            'definition'       => $package,
+            'readiness'        => $readiness,
+            'preview'          => $preview,
+            'required_profile' => $profile,
+            'profile_allowed'  => $this->usage_profile_allows( $profile ),
+            'active_profile'   => $this->get_usage_profile(),
+        );
+    }
+
+    /**
+     * Return predefined quickstart package definitions.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function get_quickstart_packages() {
+        return array(
+            'social_starter'  => array(
+                'title'            => __( 'Starter Social', 'fp-publisher' ),
+                'description'      => __( 'Flusso base per team piccoli con mapping Trello lineare e template social immediati.', 'fp-publisher' ),
+                'profile'          => 'standard',
+                'channels'         => array( 'facebook', 'instagram' ),
+                'blog_settings'    => 'post_type:post|post_status:draft|author_id:1|language:it|seo_title={title} | canonical_url:{url}',
+                'column_mapping'   => array(
+                    array( 'list' => 'Idee', 'status' => 'draft', 'channel' => 'all' ),
+                    array( 'list' => 'In approvazione', 'status' => 'review', 'channel' => 'all' ),
+                    array( 'list' => 'Pronto', 'status' => 'scheduled', 'channel' => 'all' ),
+                    array( 'list' => 'Pubblicato', 'status' => 'published', 'channel' => 'all' ),
+                ),
+                'templates'        => array(
+                    'facebook_template'  => '{title} {url} #brand',
+                    'instagram_template' => '{title}\n\n{hashtags}',
+                ),
+                'utm'              => array(
+                    'facebook'  => array(
+                        'utm_source'   => 'facebook',
+                        'utm_medium'   => 'social',
+                        'utm_campaign' => 'editoriale',
+                    ),
+                    'instagram' => array(
+                        'utm_source'   => 'instagram',
+                        'utm_medium'   => 'social',
+                        'utm_campaign' => 'editoriale',
+                    ),
+                ),
+                'trello_guidelines' => array(
+                    __( 'Liste suggerite: Idee → In approvazione → Pronto → Pubblicato.', 'fp-publisher' ),
+                    __( 'Usa etichette Trello per distinguere i canali Facebook e Instagram.', 'fp-publisher' ),
+                ),
+                'trello_template'   => 'assets/quickstart/social-starter.json',
+                'journey_doc'       => array(
+                    'path'   => 'docs/journeys/client-onboarding.md',
+                    'anchor' => '#starter-social',
+                ),
+                'notes'            => __( 'Ideale per avviare nuovi brand senza complicare il flusso.', 'fp-publisher' ),
+            ),
+            'editorial_suite' => array(
+                'title'            => __( 'Editorial Suite', 'fp-publisher' ),
+                'description'      => __( 'Preset completo per team editoriali con blog, YouTube e short form video.', 'fp-publisher' ),
+                'profile'          => 'advanced',
+                'channels'         => array( 'facebook', 'instagram', 'youtube', 'tiktok' ),
+                'blog_settings'    => 'post_type:post|post_status:pending|author_id:2|category_id:3|language:it|focus_keyword:{title}|seo_title={title} | meta_description={excerpt}',
+                'column_mapping'   => array(
+                    array( 'list' => 'Briefing', 'status' => 'draft', 'channel' => 'all' ),
+                    array( 'list' => 'Produzione', 'status' => 'in-progress', 'channel' => 'all' ),
+                    array( 'list' => 'Revisione', 'status' => 'review', 'channel' => 'all' ),
+                    array( 'list' => 'Pronto Social', 'status' => 'scheduled', 'channel' => 'social' ),
+                    array( 'list' => 'Pubblicato', 'status' => 'published', 'channel' => 'all' ),
+                ),
+                'templates'        => array(
+                    'facebook_template'  => '{title} → {url}\n#contentcalendar',
+                    'instagram_template' => '{title}\n\n📅 {due}\n{hashtags}',
+                    'youtube_template'   => '{title} | {due} | {url}',
+                    'tiktok_template'    => '{title} 🎬 {due}',
+                ),
+                'utm'              => array(
+                    'facebook'  => array(
+                        'utm_source'   => 'facebook',
+                        'utm_medium'   => 'social',
+                        'utm_campaign' => 'editorial-suite',
+                    ),
+                    'instagram' => array(
+                        'utm_source'   => 'instagram',
+                        'utm_medium'   => 'social',
+                        'utm_campaign' => 'editorial-suite',
+                    ),
+                    'youtube'   => array(
+                        'utm_source'   => 'youtube',
+                        'utm_medium'   => 'video',
+                        'utm_campaign' => 'editorial-suite',
+                    ),
+                    'tiktok'    => array(
+                        'utm_source'   => 'tiktok',
+                        'utm_medium'   => 'video',
+                        'utm_campaign' => 'editorial-suite',
+                    ),
+                ),
+                'trello_guidelines' => array(
+                    __( 'Aggiungi checklist Trello per script, grafiche e revisione SEO.', 'fp-publisher' ),
+                    __( 'Allinea le scadenze con il calendario editoriale di FP Publisher.', 'fp-publisher' ),
+                ),
+                'trello_template'   => 'assets/quickstart/editorial-suite.json',
+                'journey_doc'       => array(
+                    'path'   => 'docs/journeys/client-onboarding.md',
+                    'anchor' => '#editorial-suite',
+                ),
+                'notes'            => __( 'Perfetto per contenuti multi-canale con controllo qualità centralizzato.', 'fp-publisher' ),
+            ),
+            'enterprise_control' => array(
+                'title'            => __( 'Enterprise Control', 'fp-publisher' ),
+                'description'      => __( 'Configurazione per organizzazioni complesse con audit trail e fasi di verifica aggiuntive.', 'fp-publisher' ),
+                'profile'          => 'enterprise',
+                'channels'         => array( 'facebook', 'instagram', 'youtube', 'tiktok' ),
+                'blog_settings'    => 'post_type:post|post_status:pending|author_id:5|language:it|seo_title={title} | canonical_url:{url}|meta_description={excerpt}',
+                'column_mapping'   => array(
+                    array( 'list' => 'Intake', 'status' => 'draft', 'channel' => 'all' ),
+                    array( 'list' => 'Quality Assurance', 'status' => 'review', 'channel' => 'all' ),
+                    array( 'list' => 'Security Check', 'status' => 'review', 'channel' => 'all' ),
+                    array( 'list' => 'Ready to Launch', 'status' => 'scheduled', 'channel' => 'all' ),
+                    array( 'list' => 'Live + Audit', 'status' => 'published', 'channel' => 'all' ),
+                ),
+                'templates'        => array(
+                    'facebook_template'  => '[APPROVED] {title} {url} #{client}',
+                    'instagram_template' => '{title}\n\nTeam: {owner}\n{hashtags}',
+                    'youtube_template'   => '[Release] {title} | Owner: {owner}',
+                    'tiktok_template'    => '{title} ⚙️ QA:{qa_owner}',
+                ),
+                'utm'              => array(
+                    'facebook'  => array(
+                        'utm_source'   => 'facebook',
+                        'utm_medium'   => 'social',
+                        'utm_campaign' => 'enterprise-control',
+                    ),
+                    'instagram' => array(
+                        'utm_source'   => 'instagram',
+                        'utm_medium'   => 'social',
+                        'utm_campaign' => 'enterprise-control',
+                    ),
+                    'youtube'   => array(
+                        'utm_source'   => 'youtube',
+                        'utm_medium'   => 'video',
+                        'utm_campaign' => 'enterprise-control',
+                    ),
+                    'tiktok'    => array(
+                        'utm_source'   => 'tiktok',
+                        'utm_medium'   => 'video',
+                        'utm_campaign' => 'enterprise-control',
+                    ),
+                ),
+                'trello_guidelines' => array(
+                    __( 'Prevedi una card checklist per i controlli legali e privacy prima della pubblicazione.', 'fp-publisher' ),
+                    __( "Attiva l'audit Trello e sincronizza i log con FP Publisher per avere una cronologia completa.", 'fp-publisher' ),
+                ),
+                'trello_template'   => 'assets/quickstart/enterprise-control.json',
+                'journey_doc'       => array(
+                    'path'   => 'docs/journeys/client-onboarding.md',
+                    'anchor' => '#enterprise-control',
+                ),
+                'notes'            => __( 'Pensato per chi necessita di visibilità completa su approvatori e compliance.', 'fp-publisher' ),
+            ),
+        );
+    }
+
+    /**
+     * Build preview information for a quickstart package versus current settings.
+     *
+     * @param array<string, mixed> $package  Quickstart definition.
+     * @param array<string, mixed> $settings Current plugin settings.
+     * @return array<string, mixed>
+     */
+    private function build_quickstart_preview( array $package, array $settings ) {
+        $settings = is_array( $settings ) ? $settings : array();
+
+        $preview = array(
+            'mapping'           => array(
+                'added'         => array(),
+                'overrides'     => array(),
+                'current_total' => 0,
+            ),
+            'templates'         => array(),
+            'utm'               => array(),
+            'blog'              => array(),
+            'notes'             => isset( $package['notes'] ) ? (string) $package['notes'] : '',
+            'trello_guidelines' => array(),
+        );
+
+        $current_mapping = array();
+        if ( isset( $settings['column_mapping'] ) ) {
+            $decoded = $settings['column_mapping'];
+            if ( is_string( $decoded ) ) {
+                $decoded = json_decode( $decoded, true );
+            }
+            if ( is_array( $decoded ) ) {
+                foreach ( $decoded as $entry ) {
+                    if ( ! is_array( $entry ) ) {
+                        continue;
+                    }
+                    $item = array(
+                        'list'    => isset( $entry['list'] ) ? (string) $entry['list'] : '',
+                        'channel' => isset( $entry['channel'] ) ? (string) $entry['channel'] : 'all',
+                        'status'  => isset( $entry['status'] ) ? (string) $entry['status'] : '',
+                    );
+                    if ( '' === $item['list'] ) {
+                        continue;
+                    }
+                    if ( '' === $item['channel'] ) {
+                        $item['channel'] = 'all';
+                    }
+                    $current_mapping[] = $item;
+                }
+            }
+        }
+
+        $preview['mapping']['current_total'] = count( $current_mapping );
+
+        $current_index = array();
+        foreach ( $current_mapping as $item ) {
+            $key                 = strtolower( $item['list'] ) . '|' . strtolower( $item['channel'] );
+            $current_index[ $key ] = $item;
+        }
+
+        if ( isset( $package['column_mapping'] ) && is_array( $package['column_mapping'] ) ) {
+            foreach ( $package['column_mapping'] as $entry ) {
+                if ( ! is_array( $entry ) ) {
+                    continue;
+                }
+                $item = array(
+                    'list'    => isset( $entry['list'] ) ? (string) $entry['list'] : '',
+                    'channel' => isset( $entry['channel'] ) ? (string) $entry['channel'] : 'all',
+                    'status'  => isset( $entry['status'] ) ? (string) $entry['status'] : '',
+                );
+                if ( '' === $item['list'] ) {
+                    continue;
+                }
+                if ( '' === $item['channel'] ) {
+                    $item['channel'] = 'all';
+                }
+
+                $key = strtolower( $item['list'] ) . '|' . strtolower( $item['channel'] );
+                if ( isset( $current_index[ $key ] ) ) {
+                    $current_item              = $current_index[ $key ];
+                    $item['current_channel']   = isset( $current_item['channel'] ) ? (string) $current_item['channel'] : '';
+                    $item['current_status']    = isset( $current_item['status'] ) ? (string) $current_item['status'] : '';
+                    $preview['mapping']['overrides'][] = $item;
+                } else {
+                    $preview['mapping']['added'][] = $item;
+                }
+            }
+        }
+
+        if ( isset( $package['templates'] ) && is_array( $package['templates'] ) ) {
+            foreach ( $package['templates'] as $key => $template ) {
+                $key            = sanitize_key( $key );
+                $new_value      = (string) $template;
+                $current_value  = isset( $settings[ $key ] ) ? (string) $settings[ $key ] : '';
+                $action         = 'add';
+                if ( '' !== trim( $current_value ) ) {
+                    $action = trim( $current_value ) === trim( $new_value ) ? 'match' : 'override';
+                }
+                $channel_slug  = str_replace( '_template', '', $key );
+                $channel_label = ucwords( str_replace( '_', ' ', $channel_slug ) );
+
+                $preview['templates'][] = array(
+                    'key'           => $key,
+                    'channel_label' => $channel_label,
+                    'new'           => $new_value,
+                    'current'       => $current_value,
+                    'action'        => $action,
+                );
+            }
+        }
+
+        if ( isset( $package['utm'] ) && is_array( $package['utm'] ) ) {
+            foreach ( $package['utm'] as $channel => $params ) {
+                $channel = sanitize_key( $channel );
+                if ( ! is_array( $params ) ) {
+                    continue;
+                }
+                foreach ( $params as $param_key => $param_value ) {
+                    $param_key     = sanitize_key( $param_key );
+                    $new_value     = (string) $param_value;
+                    $current_value = isset( $settings['utm'][ $channel ][ $param_key ] ) ? (string) $settings['utm'][ $channel ][ $param_key ] : '';
+                    $action        = 'add';
+                    if ( '' !== trim( $current_value ) ) {
+                        $action = trim( $current_value ) === trim( $new_value ) ? 'match' : 'override';
+                    }
+
+                    $preview['utm'][] = array(
+                        'channel' => $channel,
+                        'param'   => $param_key,
+                        'new'     => $new_value,
+                        'current' => $current_value,
+                        'action'  => $action,
+                    );
+                }
+            }
+        }
+
+        if ( ! empty( $package['blog_settings'] ) ) {
+            $preview['blog'] = $this->parse_quickstart_blog_settings( (string) $package['blog_settings'] );
+        }
+
+        if ( isset( $package['trello_guidelines'] ) && is_array( $package['trello_guidelines'] ) ) {
+            $preview['trello_guidelines'] = array_map( 'sanitize_text_field', $package['trello_guidelines'] );
+        }
+
+        return $preview;
+    }
+
+    /**
+     * Apply quickstart package presets.
+     *
+     * @param string $slug     Package slug.
+     * @param bool   $override Whether to override existing settings.
+     * @return array|WP_Error
+     */
+    private function apply_quickstart_package( $slug, $override = false ) {
+        $packages = $this->get_quickstart_packages();
+
+        if ( ! isset( $packages[ $slug ] ) ) {
+            return new WP_Error( 'tts-invalid-package', __( 'Pacchetto non disponibile.', 'fp-publisher' ) );
+        }
+
+        $package         = $packages[ $slug ];
+        $package_profile = isset( $package['profile'] ) ? sanitize_key( $package['profile'] ) : 'standard';
+
+        if ( ! $this->usage_profile_allows( $package_profile ) ) {
+            return new WP_Error(
+                'tts-package-profile-mismatch',
+                __( 'Il pacchetto richiede un profilo di utilizzo più avanzato rispetto a quello attivo.', 'fp-publisher' )
+            );
+        }
+
+        $readiness = $this->assess_quickstart_package_readiness( $package );
+        if ( isset( $readiness['status'] ) && 'blocked' === $readiness['status'] ) {
+            return new WP_Error(
+                'tts-package-not-ready',
+                __( 'Completa prima i prerequisiti critici evidenziati nella validazione del pacchetto.', 'fp-publisher' )
+            );
+        }
+
+        $settings = get_option( 'tts_settings', array() );
+
+        if ( isset( $package['column_mapping'] ) ) {
+            $encoded = wp_json_encode( $package['column_mapping'] );
+            if ( $override || empty( $settings['column_mapping'] ) ) {
+                $settings['column_mapping'] = $encoded;
+            }
+        }
+
+        if ( isset( $package['templates'] ) && is_array( $package['templates'] ) ) {
+            foreach ( $package['templates'] as $key => $value ) {
+                if ( $override || empty( $settings[ $key ] ) ) {
+                    $settings[ $key ] = sanitize_text_field( $value );
+                }
+            }
+        }
+
+        if ( isset( $package['utm'] ) && is_array( $package['utm'] ) ) {
+            foreach ( $package['utm'] as $channel => $params ) {
+                foreach ( $params as $param_key => $param_value ) {
+                    if ( $override || empty( $settings['utm'][ $channel ][ $param_key ] ) ) {
+                        $settings['utm'][ $channel ][ $param_key ] = sanitize_text_field( $param_value );
+                    }
+                }
+            }
+        }
+
+        update_option( 'tts_settings', $settings );
+        update_option( 'tts_quickstart_last_package', array(
+            'slug'       => $slug,
+            'applied_at' => current_time( 'mysql' ),
+        ) );
+
+        if ( ! session_id() ) {
+            session_start();
+        }
+
+        $_SESSION['tts_quickstart_prefill'] = array(
+            'package'        => $slug,
+            'label'          => $package['title'],
+            'channels'       => isset( $package['channels'] ) ? array_map( 'sanitize_key', (array) $package['channels'] ) : array(),
+            'blog_settings'  => isset( $package['blog_settings'] ) ? sanitize_textarea_field( $package['blog_settings'] ) : '',
+            'trello_guidelines' => isset( $package['trello_guidelines'] ) ? array_map( 'sanitize_text_field', (array) $package['trello_guidelines'] ) : array(),
+            'column_mapping' => isset( $package['column_mapping'] ) ? $package['column_mapping'] : array(),
+            'profile'        => $package_profile,
+            'validation'     => $readiness,
+        );
+
+        $message = sprintf(
+            /* translators: %s: quickstart package title. */
+            __( 'Pacchetto "%s" applicato con successo. Apri il Client Wizard per completare la configurazione guidata.', 'fp-publisher' ),
+            $package['title']
+        );
+
+        return array(
+            'message' => $message,
+            'package' => $package,
+        );
+    }
+
+    /**
+     * Render onboarding checklist for the wizard.
+     *
+     * @param array $state          Progress state.
+     * @param int   $step           Current step number.
+     * @param array $prefill        Prefill metadata from quickstart packages.
+     * @param bool  $trello_enabled Whether Trello step is enabled.
+     * @param array $context        Runtime context (tokens, channels, validation hints).
+     */
+    private function render_client_wizard_checklist( array $state, $step, array $prefill, $trello_enabled, array $context = array() ) {
+        $defaults = array(
+            'trello_key'      => '',
+            'trello_token'    => '',
+            'trello_board'    => '',
+            'channels'        => array(),
+            'blog_settings'   => '',
+            'tokens'          => array(),
+            'mapping_count'   => 0,
+            'prefill_package' => '',
+            'validation'      => array(),
+            'usage_profile'   => $this->get_usage_profile(),
+        );
+
+        $context = wp_parse_args( $context, $defaults );
+
+        $validation_checks = array();
+        if ( isset( $context['validation']['checks'] ) && is_array( $context['validation']['checks'] ) ) {
+            foreach ( $context['validation']['checks'] as $check ) {
+                $scope = isset( $check['scope'] ) ? $check['scope'] : 'general';
+                if ( ! isset( $validation_checks[ $scope ] ) ) {
+                    $validation_checks[ $scope ] = array();
+                }
+                $validation_checks[ $scope ][] = $check;
+            }
+        }
+        $validation_summary = isset( $context['validation']['summary'] ) ? $context['validation']['summary'] : '';
+
+        $trello_status = array(
+            'status'  => 'pending',
+            'message' => __( 'Inserisci API key e token Trello per iniziare.', 'fp-publisher' ),
+        );
+
+        if ( ! $trello_enabled ) {
+            $trello_status = array(
+                'status'  => 'skipped',
+                'message' => __( 'Trello è disattivato nelle impostazioni generali.', 'fp-publisher' ),
+            );
+        } else {
+            $has_key    = '' !== trim( (string) $context['trello_key'] );
+            $has_token  = '' !== trim( (string) $context['trello_token'] );
+            $has_board  = '' !== trim( (string) $context['trello_board'] );
+
+            if ( ! $has_key || ! $has_token ) {
+                $trello_status = array(
+                    'status'  => 'blocked',
+                    'message' => __( 'Aggiungi API key e token Trello per proseguire.', 'fp-publisher' ),
+                );
+            } elseif ( ! $has_board ) {
+                $trello_status = array(
+                    'status'  => 'warning',
+                    'message' => __( 'Seleziona la board Trello da monitorare.', 'fp-publisher' ),
+                );
+            } else {
+                $trello_status = array(
+                    'status'  => ! empty( $state['trello'] ) ? 'complete' : 'pending',
+                    'message' => __( 'Credenziali Trello impostate, passa alla scelta dei canali.', 'fp-publisher' ),
+                );
+            }
+        }
+
+        $selected_channels = array_filter( array_map( 'sanitize_key', (array) $context['channels'] ) );
+        $connected_channels = array();
+        foreach ( $selected_channels as $selected_channel ) {
+            $token_value = '';
+            if ( isset( $context['tokens'][ $selected_channel ] ) ) {
+                $token_value = $context['tokens'][ $selected_channel ];
+            }
+            if ( '' !== trim( (string) $token_value ) ) {
+                $connected_channels[] = $selected_channel;
+            }
+        }
+
+        if ( empty( $selected_channels ) ) {
+            $channel_status = array(
+                'status'  => 'pending',
+                'message' => __( 'Seleziona almeno un canale da collegare.', 'fp-publisher' ),
+            );
+        } elseif ( count( $connected_channels ) === count( $selected_channels ) ) {
+            $channel_status = array(
+                'status'  => 'complete',
+                'message' => __( 'Tutti i canali selezionati risultano autorizzati.', 'fp-publisher' ),
+            );
+        } elseif ( ! empty( $connected_channels ) ) {
+            $channel_status = array(
+                'status'  => 'warning',
+                'message' => __( 'Autorizza anche i canali mancanti per evitare lacune di pubblicazione.', 'fp-publisher' ),
+            );
+        } else {
+            $channel_status = array(
+                'status'  => 'pending',
+                'message' => __( "Completa l'OAuth dal Client Wizard per almeno un canale.", 'fp-publisher' ),
+            );
+        }
+
+        if ( isset( $validation_checks['channels'] ) ) {
+            foreach ( $validation_checks['channels'] as $warning ) {
+                if ( 'blocked' === $warning['status'] ) {
+                    $channel_status['status'] = 'blocked';
+                    break;
+                }
+                if ( 'warning' === $warning['status'] && 'blocked' !== $channel_status['status'] ) {
+                    $channel_status['status'] = 'warning';
+                }
+            }
+        }
+
+        if ( ! $trello_enabled ) {
+            $mapping_status = array(
+                'status'  => 'skipped',
+                'message' => __( 'La mappatura Trello è facoltativa perché la sincronizzazione è disattivata.', 'fp-publisher' ),
+            );
+        } else {
+            $mapping_status = array(
+                'status'  => ( ! empty( $state['mapping'] ) || $context['mapping_count'] > 0 ) ? 'complete' : 'pending',
+                'message' => __( 'Associa almeno una lista Trello ai canali social.', 'fp-publisher' ),
+            );
+        }
+
+        $has_blog_settings = '' !== trim( (string) $context['blog_settings'] );
+        $blog_status = array(
+            'status'  => $has_blog_settings ? 'complete' : 'pending',
+            'message' => $has_blog_settings
+                ? __( 'Impostazioni blog presenti: puoi verificare i campi SEO nel riepilogo.', 'fp-publisher' )
+                : __( 'Compila le impostazioni blog per generare contenuti WordPress.', 'fp-publisher' ),
+        );
+
+        if ( isset( $validation_checks['blog'] ) ) {
+            foreach ( $validation_checks['blog'] as $warning ) {
+                if ( 'blocked' === $warning['status'] ) {
+                    $blog_status['status'] = 'blocked';
+                    $blog_status['message'] = $warning['message'];
+                    break;
+                }
+                if ( 'warning' === $warning['status'] && 'blocked' !== $blog_status['status'] ) {
+                    $blog_status['status'] = 'warning';
+                    $blog_status['message'] = $warning['message'];
+                }
+            }
+        }
+
+        $review_status = array(
+            'status'  => ! empty( $state['review'] ) ? 'complete' : 'pending',
+            'message' => ! empty( $state['review'] )
+                ? __( 'Riepilogo verificato: pronto alla creazione del cliente.', 'fp-publisher' )
+                : __( 'Controlla i dati raccolti e conferma per creare il cliente.', 'fp-publisher' ),
+        );
+
+        $items = array(
+            'trello'   => array(
+                'label'       => __( 'Connessione Trello', 'fp-publisher' ),
+                'description' => $trello_enabled
+                    ? __( 'Inserisci API key e token e scegli la board da monitorare.', 'fp-publisher' )
+                    : __( 'Trello è disabilitato nelle impostazioni generali.', 'fp-publisher' ),
+                'status'      => $trello_status['status'],
+                'message'     => $trello_status['message'],
+                'hints'       => isset( $validation_checks['trello'] ) ? $validation_checks['trello'] : array(),
+                'actions'     => $trello_enabled ? array(
+                    array(
+                        'label' => __( 'Gestisci integrazione Trello', 'fp-publisher' ),
+                        'url'   => admin_url( 'admin.php?page=fp-publisher-social-connections' ),
+                    ),
+                ) : array(),
+                'docs'        => array(
+                    array(
+                        'label' => __( 'Apri la Guida Quickstart', 'fp-publisher' ),
+                        'url'   => admin_url( 'admin.php?page=fp-publisher-help#quickstart' ),
+                    ),
+                ),
+            ),
+            'channels' => array(
+                'label'       => __( 'Selezione canali', 'fp-publisher' ),
+                'description' => __( 'Indica i social da collegare e verifica le app OAuth.', 'fp-publisher' ),
+                'status'      => $channel_status['status'],
+                'message'     => $channel_status['message'],
+                'hints'       => isset( $validation_checks['channels'] ) ? $validation_checks['channels'] : array(),
+                'actions'     => array(
+                    array(
+                        'label' => __( 'Apri Connessioni social', 'fp-publisher' ),
+                        'url'   => admin_url( 'admin.php?page=fp-publisher-social-connections' ),
+                    ),
+                    array(
+                        'label' => __( 'Testa le connessioni', 'fp-publisher' ),
+                        'url'   => admin_url( 'admin.php?page=fp-publisher-test-connections' ),
+                    ),
+                ),
+                'docs'        => array(
+                    array(
+                        'label' => __( 'Leggi la guida alle app social', 'fp-publisher' ),
+                        'url'   => admin_url( 'admin.php?page=fp-publisher-help#overview' ),
+                    ),
+                ),
+            ),
+            'mapping'  => array(
+                'label'       => __( 'Mappatura Trello → canali', 'fp-publisher' ),
+                'description' => __( 'Associa le liste Trello ai canali social o al blog.', 'fp-publisher' ),
+                'status'      => $mapping_status['status'],
+                'message'     => $mapping_status['message'],
+                'hints'       => isset( $validation_checks['trello'] ) ? $validation_checks['trello'] : array(),
+                'actions'     => $trello_enabled ? array(
+                    array(
+                        'label' => __( 'Apri passaggio mappatura', 'fp-publisher' ),
+                        'url'   => add_query_arg( array( 'step' => 3 ), admin_url( 'admin.php?page=fp-publisher-client-wizard' ) ),
+                    ),
+                ) : array(),
+                'docs'        => array(
+                    array(
+                        'label' => __( 'Suggerimenti di mappatura', 'fp-publisher' ),
+                        'url'   => admin_url( 'admin.php?page=fp-publisher-help#quickstart' ),
+                    ),
+                ),
+            ),
+            'blog'     => array(
+                'label'       => __( 'Impostazioni blog', 'fp-publisher' ),
+                'description' => __( 'Definisci post type, stato, SEO e categorie del blog collegato.', 'fp-publisher' ),
+                'status'      => $blog_status['status'],
+                'message'     => $blog_status['message'],
+                'hints'       => isset( $validation_checks['blog'] ) ? $validation_checks['blog'] : array(),
+                'actions'     => array(),
+                'docs'        => array(
+                    array(
+                        'label' => __( 'Configura blog & SEO', 'fp-publisher' ),
+                        'url'   => admin_url( 'admin.php?page=fp-publisher-help#blog' ),
+                    ),
+                ),
+            ),
+            'review'   => array(
+                'label'       => __( 'Riepilogo finale', 'fp-publisher' ),
+                'description' => __( 'Conferma i dati e crea il cliente pronto alla pubblicazione.', 'fp-publisher' ),
+                'status'      => $review_status['status'],
+                'message'     => $review_status['message'],
+                'hints'       => array(),
+                'actions'     => array(),
+                'docs'        => array(
+                    array(
+                        'label' => __( 'Controlla la checklist finale', 'fp-publisher' ),
+                        'url'   => admin_url( 'admin.php?page=fp-publisher-help#quickstart' ),
+                    ),
+                ),
+            ),
+        );
+
+        $status_icons = array(
+            'complete' => '✅',
+            'pending'  => '⬜',
+            'warning'  => '⚠️',
+            'blocked'  => '❌',
+            'skipped'  => '➖',
+        );
+
+        $progress_items = array_filter(
+            $items,
+            static function ( $item ) {
+                return 'skipped' !== $item['status'];
+            }
+        );
+        $total_steps     = count( $progress_items );
+        $completed_steps = count(
+            array_filter(
+                $progress_items,
+                static function ( $item ) {
+                    return 'complete' === $item['status'];
+                }
+            )
+        );
+        $progress_percent = $total_steps > 0 ? round( ( $completed_steps / $total_steps ) * 100 ) : 0;
+
+        echo '<div class="tts-wizard-checklist">';
+        echo '<h2>' . esc_html__( 'Checklist onboarding', 'fp-publisher' ) . '</h2>';
+        echo '<p class="tts-checklist-progress">' . esc_html( sprintf( __( 'Avanzamento: %1$s di %2$s passaggi completati (%3$s%%).', 'fp-publisher' ), $completed_steps, $total_steps, $progress_percent ) ) . '</p>';
+
+        if ( ! empty( $prefill['label'] ) ) {
+            echo '<p class="tts-checklist-prefill">' . sprintf(
+                /* translators: %s: quickstart package label. */
+                esc_html__( 'Preset attivo: %s', 'fp-publisher' ),
+                '<strong>' . esc_html( $prefill['label'] ) . '</strong>'
+            ) . '</p>';
+        }
+
+        echo '<ul class="tts-checklist-items">';
+        foreach ( $items as $key => $item ) {
+            $status = $item['status'];
+            $icon   = isset( $status_icons[ $status ] ) ? $status_icons[ $status ] : '⬜';
+            $classes = array( 'tts-checklist-item', 'status-' . $status );
+            if ( 'complete' === $status ) {
+                $classes[] = 'is-complete';
+            }
+
+            echo '<li class="' . esc_attr( implode( ' ', $classes ) ) . '">';
+            echo '<span class="tts-checklist-icon">' . esc_html( $icon ) . '</span>';
+            echo '<span class="tts-checklist-content">';
+            echo '<strong>' . esc_html( $item['label'] ) . '</strong>';
+            echo '<span class="tts-checklist-description">' . esc_html( $item['description'] ) . '</span>';
+            if ( '' !== $item['message'] ) {
+                echo '<span class="tts-checklist-message">' . esc_html( $item['message'] ) . '</span>';
+            }
+
+            if ( ! empty( $item['hints'] ) ) {
+                echo '<ul class="tts-checklist-hints">';
+                foreach ( $item['hints'] as $hint ) {
+                    $hint_status = isset( $hint['status'] ) && isset( $status_icons[ $hint['status'] ] ) ? $status_icons[ $hint['status'] ] : '•';
+                    $hint_label  = isset( $hint['label'] ) ? $hint['label'] : '';
+                    $hint_msg    = isset( $hint['message'] ) ? $hint['message'] : '';
+                    echo '<li>';
+                    echo '<span class="tts-checklist-hint-icon">' . esc_html( $hint_status ) . '</span>';
+                    echo '<span class="tts-checklist-hint-text">';
+                    if ( '' !== $hint_label ) {
+                        echo '<strong>' . esc_html( $hint_label ) . '</strong> ';
+                    }
+                    if ( '' !== $hint_msg ) {
+                        echo esc_html( $hint_msg );
+                    }
+                    echo '</span>';
+                    echo '</li>';
+                }
+                echo '</ul>';
+            }
+
+            if ( ! empty( $item['actions'] ) ) {
+                echo '<div class="tts-checklist-links">';
+                foreach ( $item['actions'] as $action ) {
+                    $label = isset( $action['label'] ) ? $action['label'] : '';
+                    $url   = isset( $action['url'] ) ? $action['url'] : '';
+                    if ( '' === $label || '' === $url ) {
+                        continue;
+                    }
+                    echo '<a class="button button-secondary" href="' . esc_url( $url ) . '">' . esc_html( $label ) . '</a> ';
+                }
+                echo '</div>';
+            }
+
+            if ( ! empty( $item['docs'] ) ) {
+                echo '<div class="tts-checklist-links tts-checklist-docs">';
+                foreach ( $item['docs'] as $doc ) {
+                    $doc_label = isset( $doc['label'] ) ? $doc['label'] : '';
+                    $doc_url   = isset( $doc['url'] ) ? $doc['url'] : '';
+                    if ( '' === $doc_label || '' === $doc_url ) {
+                        continue;
+                    }
+                    echo '<a class="button-link" href="' . esc_url( $doc_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $doc_label ) . '</a>';
+                }
+                echo '</div>';
+            }
+
+            echo '</span>';
+            echo '</li>';
+        }
+        echo '</ul>';
+
+        echo '<form method="post" class="tts-checklist-actions">';
+        wp_nonce_field( 'tts_reset_wizard', 'tts_reset_wizard_nonce' );
+        echo '<input type="hidden" name="tts_reset_wizard_progress" value="1" />';
+        echo '<button type="submit" class="button">' . esc_html__( 'Azzera checklist', 'fp-publisher' ) . '</button>';
+        echo '</form>';
+
+        if ( $validation_summary ) {
+            echo '<p class="tts-validation-summary">' . esc_html( $validation_summary ) . '</p>';
+        }
+
+        if ( ! empty( $prefill['trello_guidelines'] ) && is_array( $prefill['trello_guidelines'] ) ) {
+            echo '<div class="tts-checklist-guidelines">';
+            echo '<strong>' . esc_html__( 'Suggerimenti dal pacchetto selezionato', 'fp-publisher' ) . '</strong>';
+            echo '<ul>';
+            foreach ( $prefill['trello_guidelines'] as $guideline ) {
+                echo '<li>' . esc_html( $guideline ) . '</li>';
+            }
+            echo '</ul>';
+            echo '</div>';
+        }
+
+        echo '</div>';
+    }
+    /**
+     * Render the client wizard page.
      */
     public function tts_render_client_wizard() {
         if ( ! session_id() ) {
@@ -2280,19 +4073,6 @@ class TTS_Admin {
             } elseif ( 3 === $step ) {
                 $step = 4;
             }
-        }
-
-        echo '<div class="wrap tts-client-wizard">';
-        echo '<h1>' . esc_html__( 'Client Wizard', 'fp-publisher' ) . '</h1>';
-
-        // Add helpful notice about social media setup
-        if ( 2 === $step ) {
-            echo '<div class="notice notice-info">';
-            echo '<h3>' . esc_html__( 'Social Media Setup Required', 'fp-publisher' ) . '</h3>';
-            echo '<p>' . esc_html__( 'To connect social media accounts, you must first configure OAuth apps for each platform. Click "Configure App" for platforms that are not set up.', 'fp-publisher' ) . '</p>';
-            echo '<p><a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-social-connections' ) ) . '" class="button">' . esc_html__( 'Manage Social Connections', 'fp-publisher' ) . '</a> ';
-            echo '<a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-help' ) ) . '" target="_blank">' . esc_html__( 'View Setup Guide', 'fp-publisher' ) . '</a></p>';
-            echo '</div>';
         }
 
         $fb_token = get_transient( 'tts_oauth_facebook_token' );
@@ -2341,6 +4121,74 @@ class TTS_Admin {
         }
         $client_name = trim( $client_name );
 
+        if ( isset( $_POST['blog_settings'] ) ) {
+            $blog_settings = sanitize_textarea_field( wp_unslash( $_POST['blog_settings'] ) );
+        } elseif ( isset( $_GET['blog_settings'] ) ) {
+            $blog_settings = sanitize_textarea_field( wp_unslash( $_GET['blog_settings'] ) );
+        } else {
+            $blog_settings = '';
+        }
+
+        $checklist_notice = '';
+        if ( isset( $_POST['tts_reset_wizard_progress'] ) ) {
+            if ( isset( $_POST['tts_reset_wizard_nonce'] ) && wp_verify_nonce( wp_unslash( $_POST['tts_reset_wizard_nonce'] ), 'tts_reset_wizard' ) ) {
+                unset( $_SESSION['tts_wizard_progress'] );
+                $checklist_notice = __( 'Checklist ripristinata.', 'fp-publisher' );
+            }
+        }
+
+        $prefill = isset( $_SESSION['tts_quickstart_prefill'] ) ? $_SESSION['tts_quickstart_prefill'] : array();
+
+        if ( empty( $channels ) && ! empty( $prefill['channels'] ) && is_array( $prefill['channels'] ) ) {
+            $channels = array_map( 'sanitize_text_field', $prefill['channels'] );
+        }
+
+        if ( '' === $blog_settings && ! empty( $prefill['blog_settings'] ) ) {
+            $blog_settings = $prefill['blog_settings'];
+        }
+
+        $wizard_progress = isset( $_SESSION['tts_wizard_progress'] ) ? (array) $_SESSION['tts_wizard_progress'] : array(
+            'trello'   => false,
+            'channels' => false,
+            'mapping'  => false,
+            'blog'     => false,
+            'review'   => false,
+        );
+
+        if ( ! $trello_enabled || ( $trello_key && $trello_token && $board ) ) {
+            $wizard_progress['trello'] = true;
+        }
+
+        if ( ! empty( $channels ) ) {
+            $wizard_progress['channels'] = true;
+        }
+
+        if ( '' !== trim( $blog_settings ) ) {
+            $wizard_progress['blog'] = true;
+        }
+
+        $mapping_count = 0;
+        if ( isset( $_POST['tts_trello_map'] ) && is_array( $_POST['tts_trello_map'] ) ) {
+            foreach ( $_POST['tts_trello_map'] as $row ) {
+                if ( ! empty( $row['canale_social'] ) ) {
+                    $mapping_count++;
+                }
+            }
+        } elseif ( isset( $wizard_progress['mapping_count'] ) ) {
+            $mapping_count = (int) $wizard_progress['mapping_count'];
+        }
+
+        if ( ! $trello_enabled || $mapping_count > 0 ) {
+            $wizard_progress['mapping'] = true;
+        }
+
+        if ( isset( $_POST['finalize'] ) ) {
+            $wizard_progress['review'] = true;
+        }
+
+        $wizard_progress['mapping_count'] = $mapping_count;
+        $_SESSION['tts_wizard_progress'] = $wizard_progress;
+
         $client_name_error = '';
         $required_step     = $trello_enabled ? 3 : 4;
         if ( $post_step >= $required_step && '' === $client_name ) {
@@ -2348,15 +4196,82 @@ class TTS_Admin {
             $step              = 2;
         }
 
+        $wizard_context = array(
+            'trello_key'      => $trello_key,
+            'trello_token'    => $trello_token,
+            'trello_board'    => $board,
+            'channels'        => $channels,
+            'blog_settings'   => $blog_settings,
+            'tokens'          => array(
+                'facebook'  => $fb_token,
+                'instagram' => $ig_token,
+                'youtube'   => $yt_token,
+                'tiktok'    => $tt_token,
+            ),
+            'mapping_count'   => $mapping_count,
+            'prefill_package' => isset( $prefill['label'] ) ? $prefill['label'] : '',
+            'validation'      => isset( $prefill['validation'] ) ? $prefill['validation'] : array(),
+            'usage_profile'   => $this->get_usage_profile(),
+        );
+
+        echo '<div class="wrap tts-client-wizard">';
+        echo '<h1>' . esc_html__( 'Client Wizard', 'fp-publisher' ) . '</h1>';
+        echo '<style>'
+            . '.tts-wizard-checklist{background:#fff;border:1px solid #dcdcde;border-radius:8px;padding:20px;margin-bottom:20px;}'
+            . '.tts-checklist-progress{font-weight:600;margin-bottom:8px;color:#1d2327;}'
+            . '.tts-checklist-prefill{margin-bottom:8px;color:#005ae0;}'
+            . '.tts-checklist-items{list-style:none;margin:0;padding:0;}'
+            . '.tts-checklist-item{display:flex;gap:12px;border-top:1px solid #ececec;padding:12px 0;}'
+            . '.tts-checklist-item:first-child{border-top:0;padding-top:0;}'
+            . '.tts-checklist-icon{font-size:20px;line-height:1;}'
+            . '.tts-checklist-content strong{display:block;font-size:15px;margin-bottom:2px;}'
+            . '.tts-checklist-description{display:block;color:#50575e;font-size:13px;margin-bottom:4px;}'
+            . '.tts-checklist-message{display:block;color:#1d2327;font-size:13px;margin-bottom:4px;}'
+            . '.tts-checklist-hints{list-style:none;margin:6px 0 0;padding:0;}'
+            . '.tts-checklist-hints li{display:flex;gap:6px;font-size:12px;color:#50575e;margin-bottom:4px;}'
+            . '.tts-checklist-hint-icon{font-size:14px;line-height:1.2;}'
+            . '.tts-checklist-links{margin-top:8px;display:flex;flex-wrap:wrap;gap:8px;}'
+            . '.tts-checklist-docs a{font-size:12px;color:#2271b1;}'
+            . '.tts-checklist-actions{margin-top:12px;}'
+            . '.tts-inline-actions{margin:0 0 8px;}'
+            . '.tts-validate-result,.tts-token-result{margin-bottom:12px;font-size:13px;}'
+            . '.tts-validate-result.success,.tts-token-result.success{color:#007017;}'
+            . '.tts-validate-result.error,.tts-token-result.error{color:#b52738;}'
+            . '.tts-validation-summary{margin-top:12px;font-size:13px;color:#1d2327;}'
+            . '</style>';
+
+        if ( $checklist_notice ) {
+            echo '<div class="notice notice-info"><p>' . esc_html( $checklist_notice ) . '</p></div>';
+        }
+
+        $this->render_client_wizard_checklist( $wizard_progress, $step, $prefill, $trello_enabled, $wizard_context );
+
+        // Add helpful notice about social media setup.
+        if ( 2 === $step ) {
+            echo '<div class="notice notice-info">';
+            echo '<h3>' . esc_html__( 'Social Media Setup Required', 'fp-publisher' ) . '</h3>';
+            echo '<p>' . esc_html__( 'To connect social media accounts, you must first configure OAuth apps for each platform. Click "Configure App" for platforms that are not set up.', 'fp-publisher' ) . '</p>';
+            echo '<p><a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-social-connections' ) ) . '" class="button">' . esc_html__( 'Manage Social Connections', 'fp-publisher' ) . '</a> ';
+            echo '<a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-help' ) ) . '" target="_blank">' . esc_html__( 'View Setup Guide', 'fp-publisher' ) . '</a></p>';
+            echo '</div>';
+        }
+
         if ( $trello_enabled && 1 === $step ) {
             echo '<form method="post" class="tts-wizard-step tts-step-1">';
             wp_nonce_field( 'tts_client_wizard', 'tts_wizard_nonce' );
             echo '<input type="hidden" name="step" value="2" />';
             echo '<input type="hidden" name="client_name" value="' . esc_attr( $client_name ) . '" />';
+            echo '<input type="hidden" name="blog_settings" value="' . esc_attr( $blog_settings ) . '" />';
             echo '<p><label>' . esc_html__( 'Trello API Key', 'fp-publisher' ) . '<br />';
             echo '<input type="text" name="trello_key" value="' . esc_attr( $trello_key ) . '"' . ( $trello_enabled ? ' required' : '' ) . ' /></label></p>';
             echo '<p><label>' . esc_html__( 'Trello Token', 'fp-publisher' ) . '<br />';
             echo '<input type="text" name="trello_token" value="' . esc_attr( $trello_token ) . '"' . ( $trello_enabled ? ' required' : '' ) . ' /></label></p>';
+
+            echo '<p class="tts-inline-actions">';
+            echo '<button type="button" class="button tts-validate-trello" data-nonce="' . esc_attr( wp_create_nonce( 'tts_wizard' ) ) . '">'
+                . esc_html__( 'Verifica credenziali Trello', 'fp-publisher' ) . '</button>';
+            echo '</p>';
+            echo '<div class="tts-validate-result" aria-live="polite"></div>';
 
             $boards = array();
             if ( $trello_key && $trello_token ) {
@@ -2397,12 +4312,19 @@ class TTS_Admin {
             echo '<p><label>' . esc_html__( 'Client Name', 'fp-publisher' ) . '<br />';
             echo '<input type="text" name="client_name" value="' . esc_attr( $client_name ) . '" required /></label></p>';
 
+            echo '<p><label>' . esc_html__( 'Impostazioni blog', 'fp-publisher' ) . '<br />';
+            echo '<textarea name="blog_settings" class="widefat" rows="3" placeholder="post_type:post|post_status:draft|author_id:1|category_id:1">' . esc_textarea( $blog_settings ) . '</textarea>';
+            echo '<span class="description">' . esc_html__( 'Inserisci parametri separati da | per post_type, stato, autore, categorie e SEO.', 'fp-publisher' ) . '</span>';
+            echo '</label></p>';
+
             $opts = array(
                 'facebook'  => __( 'Facebook', 'fp-publisher' ),
                 'instagram' => __( 'Instagram', 'fp-publisher' ),
                 'youtube'   => __( 'YouTube', 'fp-publisher' ),
                 'tiktok'    => __( 'TikTok', 'fp-publisher' ),
             );
+
+            $wizard_nonce = wp_create_nonce( 'tts_wizard' );
 
             foreach ( $opts as $slug => $label ) {
                 $token     = '';
@@ -2444,11 +4366,13 @@ class TTS_Admin {
                     echo '<br><a href="' . esc_url( admin_url( 'admin.php?page=fp-publisher-social-connections' ) ) . '" class="button">' . esc_html__( 'Configure App', 'fp-publisher' ) . '</a>';
                 } elseif ( $connected ) {
                     echo '<br><span style="color: #00a32a;">✅ ' . esc_html__( 'Connected', 'fp-publisher' ) . '</span>';
+                    echo '<br><button type="button" class="button button-secondary tts-test-token" data-platform="' . esc_attr( $slug ) . '" data-nonce="' . esc_attr( $wizard_nonce ) . '">' . esc_html__( 'Test token', 'fp-publisher' ) . '</button>';
                 } else {
                     $url = add_query_arg( array( 'action' => 'tts_oauth_' . $slug, 'step' => 2 ), admin_url( 'admin-post.php' ) );
                     echo '<br><span style="color: #f56e28;">🟡 ' . esc_html__( 'Ready to connect', 'fp-publisher' ) . '</span>';
                     echo '<br><a href="' . esc_url( $url ) . '" class="button button-primary">' . esc_html__( 'Connect Account', 'fp-publisher' ) . '</a>';
                 }
+                echo '<div class="tts-token-result" data-platform="' . esc_attr( $slug ) . '" aria-live="polite"></div>';
                 echo '</div>';
             }
 
@@ -2472,6 +4396,7 @@ class TTS_Admin {
             echo '<input type="hidden" name="trello_token" value="' . esc_attr( $trello_token ) . '" />';
             echo '<input type="hidden" name="trello_board" value="' . esc_attr( $board ) . '" />';
             echo '<input type="hidden" name="client_name" value="' . esc_attr( $client_name ) . '" />';
+            echo '<input type="hidden" name="blog_settings" value="' . esc_attr( $blog_settings ) . '" />';
             foreach ( $channels as $ch ) {
                 echo '<input type="hidden" name="channels[]" value="' . esc_attr( $ch ) . '" />';
             }
@@ -2507,6 +4432,9 @@ class TTS_Admin {
                     if ( $tt_token ) {
                         update_post_meta( $post_id, '_tts_tt_token', $tt_token );
                     }
+                    if ( '' !== $blog_settings ) {
+                        update_post_meta( $post_id, '_tts_blog_settings', $blog_settings );
+                    }
                     if ( $trello_enabled && isset( $_POST['tts_trello_map'] ) && is_array( $_POST['tts_trello_map'] ) ) {
                         $map = array();
                         foreach ( $_POST['tts_trello_map'] as $id_list => $row ) {
@@ -2527,6 +4455,12 @@ class TTS_Admin {
                     delete_transient( 'tts_oauth_instagram_token' );
                     delete_transient( 'tts_oauth_youtube_token' );
                     delete_transient( 'tts_oauth_tiktok_token' );
+
+                    $_SESSION['tts_wizard_progress']['trello']   = true;
+                    $_SESSION['tts_wizard_progress']['channels'] = true;
+                    $_SESSION['tts_wizard_progress']['mapping']  = true;
+                    $_SESSION['tts_wizard_progress']['blog']     = '' !== $blog_settings;
+                    $_SESSION['tts_wizard_progress']['review']   = true;
 
                     echo '<p>' . esc_html__( 'Client created.', 'fp-publisher' ) . '</p>';
                 }
@@ -2552,6 +4486,7 @@ class TTS_Admin {
             echo '<input type="hidden" name="trello_token" value="' . esc_attr( $trello_token ) . '" />';
             echo '<input type="hidden" name="trello_board" value="' . esc_attr( $board ) . '" />';
             echo '<input type="hidden" name="client_name" value="' . esc_attr( $client_name ) . '" />';
+            echo '<input type="hidden" name="blog_settings" value="' . esc_attr( $blog_settings ) . '" />';
             foreach ( $channels as $ch ) {
                 echo '<input type="hidden" name="channels[]" value="' . esc_attr( $ch ) . '" />';
             }
@@ -2563,6 +4498,10 @@ class TTS_Admin {
 
             echo '<h2>' . esc_html__( 'Summary', 'fp-publisher' ) . '</h2>';
             echo '<p>' . esc_html__( 'Client Name:', 'fp-publisher' ) . ' ' . esc_html( $client_name ? $client_name : __( 'Client', 'fp-publisher' ) ) . '</p>';
+
+            if ( '' !== $blog_settings ) {
+                echo '<p><strong>' . esc_html__( 'Impostazioni blog', 'fp-publisher' ) . ':</strong><br><code>' . esc_html( $blog_settings ) . '</code></p>';
+            }
             if ( $trello_enabled && $board ) {
                 echo '<p>' . esc_html__( 'Trello Board:', 'fp-publisher' ) . ' ' . esc_html( $board ) . '</p>';
             }
@@ -2572,6 +4511,82 @@ class TTS_Admin {
         }
 
         echo '</div>';
+
+        $ajax_url = admin_url( 'admin-ajax.php' );
+        ob_start();
+        ?>
+        <script>
+        jQuery(function($){
+            var ajaxUrl = <?php echo wp_json_encode( $ajax_url ); ?>;
+
+            $(document).on('click', '.tts-validate-trello', function(e){
+                e.preventDefault();
+                var $btn = $(this);
+                var nonce = $btn.data('nonce');
+                var $form = $btn.closest('form');
+                var apiKey = $form.find('input[name="trello_key"]').val();
+                var token = $form.find('input[name="trello_token"]').val();
+                var $output = $form.find('.tts-validate-result');
+
+                $output.removeClass('success error').text(<?php echo wp_json_encode( __( 'Verifica in corso…', 'fp-publisher' ) ); ?>);
+                $btn.prop('disabled', true);
+
+                $.post(ajaxUrl, {
+                    action: 'tts_validate_trello_credentials',
+                    nonce: nonce,
+                    api_key: apiKey,
+                    token: token
+                }).done(function(response){
+                    if (response && response.success && response.data) {
+                        var statusClass = response.data.success ? 'success' : 'error';
+                        var message = response.data.message || <?php echo wp_json_encode( __( 'Risposta non disponibile.', 'fp-publisher' ) ); ?>;
+                        $output.removeClass('success error').addClass(statusClass).text(message);
+                    } else {
+                        $output.removeClass('success').addClass('error').text(<?php echo wp_json_encode( __( 'Impossibile validare le credenziali.', 'fp-publisher' ) ); ?>);
+                    }
+                }).fail(function(){
+                    $output.removeClass('success').addClass('error').text(<?php echo wp_json_encode( __( 'Errore di comunicazione con il server.', 'fp-publisher' ) ); ?>);
+                }).always(function(){
+                    $btn.prop('disabled', false);
+                });
+            });
+
+            $(document).on('click', '.tts-test-token', function(e){
+                e.preventDefault();
+                var $btn = $(this);
+                var platform = $btn.data('platform');
+                var nonce = $btn.data('nonce');
+                var $output = $btn.closest('div').find('.tts-token-result[data-platform="' + platform + '"]');
+
+                if (!$output.length) {
+                    return;
+                }
+
+                $output.removeClass('success error').text(<?php echo wp_json_encode( __( 'Verifica in corso…', 'fp-publisher' ) ); ?>);
+                $btn.prop('disabled', true);
+
+                $.post(ajaxUrl, {
+                    action: 'tts_test_wizard_token',
+                    nonce: nonce,
+                    platform: platform
+                }).done(function(response){
+                    if (response && response.success && response.data) {
+                        var statusClass = response.data.success ? 'success' : 'error';
+                        var message = response.data.message || <?php echo wp_json_encode( __( 'Risposta non disponibile.', 'fp-publisher' ) ); ?>;
+                        $output.removeClass('success error').addClass(statusClass).text(message);
+                    } else {
+                        $output.removeClass('success').addClass('error').text(<?php echo wp_json_encode( __( 'Impossibile testare il token.', 'fp-publisher' ) ); ?>);
+                    }
+                }).fail(function(){
+                    $output.removeClass('success').addClass('error').text(<?php echo wp_json_encode( __( 'Errore di comunicazione con il server.', 'fp-publisher' ) ); ?>);
+                }).always(function(){
+                    $btn.prop('disabled', false);
+                });
+            });
+        });
+        </script>
+        <?php
+        echo ob_get_clean();
     }
 
     /**
@@ -4494,16 +6509,21 @@ class TTS_Admin {
                     <h3><?php esc_html_e( 'Quick Links', 'fp-publisher' ); ?></h3>
                     <ul>
                         <li><a href="#overview"><?php esc_html_e( 'Overview', 'fp-publisher' ); ?></a></li>
+                        <li><a href="#quickstart"><?php esc_html_e( 'Quickstart Packages', 'fp-publisher' ); ?></a></li>
+                        <li><a href="#blog"><?php esc_html_e( 'Blog & SEO', 'fp-publisher' ); ?></a></li>
                         <li><a href="#facebook"><?php esc_html_e( 'Facebook Setup', 'fp-publisher' ); ?></a></li>
                         <li><a href="#instagram"><?php esc_html_e( 'Instagram Setup', 'fp-publisher' ); ?></a></li>
                         <li><a href="#youtube"><?php esc_html_e( 'YouTube Setup', 'fp-publisher' ); ?></a></li>
                         <li><a href="#tiktok"><?php esc_html_e( 'TikTok Setup', 'fp-publisher' ); ?></a></li>
                         <li><a href="#troubleshooting"><?php esc_html_e( 'Troubleshooting', 'fp-publisher' ); ?></a></li>
                     </ul>
-                    
+
                     <div class="tts-help-actions">
                         <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-publisher-social-connections' ) ); ?>" class="button button-primary">
                             <?php esc_html_e( 'Configure Social Apps', 'fp-publisher' ); ?>
+                        </a>
+                        <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-publisher-quickstart' ) ); ?>" class="button">
+                            <?php esc_html_e( 'Manage Quickstart Packages', 'fp-publisher' ); ?>
                         </a>
                         <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-publisher-client-wizard' ) ); ?>" class="button">
                             <?php esc_html_e( 'Create Client', 'fp-publisher' ); ?>
@@ -4525,6 +6545,28 @@ class TTS_Admin {
                         <div class="tts-notice-warning">
                             <p><strong><?php esc_html_e( 'Important:', 'fp-publisher' ); ?></strong> <?php esc_html_e( 'Each social media platform requires you to create a developer application. This is a one-time setup per platform.', 'fp-publisher' ); ?></p>
                         </div>
+                    </section>
+
+                    <section id="quickstart">
+                        <h2><?php esc_html_e( '⚙️ Quickstart Packages', 'fp-publisher' ); ?></h2>
+                        <p><?php esc_html_e( 'Use curated presets to prefill the Client Wizard with Trello mappings, social templates and UTM parameters.', 'fp-publisher' ); ?></p>
+                        <ol>
+                            <li><?php esc_html_e( 'Open Clients → Quickstart Packages and choose the preset that matches your active usage profile.', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Click “Anteprima modifiche” to review mapping, template and UTM overrides before applying the preset.', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Resolve any blocked requirements highlighted in the readiness checklist, then apply the package.', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Launch the Client Wizard: the onboarding checklist will reuse the validation results and link back to this guide.', 'fp-publisher' ); ?></li>
+                        </ol>
+                        <p><?php esc_html_e( 'Tip: adjust the usage profile (Standard, Advanced, Enterprise) from Settings → Modalità di utilizzo to surface only the tools your team needs.', 'fp-publisher' ); ?></p>
+                    </section>
+
+                    <section id="blog">
+                        <h2><?php esc_html_e( '📝 Blog & SEO', 'fp-publisher' ); ?></h2>
+                        <p><?php esc_html_e( 'The blog prefill string accepts pipe-separated parameters such as post_type, post_status, author_id, language and SEO metadata.', 'fp-publisher' ); ?></p>
+                        <ul>
+                            <li><?php esc_html_e( 'Use the Quickstart preview to confirm how blog settings will be prefilled in the Client Wizard.', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'Populate seo_title, meta_description and canonical_url to align WordPress articles with your editorial strategy.', 'fp-publisher' ); ?></li>
+                            <li><?php esc_html_e( 'For multilingual setups include the language parameter and ensure WPML integration is configured in the publisher.', 'fp-publisher' ); ?></li>
+                        </ul>
                     </section>
 
                     <section id="facebook">
@@ -6659,6 +8701,136 @@ class TTS_Admin {
         );
 
         return wp_send_json_success( $sanitized_response );
+    }
+
+    /**
+     * AJAX handler to validate Trello credentials from the wizard.
+     */
+    public function ajax_validate_trello_credentials() {
+        if ( ! $this->enforce_ajax_security( __FUNCTION__ ) ) {
+            return;
+        }
+
+        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+        if ( ! wp_verify_nonce( $nonce, 'tts_wizard' ) ) {
+            return wp_send_json_error( __( 'Security check failed.', 'fp-publisher' ), 403 );
+        }
+
+        $api_key = isset( $_POST['api_key'] ) ? sanitize_text_field( wp_unslash( $_POST['api_key'] ) ) : '';
+        $token   = isset( $_POST['token'] ) ? sanitize_text_field( wp_unslash( $_POST['token'] ) ) : '';
+
+        if ( '' === $api_key || '' === $token ) {
+            return wp_send_json_success(
+                array(
+                    'success' => false,
+                    'message' => __( 'Fornisci sia API key che token Trello.', 'fp-publisher' ),
+                )
+            );
+        }
+
+        $result  = $this->test_trello_connection( $api_key, $token );
+        $success = ! empty( $result['success'] );
+        $message = isset( $result['message'] ) ? sanitize_text_field( $result['message'] ) : '';
+
+        if ( '' === $message ) {
+            $message = $success
+                ? __( 'Credenziali verificate con successo.', 'fp-publisher' )
+                : __( 'Credenziali non valide. Ricontrolla key e token.', 'fp-publisher' );
+        }
+
+        return wp_send_json_success(
+            array(
+                'success' => $success,
+                'message' => $message,
+            )
+        );
+    }
+
+    /**
+     * AJAX handler to test OAuth tokens captured during the wizard flow.
+     */
+    public function ajax_test_wizard_token() {
+        if ( ! $this->enforce_ajax_security( __FUNCTION__ ) ) {
+            return;
+        }
+
+        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+        if ( ! wp_verify_nonce( $nonce, 'tts_wizard' ) ) {
+            return wp_send_json_error( __( 'Security check failed.', 'fp-publisher' ), 403 );
+        }
+
+        $platform = isset( $_POST['platform'] ) ? sanitize_key( wp_unslash( $_POST['platform'] ) ) : '';
+        if ( '' === $platform ) {
+            return wp_send_json_success(
+                array(
+                    'success' => false,
+                    'message' => __( 'Piattaforma non valida.', 'fp-publisher' ),
+                )
+            );
+        }
+
+        $transient_map = array(
+            'facebook'  => 'tts_oauth_facebook_token',
+            'instagram' => 'tts_oauth_instagram_token',
+            'youtube'   => 'tts_oauth_youtube_token',
+            'tiktok'    => 'tts_oauth_tiktok_token',
+        );
+
+        if ( ! isset( $transient_map[ $platform ] ) ) {
+            return wp_send_json_success(
+                array(
+                    'success' => false,
+                    'message' => __( 'Piattaforma non supportata.', 'fp-publisher' ),
+                )
+            );
+        }
+
+        $token = get_transient( $transient_map[ $platform ] );
+        if ( '' === trim( (string) $token ) ) {
+            return wp_send_json_success(
+                array(
+                    'success' => false,
+                    'message' => __( 'Completa prima la procedura OAuth per questo canale.', 'fp-publisher' ),
+                )
+            );
+        }
+
+        switch ( $platform ) {
+            case 'facebook':
+                $result = $this->test_facebook_client_connection( $token );
+                break;
+            case 'instagram':
+                $result = $this->test_instagram_client_connection( $token );
+                break;
+            case 'youtube':
+                $result = $this->test_youtube_client_connection( $token );
+                break;
+            case 'tiktok':
+                $result = $this->test_tiktok_client_connection( $token );
+                break;
+            default:
+                $result = array(
+                    'success' => false,
+                    'message' => __( 'Piattaforma non supportata.', 'fp-publisher' ),
+                );
+                break;
+        }
+
+        $success = ! empty( $result['success'] );
+        $message = isset( $result['message'] ) ? sanitize_text_field( $result['message'] ) : '';
+
+        if ( '' === $message ) {
+            $message = $success
+                ? __( 'Token valido.', 'fp-publisher' )
+                : __( 'Token non valido o senza permessi sufficienti.', 'fp-publisher' );
+        }
+
+        return wp_send_json_success(
+            array(
+                'success' => $success,
+                'message' => $message,
+            )
+        );
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/admin/css/tts-dashboard.css
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/css/tts-dashboard.css
@@ -198,6 +198,108 @@
     border-bottom: none;
 }
 
+/* Actionable health summary */
+.tts-actionable-summary {
+    margin-top: 20px;
+    padding: 16px;
+    background: #f6f7f7;
+    border-radius: 8px;
+    border-left: 4px solid #135e96;
+}
+
+.tts-actionable-summary--compact {
+    margin-top: 12px;
+    padding: 12px;
+    background: #ffffff;
+    border-left-color: #00a32a;
+    box-shadow: inset 0 0 0 1px #dcdcde;
+}
+
+.tts-actionable-summary h4 {
+    margin: 0 0 12px 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.tts-actionable-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.tts-actionable-item {
+    background: #ffffff;
+    border-radius: 6px;
+    border: 1px solid #dcdcde;
+    padding: 12px 14px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.tts-actionable-summary--compact .tts-actionable-item {
+    border: none;
+    box-shadow: none;
+    background: transparent;
+    padding: 8px 0;
+}
+
+.tts-status-critical {
+    border-left: 4px solid #d63638;
+}
+
+.tts-status-warning {
+    border-left: 4px solid #f56e28;
+}
+
+.tts-status-ok {
+    border-left: 4px solid #00a32a;
+}
+
+.tts-actionable-item-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.tts-actionable-icon {
+    font-size: 20px;
+    line-height: 1;
+}
+
+.tts-actionable-count {
+    background: #1d2327;
+    color: #ffffff;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.tts-actionable-copy {
+    flex: 1;
+}
+
+.tts-actionable-copy p {
+    margin: 4px 0 0 0;
+    font-size: 13px;
+    color: #50575e;
+}
+
+.tts-actionable-actions {
+    margin: 8px 0 0 34px;
+    padding: 0;
+    list-style: disc;
+    color: #3c434a;
+    font-size: 13px;
+}
+
+.tts-actionable-actions li {
+    margin: 4px 0;
+}
+
 .tts-timeline-icon {
     font-size: 16px;
     width: 20px;

--- a/wp-content/plugins/trello-social-auto-publisher/assets/quickstart/editorial-suite.json
+++ b/wp-content/plugins/trello-social-auto-publisher/assets/quickstart/editorial-suite.json
@@ -1,0 +1,38 @@
+{
+  "name": "FP Publisher - Editorial Suite",
+  "description": "Board di riferimento per il pacchetto Quickstart 'Editorial Suite'. Pensata per team editoriali multi-canale.",
+  "labels": [
+    { "name": "Facebook", "color": "blue" },
+    { "name": "Instagram", "color": "purple" },
+    { "name": "YouTube", "color": "red" },
+    { "name": "TikTok", "color": "pink" },
+    { "name": "Blog", "color": "orange" }
+  ],
+  "lists": [
+    { "name": "Briefing", "pos": 100 },
+    { "name": "Produzione", "pos": 200 },
+    { "name": "Revisione", "pos": 300 },
+    { "name": "Pronto Social", "pos": 400 },
+    { "name": "Pubblicato", "pos": 500 },
+    { "name": "Archivio", "pos": 600 }
+  ],
+  "example_cards": [
+    {
+      "name": "Campagna lancio prodotto",
+      "desc": "Card modello con checklist per asset lunghi (blog, video) e short-form.",
+      "labels": ["Facebook", "Instagram", "YouTube", "TikTok", "Blog"],
+      "checklist": [
+        "Script video approvato",
+        "Copertine e grafiche caricate",
+        "SEO e metadata verificati",
+        "Pianificazione completata in FP Publisher"
+      ],
+      "list": "Briefing"
+    }
+  ],
+  "guidelines": [
+    "Usa le checklist per coordinare copywriter, video editor e social media manager",
+    "Aggiorna la data di pubblicazione nelle custom field Trello e nel calendario di FP Publisher",
+    "Duplica la card per ogni episodio o rubrica ricorrente"
+  ]
+}

--- a/wp-content/plugins/trello-social-auto-publisher/assets/quickstart/enterprise-control.json
+++ b/wp-content/plugins/trello-social-auto-publisher/assets/quickstart/enterprise-control.json
@@ -1,0 +1,37 @@
+{
+  "name": "FP Publisher - Enterprise Control",
+  "description": "Template Trello pensato per il pacchetto Quickstart 'Enterprise Control' con focus su audit e compliance.",
+  "labels": [
+    { "name": "Legale", "color": "yellow" },
+    { "name": "Compliance", "color": "orange" },
+    { "name": "Sicurezza", "color": "red" },
+    { "name": "Social", "color": "blue" }
+  ],
+  "lists": [
+    { "name": "Intake", "pos": 100 },
+    { "name": "Quality Assurance", "pos": 200 },
+    { "name": "Security Check", "pos": 300 },
+    { "name": "Ready to Launch", "pos": 400 },
+    { "name": "Live + Audit", "pos": 500 },
+    { "name": "Archivio", "pos": 600 }
+  ],
+  "example_cards": [
+    {
+      "name": "Richiesta contenuto enterprise",
+      "desc": "Card modello con campi per responsabile, approvatore, data di lancio e checklist di verifica.",
+      "labels": ["Legale", "Compliance", "Social"],
+      "checklist": [
+        "Verifica requisiti brand",
+        "Audit privacy completato",
+        "Controllo accessi e permessi aggiornati",
+        "Log sincronizzati con FP Publisher"
+      ],
+      "list": "Intake"
+    }
+  ],
+  "guidelines": [
+    "Imposta automazioni Trello per notificare i revisori quando una card entra in 'Quality Assurance'",
+    "Collega le checklist alle policy aziendali e mantieni la cronologia degli audit",
+    "Utilizza la lista 'Live + Audit' per tracciare retrospettive e follow-up"
+  ]
+}

--- a/wp-content/plugins/trello-social-auto-publisher/assets/quickstart/social-starter.json
+++ b/wp-content/plugins/trello-social-auto-publisher/assets/quickstart/social-starter.json
@@ -1,0 +1,34 @@
+{
+  "name": "FP Publisher - Starter Social",
+  "description": "Board template per il pacchetto Quickstart 'Starter Social'. Include le colonne e le etichette suggerite dal plugin.",
+  "labels": [
+    { "name": "Facebook", "color": "blue" },
+    { "name": "Instagram", "color": "purple" },
+    { "name": "Pronto", "color": "green" }
+  ],
+  "lists": [
+    { "name": "Idee", "pos": 100 },
+    { "name": "In approvazione", "pos": 200 },
+    { "name": "Pronto", "pos": 300 },
+    { "name": "Pubblicato", "pos": 400 },
+    { "name": "Archivio", "pos": 500 }
+  ],
+  "example_cards": [
+    {
+      "name": "Post di esempio",
+      "desc": "Usa questa card per definire tono, canali e asset da allegare al contenuto.",
+      "labels": ["Facebook", "Instagram"],
+      "checklist": [
+        "Copy approvato",
+        "Grafica caricata",
+        "Asset programmati su FP Publisher"
+      ],
+      "list": "Idee"
+    }
+  ],
+  "guidelines": [
+    "Etichette Facebook/Instagram per distinguere i canali da sincronizzare",
+    "Sposta la card in 'Pronto' quando i contenuti sono schedulati in FP Publisher",
+    "Archivia periodicamente le card completate per mantenere la board pulita"
+  ]
+}

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cli.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cli.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * WP-CLI commands for FP Publisher.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+    /**
+     * Provide diagnostic and setup helpers via WP-CLI.
+     */
+    class TTS_CLI_Command {
+
+        /**
+         * Execute or display the latest system health check.
+         *
+         * ## OPTIONS
+         *
+         * [--force]
+         * : Force a new health scan instead of reusing the cached snapshot.
+         */
+        public function health( $args, $assoc_args ) {
+            $force  = isset( $assoc_args['force'] );
+            $health = get_option( 'tts_last_health_check', array() );
+
+            if ( $force || empty( $health ) ) {
+                if ( $force ) {
+                    \WP_CLI::log( __( 'Esecuzione forzata del controllo salute…', 'fp-publisher' ) );
+                } else {
+                    \WP_CLI::log( __( 'Nessun controllo precedente disponibile, ne viene eseguito uno ora…', 'fp-publisher' ) );
+                }
+
+                $health = TTS_Monitoring::perform_health_check();
+            }
+
+            if ( empty( $health ) || ! is_array( $health ) ) {
+                \WP_CLI::error( __( 'Impossibile recuperare i dati di salute del sistema.', 'fp-publisher' ) );
+            }
+
+            $score = isset( $health['score'] ) ? (int) $health['score'] : 0;
+            \WP_CLI::log( sprintf( __( 'Punteggio salute: %d/100', 'fp-publisher' ), $score ) );
+
+            $checks = isset( $health['checks'] ) && is_array( $health['checks'] ) ? $health['checks'] : array();
+            $rows   = array();
+
+            foreach ( $checks as $key => $check ) {
+                $rows[] = array(
+                    'check'   => $this->format_check_label( $key ),
+                    'status'  => $this->extract_check_status( $check ),
+                    'message' => $this->extract_check_message( $check ),
+                );
+            }
+
+            if ( ! empty( $rows ) ) {
+                \WP_CLI\Utils::format_items( 'table', $rows, array( 'check', 'status', 'message' ) );
+            }
+
+            $suggestions = TTS_Monitoring::get_remediation_suggestions( $health );
+            if ( ! empty( $suggestions ) ) {
+                \WP_CLI::log( '' );
+                \WP_CLI::log( __( 'Azioni consigliate:', 'fp-publisher' ) );
+
+                $formatted = array();
+                foreach ( $suggestions as $suggestion ) {
+                    $formatted[] = array(
+                        'title'       => isset( $suggestion['title'] ) ? $suggestion['title'] : '',
+                        'description' => isset( $suggestion['description'] ) ? $suggestion['description'] : '',
+                        'link'        => isset( $suggestion['link'] ) ? $suggestion['link'] : '',
+                    );
+                }
+
+                \WP_CLI\Utils::format_items( 'table', $formatted, array( 'title', 'description', 'link' ) );
+            }
+
+            $actionable = TTS_Monitoring::get_actionable_health_summary();
+            if ( ! empty( $actionable ) ) {
+                \WP_CLI::log( '' );
+                \WP_CLI::log( __( 'Stato componenti critici:', 'fp-publisher' ) );
+
+                $rows = array();
+                foreach ( $actionable as $item ) {
+                    $rows[] = array(
+                        'component' => isset( $item['label'] ) ? $item['label'] : '',
+                        'status'    => isset( $item['status'] ) ? ucfirst( $item['status'] ) : '',
+                        'note'      => isset( $item['description'] ) ? $item['description'] : '',
+                    );
+                }
+
+                if ( ! empty( $rows ) ) {
+                    \WP_CLI\Utils::format_items( 'table', $rows, array( 'component', 'status', 'note' ) );
+                }
+            }
+
+            \WP_CLI::success( __( 'Analisi completata.', 'fp-publisher' ) );
+        }
+
+        /**
+         * Inspect or validate Quickstart packages from the command line.
+         *
+         * ## OPTIONS
+         *
+         * [--list]
+         * : Visualizza l\'elenco dei pacchetti disponibili.
+         *
+         * [--slug=<slug>]
+         * : Valida un pacchetto specifico e mostra i prerequisiti.
+         */
+        public function quickstart( $args, $assoc_args ) {
+            $admin = new TTS_Admin();
+
+            if ( isset( $assoc_args['list'] ) ) {
+                $catalog = $admin->get_quickstart_package_catalog();
+
+                if ( empty( $catalog ) ) {
+                    \WP_CLI::warning( __( 'Nessun pacchetto Quickstart configurato.', 'fp-publisher' ) );
+                    return;
+                }
+
+                foreach ( $catalog as &$entry ) {
+                    $entry['profile'] = $admin->get_usage_profile_label( $entry['profile'] );
+                }
+
+                \WP_CLI\Utils::format_items( 'table', $catalog, array( 'slug', 'title', 'profile', 'description' ) );
+                return;
+            }
+
+            if ( empty( $assoc_args['slug'] ) ) {
+                \WP_CLI::error( __( 'Specificare uno slug con --slug=<pacchetto> oppure usare --list.', 'fp-publisher' ) );
+            }
+
+            $slug      = sanitize_key( $assoc_args['slug'] );
+            $overview  = $admin->get_quickstart_package_overview( $slug );
+
+            if ( is_wp_error( $overview ) ) {
+                \WP_CLI::error( $overview->get_error_message() );
+            }
+
+            $definition = isset( $overview['definition'] ) ? $overview['definition'] : array();
+            $title      = isset( $definition['title'] ) ? $definition['title'] : $slug;
+            $profile    = $admin->get_usage_profile_label( isset( $overview['required_profile'] ) ? $overview['required_profile'] : 'standard' );
+
+            \WP_CLI::log( sprintf( __( 'Pacchetto: %s', 'fp-publisher' ), $title ) );
+            \WP_CLI::log( sprintf( __( 'Profilo richiesto: %s', 'fp-publisher' ), $profile ) );
+
+            if ( empty( $overview['profile_allowed'] ) ) {
+                \WP_CLI::warning( sprintf(
+                    /* translators: %s: active usage profile label. */
+                    __( 'Il profilo attivo (%s) non soddisfa i requisiti del pacchetto.', 'fp-publisher' ),
+                    $admin->get_usage_profile_label( isset( $overview['active_profile'] ) ? $overview['active_profile'] : 'standard' )
+                ) );
+            }
+
+            if ( isset( $definition['description'] ) && '' !== $definition['description'] ) {
+                \WP_CLI::log( $definition['description'] );
+            }
+
+            if ( isset( $definition['trello_template'] ) && '' !== $definition['trello_template'] ) {
+                \WP_CLI::log( sprintf( __( 'Template Trello: %s', 'fp-publisher' ), $definition['trello_template'] ) );
+            }
+
+            if ( isset( $definition['journey_doc']['path'] ) ) {
+                $doc_path = $definition['journey_doc']['path'];
+                if ( isset( $definition['journey_doc']['anchor'] ) && '' !== $definition['journey_doc']['anchor'] ) {
+                    $doc_path .= $definition['journey_doc']['anchor'];
+                }
+                \WP_CLI::log( sprintf( __( 'Percorso guidato: %s', 'fp-publisher' ), $doc_path ) );
+            }
+
+            $readiness = isset( $overview['readiness'] ) ? $overview['readiness'] : array();
+            if ( isset( $readiness['summary'] ) ) {
+                \WP_CLI::log( '' );
+                \WP_CLI::log( sprintf( __( 'Validazione ambiente: %s', 'fp-publisher' ), $readiness['summary'] ) );
+            }
+
+            if ( isset( $readiness['checks'] ) && is_array( $readiness['checks'] ) ) {
+                $checks = array();
+                foreach ( $readiness['checks'] as $check ) {
+                    $checks[] = array(
+                        'status'  => isset( $check['status'] ) ? $check['status'] : 'ok',
+                        'label'   => isset( $check['label'] ) ? $check['label'] : '',
+                        'message' => isset( $check['message'] ) ? $check['message'] : '',
+                    );
+                }
+
+                if ( ! empty( $checks ) ) {
+                    \WP_CLI\Utils::format_items( 'table', $checks, array( 'status', 'label', 'message' ) );
+                }
+            }
+
+            $preview = isset( $overview['preview'] ) ? $overview['preview'] : array();
+            if ( isset( $preview['mapping'] ) && isset( $preview['mapping']['added'] ) ) {
+                $added   = count( $preview['mapping']['added'] );
+                $over    = isset( $preview['mapping']['overrides'] ) ? count( $preview['mapping']['overrides'] ) : 0;
+                $current = isset( $preview['mapping']['current_total'] ) ? (int) $preview['mapping']['current_total'] : 0;
+                \WP_CLI::log( sprintf( __( 'Mapping Trello aggiunti: %1$d · sovrascritture: %2$d · mapping attuali: %3$d', 'fp-publisher' ), $added, $over, $current ) );
+            }
+
+            if ( isset( $preview['templates'] ) && ! empty( $preview['templates'] ) ) {
+                $template_rows = array();
+                foreach ( $preview['templates'] as $channel => $template ) {
+                    $template_rows[] = array(
+                        'channel' => $channel,
+                        'status'  => isset( $template['action'] ) ? $template['action'] : 'add',
+                        'sample'  => isset( $template['value'] ) ? $template['value'] : '',
+                    );
+                }
+
+                if ( ! empty( $template_rows ) ) {
+                    \WP_CLI::log( '' );
+                    \WP_CLI::log( __( 'Template social coinvolti:', 'fp-publisher' ) );
+                    \WP_CLI\Utils::format_items( 'table', $template_rows, array( 'channel', 'status', 'sample' ) );
+                }
+            }
+
+            if ( isset( $preview['utm'] ) && ! empty( $preview['utm'] ) ) {
+                \WP_CLI::log( '' );
+                \WP_CLI::log( __( 'Parametri UTM proposti:', 'fp-publisher' ) );
+
+                $utm_rows = array();
+                foreach ( $preview['utm'] as $utm_entry ) {
+                    $utm_rows[] = array(
+                        'channel' => isset( $utm_entry['channel'] ) ? $utm_entry['channel'] : 'all',
+                        'param'   => isset( $utm_entry['param'] ) ? $utm_entry['param'] : '',
+                        'action'  => isset( $utm_entry['action'] ) ? $utm_entry['action'] : '',
+                        'value'   => isset( $utm_entry['new'] ) ? $utm_entry['new'] : '',
+                    );
+                }
+
+                \WP_CLI\Utils::format_items( 'table', $utm_rows, array( 'channel', 'param', 'action', 'value' ) );
+            }
+
+            if ( isset( $preview['blog'] ) && ! empty( $preview['blog'] ) ) {
+                \WP_CLI::log( '' );
+                \WP_CLI::log( __( 'Prefill blog:', 'fp-publisher' ) );
+                foreach ( $preview['blog'] as $key => $value ) {
+                    \WP_CLI::log( sprintf( ' - %s: %s', $key, $value ) );
+                }
+            }
+
+            \WP_CLI::success( __( 'Analisi pacchetto completata.', 'fp-publisher' ) );
+        }
+
+        /**
+         * Convert check identifiers to human readable labels.
+         *
+         * @param string $key Check slug.
+         * @return string
+         */
+        private function format_check_label( $key ) {
+            $key = str_replace( '_', ' ', (string) $key );
+            $key = trim( $key );
+
+            if ( '' === $key ) {
+                return __( 'Check', 'fp-publisher' );
+            }
+
+            return ucwords( $key );
+        }
+
+        /**
+         * Normalize status values for CLI rendering.
+         *
+         * @param array<string, mixed> $check Check payload.
+         * @return string
+         */
+        private function extract_check_status( $check ) {
+            if ( isset( $check['status'] ) ) {
+                if ( is_bool( $check['status'] ) ) {
+                    return $check['status'] ? 'ok' : 'ko';
+                }
+
+                if ( is_string( $check['status'] ) && '' !== $check['status'] ) {
+                    return $check['status'];
+                }
+            }
+
+            if ( isset( $check['failed_connections'] ) && (int) $check['failed_connections'] > 0 ) {
+                return 'warning';
+            }
+
+            if ( isset( $check['alerts'] ) && ! empty( $check['alerts'] ) ) {
+                return 'warning';
+            }
+
+            return 'ok';
+        }
+
+        /**
+         * Extract the most relevant message for a health check row.
+         *
+         * @param array<string, mixed> $check Check payload.
+         * @return string
+         */
+        private function extract_check_message( $check ) {
+            if ( isset( $check['message'] ) && '' !== $check['message'] ) {
+                return $check['message'];
+            }
+
+            if ( isset( $check['error_rate'] ) ) {
+                return sprintf( __( 'Tasso di errore: %s%%', 'fp-publisher' ), $check['error_rate'] );
+            }
+
+            if ( isset( $check['details'] ) && is_array( $check['details'] ) ) {
+                $preview = array_slice( $check['details'], 0, 3, true );
+                return wp_json_encode( $preview );
+            }
+
+            return '';
+        }
+    }
+
+    \WP_CLI::add_command( 'tts', 'TTS_CLI_Command' );
+}

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-monitoring.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-monitoring.php
@@ -109,7 +109,24 @@ class TTS_Monitoring {
                 'message' => 'High error rate detected: ' . $error_health['error_rate'] . '%'
             );
         }
-        
+
+        // Token health check
+        $token_health = self::assess_token_health();
+        $health_data['checks']['tokens'] = $token_health;
+        if ( isset( $token_health['status'] ) && ! $token_health['status'] ) {
+            $health_data['score'] -= 15;
+
+            if ( ! empty( $token_health['alerts'] ) ) {
+                $health_data['alerts'] = array_merge( $health_data['alerts'], $token_health['alerts'] );
+            } else {
+                $health_data['alerts'][] = array(
+                    'type'     => 'tokens',
+                    'severity' => 'medium',
+                    'message'  => isset( $token_health['message'] ) ? $token_health['message'] : __( 'I token social richiedono attenzione.', 'fp-publisher' ),
+                );
+            }
+        }
+
         // Store health data
         update_option( 'tts_last_health_check', $health_data );
         
@@ -383,9 +400,9 @@ class TTS_Monitoring {
      */
     private static function check_error_rates() {
         global $wpdb;
-        
+
         $logs_table = $wpdb->prefix . 'tts_logs';
-        
+
         // Count total and error logs in last 24 hours
         $total_logs = $wpdb->get_var( "
             SELECT COUNT(*) FROM {$logs_table}
@@ -405,6 +422,657 @@ class TTS_Monitoring {
             'error_logs' => (int) $error_logs,
             'error_rate' => round( $error_rate, 2 )
         );
+    }
+
+    /**
+     * Assess the health of stored social tokens across clients.
+     *
+     * @return array<string, mixed>
+     */
+    private static function assess_token_health() {
+        $channels = array(
+            'facebook'  => array(
+                'label'       => 'Facebook',
+                'token_meta'  => '_tts_fb_token',
+                'expires_meta'=> '_tts_fb_token_expires_at',
+            ),
+            'instagram' => array(
+                'label'       => 'Instagram',
+                'token_meta'  => '_tts_ig_token',
+                'expires_meta'=> '_tts_ig_token_expires_at',
+            ),
+            'youtube'   => array(
+                'label'       => 'YouTube',
+                'token_meta'  => '_tts_yt_token',
+                'expires_meta'=> '_tts_yt_token_expires_at',
+            ),
+            'tiktok'    => array(
+                'label'       => 'TikTok',
+                'token_meta'  => '_tts_tt_token',
+                'expires_meta'=> '_tts_tt_token_expires_at',
+            ),
+        );
+
+        $clients = get_posts(
+            array(
+                'post_type'      => 'tts_client',
+                'fields'         => 'ids',
+                'posts_per_page' => -1,
+                'post_status'    => 'any',
+            )
+        );
+
+        $summary = array(
+            'status'          => true,
+            'message'         => __( 'Tutti i token social risultano validi.', 'fp-publisher' ),
+            'missing_tokens'  => array(),
+            'expiring_tokens' => array(),
+            'stale_tokens'    => array(),
+            'alerts'          => array(),
+        );
+
+        if ( empty( $clients ) ) {
+            return $summary;
+        }
+
+        $now                = time();
+        $critical_threshold = DAY_IN_SECONDS;
+        $warning_threshold  = 3 * DAY_IN_SECONDS;
+
+        foreach ( $clients as $client_id ) {
+            $client_name = get_the_title( $client_id );
+
+            foreach ( $channels as $channel => $meta ) {
+                $token_value = trim( (string) get_post_meta( $client_id, $meta['token_meta'], true ) );
+
+                if ( '' === $token_value ) {
+                    $summary['status'] = false;
+                    $summary['missing_tokens'][] = array(
+                        'client_id'     => $client_id,
+                        'client_name'   => $client_name,
+                        'channel'       => $channel,
+                        'channel_label' => $meta['label'],
+                    );
+                    $summary['alerts'][] = array(
+                        'type'     => 'tokens',
+                        'severity' => 'high',
+                        'message'  => sprintf( __( 'Token mancante per %1$s (%2$s).', 'fp-publisher' ), $client_name, $meta['label'] ),
+                    );
+                    continue;
+                }
+
+                $expires_at = isset( $meta['expires_meta'] ) ? (int) get_post_meta( $client_id, $meta['expires_meta'], true ) : 0;
+                if ( $expires_at > 0 ) {
+                    $time_remaining = $expires_at - $now;
+
+                    if ( $time_remaining <= 0 ) {
+                        $summary['status'] = false;
+                        $summary['missing_tokens'][] = array(
+                            'client_id'     => $client_id,
+                            'client_name'   => $client_name,
+                            'channel'       => $channel,
+                            'channel_label' => $meta['label'],
+                        );
+                        $summary['alerts'][] = array(
+                            'type'     => 'tokens',
+                            'severity' => 'high',
+                            'message'  => sprintf( __( 'Token scaduto per %1$s (%2$s).', 'fp-publisher' ), $client_name, $meta['label'] ),
+                        );
+                        continue;
+                    }
+
+                    if ( $time_remaining <= $critical_threshold ) {
+                        $summary['status'] = false;
+                        $summary['expiring_tokens'][] = array(
+                            'client_id'     => $client_id,
+                            'client_name'   => $client_name,
+                            'channel'       => $channel,
+                            'channel_label' => $meta['label'],
+                            'seconds'       => $time_remaining,
+                        );
+                        $summary['alerts'][] = array(
+                            'type'     => 'tokens',
+                            'severity' => 'high',
+                            'message'  => sprintf( __( 'Il token di %1$s (%2$s) scade entro 24 ore.', 'fp-publisher' ), $client_name, $meta['label'] ),
+                        );
+                    } elseif ( $time_remaining <= $warning_threshold ) {
+                        $summary['status'] = false;
+                        $summary['expiring_tokens'][] = array(
+                            'client_id'     => $client_id,
+                            'client_name'   => $client_name,
+                            'channel'       => $channel,
+                            'channel_label' => $meta['label'],
+                            'seconds'       => $time_remaining,
+                        );
+                        $summary['alerts'][] = array(
+                            'type'     => 'tokens',
+                            'severity' => 'medium',
+                            'message'  => sprintf( __( 'Il token di %1$s (%2$s) scadrà nei prossimi giorni.', 'fp-publisher' ), $client_name, $meta['label'] ),
+                        );
+                    }
+                } else {
+                    $summary['stale_tokens'][] = array(
+                        'client_id'     => $client_id,
+                        'client_name'   => $client_name,
+                        'channel'       => $channel,
+                        'channel_label' => $meta['label'],
+                    );
+                }
+            }
+        }
+
+        if ( ! empty( $summary['missing_tokens'] ) ) {
+            $summary['message'] = __( 'Sono presenti clienti senza token social configurati.', 'fp-publisher' );
+        } elseif ( ! empty( $summary['expiring_tokens'] ) ) {
+            $summary['message'] = __( 'Alcuni token stanno per scadere e richiedono rinnovo.', 'fp-publisher' );
+        } elseif ( ! empty( $summary['stale_tokens'] ) ) {
+            $summary['message'] = __( 'Alcuni token non indicano la data di scadenza: verifica le integrazioni.', 'fp-publisher' );
+        }
+
+        return $summary;
+    }
+
+    /**
+     * Get actionable remediation suggestions based on the latest health snapshot.
+     *
+     * @param array $health_data Optional pre-fetched health data.
+     * @return array<int, array<string, string>>
+     */
+    public static function get_remediation_suggestions( $health_data = array() ) {
+        if ( empty( $health_data ) || ! is_array( $health_data ) ) {
+            $health_data = get_option( 'tts_last_health_check', array() );
+        }
+
+        if ( empty( $health_data ) || ! is_array( $health_data ) ) {
+            return array();
+        }
+
+        $suggestions = array();
+
+        $add_suggestion = static function ( $title, $description, $link = '' ) use ( &$suggestions ) {
+            $entry = array(
+                'title'       => $title,
+                'description' => $description,
+            );
+
+            if ( '' !== $link ) {
+                $entry['link'] = $link;
+            }
+
+            $suggestions[] = $entry;
+        };
+
+        $admin_url = admin_url( 'admin.php' );
+
+        $format_token_list = static function ( array $entries ) {
+            if ( empty( $entries ) ) {
+                return '';
+            }
+
+            $labels = array();
+            foreach ( $entries as $entry ) {
+                $client  = isset( $entry['client_name'] ) ? $entry['client_name'] : __( 'Cliente', 'fp-publisher' );
+                $channel = isset( $entry['channel_label'] ) ? $entry['channel_label'] : ( isset( $entry['channel'] ) ? ucfirst( $entry['channel'] ) : __( 'Canale', 'fp-publisher' ) );
+                $labels[] = $client . ' – ' . $channel;
+            }
+
+            $max = 3;
+            if ( count( $labels ) > $max ) {
+                $remaining = count( $labels ) - $max;
+                $labels    = array_slice( $labels, 0, $max );
+                $labels[]  = sprintf( _n( '+%d altro', '+%d altri', $remaining, 'fp-publisher' ), $remaining );
+            }
+
+            return implode( ', ', $labels );
+        };
+
+        if ( isset( $health_data['checks']['api_connections'] ) ) {
+            $api_health = $health_data['checks']['api_connections'];
+
+            if ( ! empty( $api_health['platform_status'] ) && is_array( $api_health['platform_status'] ) ) {
+                foreach ( $api_health['platform_status'] as $platform => $status ) {
+                    if ( empty( $status['success'] ) ) {
+                        $message = isset( $status['message'] ) ? $status['message'] : __( 'Connection requires attention.', 'fp-publisher' );
+                        $platform_name = ucfirst( $platform );
+                        $add_suggestion(
+                            sprintf( __( 'Re-authorize %s', 'fp-publisher' ), $platform_name ),
+                            sprintf( __( '%1$s reports "%2$s". Apri la pagina Connessioni Social per aggiornare token e credenziali.', 'fp-publisher' ), $platform_name, $message ),
+                            add_query_arg( array( 'page' => 'fp-publisher-social-connections' ), $admin_url )
+                        );
+                    }
+                }
+            }
+
+            if ( isset( $api_health['failed_connections'] ) && $api_health['failed_connections'] > 0 ) {
+                $add_suggestion(
+                    __( 'Controlla le quote API', 'fp-publisher' ),
+                    __( 'Una o più integrazioni stanno restituendo errori. Verifica i limiti di utilizzo dalle console dei vari provider.', 'fp-publisher' ),
+                    add_query_arg( array( 'page' => 'fp-publisher-test-connections' ), $admin_url )
+                );
+            }
+        }
+
+        if ( isset( $health_data['checks']['scheduler'] ) ) {
+            $scheduler = $health_data['checks']['scheduler'];
+            if ( ! empty( $scheduler['details'] ) && is_array( $scheduler['details'] ) ) {
+                foreach ( $scheduler['details'] as $hook => $status ) {
+                    if ( 'not_scheduled' === $status ) {
+                        $add_suggestion(
+                            __( 'Ripristina le attività pianificate', 'fp-publisher' ),
+                            sprintf( __( 'La routine "%s" non è pianificata. Esegui un controllo cron o salva di nuovo le impostazioni per riattivarla.', 'fp-publisher' ), $hook ),
+                            add_query_arg( array( 'page' => 'fp-publisher-health' ), $admin_url )
+                        );
+                    }
+                }
+            }
+        }
+
+        if ( isset( $health_data['checks']['tokens'] ) ) {
+            $token_health = $health_data['checks']['tokens'];
+
+            if ( ! empty( $token_health['missing_tokens'] ) ) {
+                $add_suggestion(
+                    __( 'Completa i token mancanti', 'fp-publisher' ),
+                    sprintf( __( 'Clienti da aggiornare: %s.', 'fp-publisher' ), $format_token_list( $token_health['missing_tokens'] ) ),
+                    admin_url( 'edit.php?post_type=tts_client' )
+                );
+            }
+
+            if ( ! empty( $token_health['expiring_tokens'] ) ) {
+                $add_suggestion(
+                    __( 'Rinnova i token in scadenza', 'fp-publisher' ),
+                    sprintf( __( 'Token prossimi alla scadenza: %s.', 'fp-publisher' ), $format_token_list( $token_health['expiring_tokens'] ) ),
+                    add_query_arg( array( 'page' => 'fp-publisher-social-connections' ), $admin_url )
+                );
+            }
+
+            if ( ! empty( $token_health['stale_tokens'] ) ) {
+                $add_suggestion(
+                    __( 'Verifica la durata dei token', 'fp-publisher' ),
+                    sprintf( __( 'Aggiorna le integrazioni per registrare la scadenza dei token: %s.', 'fp-publisher' ), $format_token_list( $token_health['stale_tokens'] ) ),
+                    add_query_arg( array( 'page' => 'fp-publisher-test-connections' ), $admin_url )
+                );
+            }
+        }
+
+        global $wpdb;
+        $logs_table = $wpdb->prefix . 'tts_logs';
+
+        // Highlight webhook delivery issues.
+        $webhook_errors = (int) $wpdb->get_var( "
+            SELECT COUNT(*) FROM {$logs_table}
+            WHERE channel = 'webhook'
+              AND status = 'error'
+              AND created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR)
+        " );
+
+        if ( $webhook_errors > 0 ) {
+            $add_suggestion(
+                __( 'Rinnova il webhook Trello', 'fp-publisher' ),
+                __( 'Sono stati registrati errori webhook nelle ultime 24 ore. Conferma che il board Trello sia raggiungibile e rinnova il webhook.', 'fp-publisher' ),
+                add_query_arg( array( 'page' => 'fp-publisher-health' ), $admin_url )
+            );
+        }
+
+        // Detect API quota related messages.
+        $quota_errors = (int) $wpdb->get_var( $wpdb->prepare( "
+            SELECT COUNT(*) FROM {$logs_table}
+            WHERE status = 'error'
+              AND message LIKE %s
+              AND created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR)
+        ", '%quota%' ) );
+
+        if ( $quota_errors > 0 ) {
+            $add_suggestion(
+                __( 'Pianifica un raffreddamento delle API', 'fp-publisher' ),
+                __( 'Sono stati rilevati errori di quota API. Valuta di ridurre la frequenza delle pubblicazioni o di suddividerle su fasce orarie diverse.', 'fp-publisher' ),
+                add_query_arg( array( 'page' => 'fp-publisher-frequency-status' ), $admin_url )
+            );
+        }
+
+        // Highlight token refresh issues in logs.
+        $token_errors = (int) $wpdb->get_var( $wpdb->prepare( "
+            SELECT COUNT(*) FROM {$logs_table}
+            WHERE status = 'error'
+              AND channel IN ('facebook', 'instagram', 'youtube', 'tiktok')
+              AND (message LIKE %s OR message LIKE %s)
+              AND created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR)
+        ", '%token%', '%auth%' ) );
+
+        if ( $token_errors > 0 ) {
+            $add_suggestion(
+                __( 'Aggiorna i token scaduti', 'fp-publisher' ),
+                __( 'Il registro mostra errori di autenticazione recenti. Accedi di nuovo ai canali social per generare token aggiornati.', 'fp-publisher' ),
+                add_query_arg( array( 'page' => 'fp-publisher-social-connections' ), $admin_url )
+            );
+        }
+
+        return $suggestions;
+    }
+
+    /**
+     * Build an actionable health summary for key components.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function get_actionable_health_summary() {
+        $health_data = get_option( 'tts_last_health_check', array() );
+        $summary     = array();
+
+        $raise_severity = static function ( array &$item, $candidate ) {
+            $current_level = TTS_Monitoring::get_status_level_weight( isset( $item['status'] ) ? $item['status'] : 'ok' );
+            $new_level     = TTS_Monitoring::get_status_level_weight( $candidate );
+
+            if ( $new_level > $current_level ) {
+                $item['status'] = $candidate;
+            }
+        };
+
+        $token_overview = array(
+            'key'         => 'tokens',
+            'label'       => __( 'Token social', 'fp-publisher' ),
+            'status'      => 'ok',
+            'description' => __( 'Tutti i token risultano validi.', 'fp-publisher' ),
+            'count'       => 0,
+            'actions'     => array(),
+        );
+
+        if ( isset( $health_data['checks']['tokens'] ) && is_array( $health_data['checks']['tokens'] ) ) {
+            $token_health          = $health_data['checks']['tokens'];
+            $missing_tokens        = isset( $token_health['missing_tokens'] ) ? (array) $token_health['missing_tokens'] : array();
+            $expiring_tokens       = isset( $token_health['expiring_tokens'] ) ? (array) $token_health['expiring_tokens'] : array();
+            $stale_tokens          = isset( $token_health['stale_tokens'] ) ? (array) $token_health['stale_tokens'] : array();
+            $affected_integrations = count( $missing_tokens ) + count( $expiring_tokens );
+
+            if ( $affected_integrations > 0 ) {
+                $token_overview['count']       = $affected_integrations;
+                $token_overview['description'] = sprintf(
+                    /* translators: %d: number of integrations without a valid token. */
+                    __( '%d integrazioni richiedono un token valido o aggiornato.', 'fp-publisher' ),
+                    (int) $affected_integrations
+                );
+            }
+
+            if ( ! empty( $missing_tokens ) ) {
+                $token_overview['affected_clients'] = array_map(
+                    static function ( $entry ) {
+                        return isset( $entry['client_name'] ) ? $entry['client_name'] : '';
+                    },
+                    $missing_tokens
+                );
+
+                $token_overview['actions'][] = array(
+                    'description' => __( 'Completa le credenziali mancanti per i client interessati.', 'fp-publisher' ),
+                    'url'         => admin_url( 'edit.php?post_type=tts_client' ),
+                );
+
+                $raise_severity( $token_overview, 'critical' );
+            }
+
+            if ( ! empty( $expiring_tokens ) ) {
+                $token_overview['actions'][] = array(
+                    'description' => __( 'Rinnova i token in scadenza dalla pagina Connessioni social.', 'fp-publisher' ),
+                    'url'         => add_query_arg( array( 'page' => 'fp-publisher-social-connections' ), admin_url( 'admin.php' ) ),
+                );
+
+                $raise_severity( $token_overview, 'warning' );
+            }
+
+            if ( empty( $missing_tokens ) && empty( $expiring_tokens ) && ! empty( $stale_tokens ) ) {
+                $token_overview['description'] = __( 'Aggiorna la data di scadenza per alcune integrazioni.', 'fp-publisher' );
+                $token_overview['actions'][]   = array(
+                    'description' => __( 'Apri la pagina di test connessioni per registrare le nuove scadenze.', 'fp-publisher' ),
+                    'url'         => add_query_arg( array( 'page' => 'fp-publisher-test-connections' ), admin_url( 'admin.php' ) ),
+                );
+
+                $raise_severity( $token_overview, 'warning' );
+            }
+        }
+
+        $summary[] = $token_overview;
+
+        $scheduler_overview = array(
+            'key'         => 'scheduler',
+            'label'       => __( 'Attività pianificate', 'fp-publisher' ),
+            'status'      => 'ok',
+            'description' => __( 'Tutte le routine richieste risultano pianificate.', 'fp-publisher' ),
+            'count'       => 0,
+            'actions'     => array(),
+        );
+
+        if ( isset( $health_data['checks']['scheduler'] ) && is_array( $health_data['checks']['scheduler'] ) ) {
+            $scheduler_checks = $health_data['checks']['scheduler'];
+
+            if ( isset( $scheduler_checks['details'] ) && is_array( $scheduler_checks['details'] ) ) {
+                $missing_hooks = array_keys(
+                    array_filter(
+                        $scheduler_checks['details'],
+                        static function ( $status ) {
+                            return 'scheduled' !== $status;
+                        }
+                    )
+                );
+
+                if ( ! empty( $missing_hooks ) ) {
+                    $scheduler_overview['count']       = count( $missing_hooks );
+                    $scheduler_overview['description'] = sprintf(
+                        /* translators: %d: number of missing cron hooks. */
+                        __( '%d routine non risultano pianificate.', 'fp-publisher' ),
+                        (int) $scheduler_overview['count']
+                    );
+
+                    $scheduler_overview['details']   = $missing_hooks;
+                    $scheduler_overview['actions'][] = array(
+                        'description' => __( 'Apri la pagina Salute per riattivare le attività e controllare WP-Cron.', 'fp-publisher' ),
+                        'url'         => add_query_arg( array( 'page' => 'fp-publisher-health' ), admin_url( 'admin.php' ) ),
+                    );
+
+                    $raise_severity( $scheduler_overview, 'critical' );
+                }
+            }
+        }
+
+        $summary[] = $scheduler_overview;
+
+        global $wpdb;
+        $logs_table   = $wpdb->prefix . 'tts_logs';
+        $logs_enabled = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $logs_table ) );
+
+        $webhook_overview = array(
+            'key'         => 'webhook',
+            'label'       => __( 'Consegna webhook', 'fp-publisher' ),
+            'status'      => 'ok',
+            'description' => __( 'Nessun errore webhook nelle ultime 24 ore.', 'fp-publisher' ),
+            'count'       => 0,
+            'actions'     => array(),
+        );
+
+        $webhook_errors = 0;
+        if ( $logs_enabled ) {
+            $webhook_errors = (int) $wpdb->get_var( "
+                SELECT COUNT(*) FROM {$logs_table}
+                WHERE channel = 'webhook'
+                  AND status = 'error'
+                  AND created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR)
+            " );
+        }
+
+        if ( $webhook_errors > 0 ) {
+            $webhook_overview['count']       = $webhook_errors;
+            $webhook_overview['description'] = sprintf(
+                /* translators: %d: number of webhook errors. */
+                __( '%d errori webhook rilevati nelle ultime 24 ore.', 'fp-publisher' ),
+                (int) $webhook_errors
+            );
+
+            $webhook_overview['actions'][] = array(
+                'description' => __( 'Verifica lo stato del webhook Trello e rinnova la sottoscrizione.', 'fp-publisher' ),
+                'url'         => add_query_arg( array( 'page' => 'fp-publisher-health' ), admin_url( 'admin.php' ) ),
+            );
+
+            $raise_severity( $webhook_overview, $webhook_errors > 3 ? 'critical' : 'warning' );
+        }
+
+        $summary[] = $webhook_overview;
+
+        $quota_overview = array(
+            'key'         => 'api_quota',
+            'label'       => __( 'Quote API', 'fp-publisher' ),
+            'status'      => 'ok',
+            'description' => __( 'Nessun errore di quota registrato.', 'fp-publisher' ),
+            'count'       => 0,
+            'actions'     => array(),
+        );
+
+        $quota_errors = 0;
+        if ( $logs_enabled ) {
+            $quota_errors = (int) $wpdb->get_var( $wpdb->prepare( "
+                SELECT COUNT(*) FROM {$logs_table}
+                WHERE status = 'error'
+                  AND message LIKE %s
+                  AND created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR)
+            ", '%quota%' ) );
+        }
+
+        if ( $quota_errors > 0 ) {
+            $quota_overview['count']       = $quota_errors;
+            $quota_overview['description'] = sprintf(
+                /* translators: %d: number of quota related errors. */
+                __( '%d errori legati alle quote API nelle ultime 24 ore.', 'fp-publisher' ),
+                (int) $quota_errors
+            );
+
+            $quota_overview['actions'][] = array(
+                'description' => __( 'Riduci la frequenza di pubblicazione o suddividi le campagne.', 'fp-publisher' ),
+                'url'         => add_query_arg( array( 'page' => 'fp-publisher-frequency-status' ), admin_url( 'admin.php' ) ),
+            );
+
+            $raise_severity( $quota_overview, $quota_errors > 5 ? 'critical' : 'warning' );
+        }
+
+        $summary[] = $quota_overview;
+
+        if ( isset( $health_data['checks']['database'] ) && is_array( $health_data['checks']['database'] ) ) {
+            $database    = $health_data['checks']['database'];
+            $db_overview = array(
+                'key'         => 'database',
+                'label'       => __( 'Database', 'fp-publisher' ),
+                'status'      => ! empty( $database['status'] ) ? 'ok' : 'critical',
+                'description' => isset( $database['message'] ) ? $database['message'] : __( 'Database non verificato.', 'fp-publisher' ),
+                'actions'     => array(),
+            );
+
+            if ( isset( $database['status'] ) && ! $database['status'] ) {
+                $db_overview['actions'][] = array(
+                    'description' => __( 'Esegui l’ottimizzazione tabelle dal pannello manutenzione.', 'fp-publisher' ),
+                    'url'         => add_query_arg( array( 'page' => 'fp-publisher-health' ), admin_url( 'admin.php' ) ),
+                );
+            }
+
+            if ( isset( $database['details']['response_time_ms'] ) && $database['details']['response_time_ms'] > 1200 ) {
+                $response_time = number_format_i18n( (float) $database['details']['response_time_ms'], 2 );
+                $db_overview['description'] = sprintf(
+                    /* translators: %s: database response time. */
+                    __( 'Tempo di risposta elevato: %s ms.', 'fp-publisher' ),
+                    $response_time
+                );
+
+                $raise_severity( $db_overview, 'warning' );
+            }
+
+            $summary[] = $db_overview;
+        }
+
+        if ( isset( $health_data['checks']['api_connections'] ) && is_array( $health_data['checks']['api_connections'] ) ) {
+            $api_health   = $health_data['checks']['api_connections'];
+            $api_overview = array(
+                'key'         => 'api_connections',
+                'label'       => __( 'Connessioni API', 'fp-publisher' ),
+                'status'      => 'ok',
+                'description' => __( 'Tutte le integrazioni rispondono correttamente.', 'fp-publisher' ),
+                'count'       => 0,
+                'actions'     => array(),
+            );
+
+            if ( isset( $api_health['failed_connections'] ) && $api_health['failed_connections'] > 0 ) {
+                $api_overview['count']       = (int) $api_health['failed_connections'];
+                $api_overview['description'] = sprintf(
+                    /* translators: %d: number of failing API connections. */
+                    __( '%d integrazioni stanno riportando errori.', 'fp-publisher' ),
+                    (int) $api_overview['count']
+                );
+
+                $api_overview['actions'][] = array(
+                    'description' => __( 'Apri il pannello di test per ristabilire le connessioni.', 'fp-publisher' ),
+                    'url'         => add_query_arg( array( 'page' => 'fp-publisher-test-connections' ), admin_url( 'admin.php' ) ),
+                );
+
+                $raise_severity( $api_overview, $api_overview['count'] > 2 ? 'critical' : 'warning' );
+            }
+
+            $summary[] = $api_overview;
+        }
+
+        return $summary;
+    }
+
+    /**
+     * Translate status label to sorting weight.
+     *
+     * @param string $status Status label.
+     * @return int
+     */
+    private static function get_status_level_weight( $status ) {
+        switch ( $status ) {
+            case 'critical':
+                return 3;
+            case 'warning':
+                return 2;
+            case 'ok':
+            default:
+                return 1;
+        }
+    }
+
+    /**
+     * Return a summary of scheduled maintenance hooks and their next execution.
+     *
+     * @return array<int, array<string, string|int|null>>
+     */
+    public static function get_scheduled_task_summary() {
+        $tasks = array(
+            'tts_refresh_tokens'      => array(
+                'label' => __( 'Refresh token social', 'fp-publisher' ),
+                'frequency' => __( 'Settimanale', 'fp-publisher' ),
+            ),
+            'tts_hourly_health_check' => array(
+                'label' => __( 'Verifica salute sistema', 'fp-publisher' ),
+                'frequency' => __( 'Oraria', 'fp-publisher' ),
+            ),
+            'tts_fetch_metrics'       => array(
+                'label' => __( 'Import metriche canali', 'fp-publisher' ),
+                'frequency' => __( 'Ogni 6 ore', 'fp-publisher' ),
+            ),
+            'tts_check_links'         => array(
+                'label' => __( 'Link checker contenuti', 'fp-publisher' ),
+                'frequency' => __( 'Giornaliera', 'fp-publisher' ),
+            ),
+        );
+
+        $summary = array();
+
+        foreach ( $tasks as $hook => $meta ) {
+            $next_run = wp_next_scheduled( $hook );
+            $summary[] = array(
+                'hook'      => $hook,
+                'label'     => $meta['label'],
+                'frequency' => $meta['frequency'],
+                'next_run'  => $next_run ? $next_run : null,
+                'status'    => $next_run ? 'scheduled' : 'missing',
+            );
+        }
+
+        return $summary;
     }
     
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -84,6 +84,22 @@ class TTS_Settings {
             'tts_column_mapping'
         );
 
+        // Usage modes.
+        add_settings_section(
+            'tts_usage_modes',
+            __( 'Modalità di utilizzo', 'fp-publisher' ),
+            array( $this, 'render_usage_modes_intro' ),
+            'tts_settings'
+        );
+
+        add_settings_field(
+            'usage_profile',
+            __( 'Interfaccia preferita', 'fp-publisher' ),
+            array( $this, 'render_usage_profile_field' ),
+            'tts_settings',
+            'tts_usage_modes'
+        );
+
         // Social access token.
         add_settings_section(
             'tts_social_token',
@@ -375,6 +391,47 @@ class TTS_Settings {
     }
 
     /**
+     * Render introductory copy for the usage modes section.
+     */
+    public function render_usage_modes_intro() {
+        echo '<p class="description">' . esc_html__( 'Seleziona il profilo che meglio rappresenta il tuo team per mostrare solo gli strumenti necessari.', 'fp-publisher' ) . '</p>';
+    }
+
+    /**
+     * Render usage profile selector field.
+     */
+    public function render_usage_profile_field() {
+        $options = get_option( 'tts_settings', array() );
+        $value   = isset( $options['usage_profile'] ) ? sanitize_key( $options['usage_profile'] ) : 'standard';
+
+        $choices = array(
+            'standard'   => array(
+                'label'       => __( 'Profilo Standard', 'fp-publisher' ),
+                'description' => __( 'Mostra un set di strumenti essenziali per piccoli team o chi è alle prime armi.', 'fp-publisher' ),
+            ),
+            'advanced'   => array(
+                'label'       => __( 'Profilo Avanzato', 'fp-publisher' ),
+                'description' => __( 'Aggiunge monitoraggio approfondito, suggerimenti operativi e automazioni aggiuntive.', 'fp-publisher' ),
+            ),
+            'enterprise' => array(
+                'label'       => __( 'Profilo Enterprise', 'fp-publisher' ),
+                'description' => __( 'Sblocca audit trail completi, controlli di sicurezza e preset multi-brand.', 'fp-publisher' ),
+            ),
+        );
+
+        echo '<fieldset class="tts-usage-profile">';
+        foreach ( $choices as $key => $choice ) {
+            $checked = checked( $value, $key, false );
+            echo '<label style="display:block;margin-bottom:12px;">';
+            echo '<input type="radio" name="tts_settings[usage_profile]" value="' . esc_attr( $key ) . '" ' . $checked . ' /> ';
+            echo '<strong>' . esc_html( $choice['label'] ) . '</strong>';
+            echo '<br /><span class="description">' . esc_html( $choice['description'] ) . '</span>';
+            echo '</label>';
+        }
+        echo '</fieldset>';
+    }
+
+    /**
      * Render scheduling offset field for a channel.
      *
      * @param array $args Field arguments.
@@ -596,6 +653,12 @@ function tts_sanitize_settings( $input ) {
 
     if ( isset( $input['log_retention_days'] ) ) {
         $output['log_retention_days'] = absint( $input['log_retention_days'] );
+    }
+
+    if ( isset( $input['usage_profile'] ) ) {
+        $profile  = sanitize_key( $input['usage_profile'] );
+        $allowed  = array( 'standard', 'advanced', 'enterprise' );
+        $output['usage_profile'] = in_array( $profile, $allowed, true ) ? $profile : 'standard';
     }
 
     $offset_keys = array( 'facebook_offset', 'instagram_offset', 'youtube_offset', 'tiktok_offset' );

--- a/wp-content/plugins/trello-social-auto-publisher/tools/build-release-package.sh
+++ b/wp-content/plugins/trello-social-auto-publisher/tools/build-release-package.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PLUGIN_SLUG="trello-social-auto-publisher"
+PLUGIN_DIR="$ROOT_DIR/wp-content/plugins/$PLUGIN_SLUG"
+BUILD_ROOT="$ROOT_DIR/build/release"
+DIST_DIR="$BUILD_ROOT/$PLUGIN_SLUG"
+ARTIFACT_DIR="$BUILD_ROOT/artifacts"
+
+rm -rf "$BUILD_ROOT"
+mkdir -p "$DIST_DIR" "$ARTIFACT_DIR"
+
+VERSION="$(php -r '
+    $file = file_get_contents("'"$PLUGIN_DIR"'/trello-social-auto-publisher.php");
+    if (preg_match("/Version:\s*([0-9.]+)/", $file, $m)) {
+        echo $m[1];
+    }
+' 2>/dev/null || true)"
+if [[ -z "$VERSION" ]]; then
+    VERSION="dev-$(date +%Y%m%d%H%M)"
+fi
+
+echo "• Versione target: $VERSION"
+
+rsync -a --delete \
+  --exclude 'node_modules' \
+  --exclude '.git' \
+  --exclude '.github' \
+  --exclude '.DS_Store' \
+  --exclude 'tests' \
+  --exclude 'package-lock.json' \
+  "$PLUGIN_DIR/" "$DIST_DIR/"
+
+ZIP_NAME="${PLUGIN_SLUG}-${VERSION}.zip"
+ZIP_PATH="$ARTIFACT_DIR/$ZIP_NAME"
+
+pushd "$BUILD_ROOT" > /dev/null
+zip -rq "$ZIP_PATH" "$PLUGIN_SLUG"
+popd > /dev/null
+
+( cd "$ARTIFACT_DIR" && sha256sum "$ZIP_NAME" > checksums.txt )
+
+LAST_TAG="$(git -C "$ROOT_DIR" describe --tags --abbrev=0 2>/dev/null || echo '')"
+if [[ -n "$LAST_TAG" ]]; then
+    CHANGELOG="$(git -C "$ROOT_DIR" log --pretty='- %s' "${LAST_TAG}"..HEAD)"
+else
+    CHANGELOG="$(git -C "$ROOT_DIR" log --pretty='- %s' HEAD~20..HEAD)"
+fi
+if [[ -z "$CHANGELOG" ]]; then
+    CHANGELOG='- Aggiornamento tecnico.'
+fi
+
+cat > "$ARTIFACT_DIR/release-notes.md" <<EONOTES
+# FP Publisher v$VERSION
+
+## Sommario
+$CHANGELOG
+EONOTES
+
+cat > "$ARTIFACT_DIR/manifest.json" <<EOMANIFEST
+{
+  "plugin": "$PLUGIN_SLUG",
+  "version": "$VERSION",
+  "generated_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "artifacts": {
+    "package": "$ZIP_NAME",
+    "checksum_file": "checksums.txt"
+  }
+}
+EOMANIFEST
+
+echo "Pacchetto generato: $ZIP_PATH"
+echo "Manifest: $ARTIFACT_DIR/manifest.json"

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -496,6 +496,7 @@ add_action( 'plugins_loaded', function () {
         'class-tts-workflow-system.php',
         'class-tts-advanced-media.php',
         'class-tts-integration-hub.php',
+        'class-tts-cli.php',
         'tts-logger.php',
         'tts-notify.php',
         'tts-template.php',


### PR DESCRIPTION
## Summary
- add wizard-side AJAX validation for Trello credentials with inline feedback
- expose per-channel token testing during onboarding and surface the results in the client wizard UI
- document the new real-time verification flow across quickstart, troubleshooting, and onboarding guides

## Testing
- composer test
- php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d59d45c78c832fb832896555b1eb2b