### PR TITLE
Refine analytics batching and scheduling

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
@@ -14,52 +14,351 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class TTS_Analytics {
 
+    const LOCK_TRANSIENT          = 'tts_analytics_fetch_in_progress';
+    const OPTION_LAST_PROCESSED_ID = 'tts_analytics_last_processed_id';
+    const OPTION_LAST_RUN          = 'tts_analytics_last_run';
+    const ASYNC_ACTION_HOOK        = 'tts_fetch_post_metrics';
+
     /**
-     * Fetch metrics for all published social posts.
+     * Register asynchronous processing hook.
+     */
+    public static function register_async_hook() {
+        add_action( self::ASYNC_ACTION_HOOK, array( __CLASS__, 'process_post_metrics' ), 10, 1 );
+    }
+
+    /**
+     * Fetch metrics for published social posts in controllable batches.
      */
     public static function fetch_all() {
-        $posts = get_posts(
-            array(
-                'post_type'      => 'tts_social_post',
-                'posts_per_page' => -1,
-                'post_status'    => 'any',
-                'fields'         => 'ids',
-                'meta_key'       => '_published_status',
-                'meta_value'     => 'published',
-            )
-        );
-
-        foreach ( $posts as $post_id ) {
-            $client_id = (int) get_post_meta( $post_id, '_tts_client_id', true );
-            if ( ! $client_id ) {
-                continue;
-            }
-
-            $tokens = array(
-                'facebook'  => get_post_meta( $client_id, '_tts_fb_token', true ),
-                'instagram' => get_post_meta( $client_id, '_tts_ig_token', true ),
-                'youtube'   => get_post_meta( $client_id, '_tts_yt_token', true ),
-                'tiktok'    => get_post_meta( $client_id, '_tts_tt_token', true ),
+        if ( get_transient( self::LOCK_TRANSIENT ) ) {
+            TTS_Logger::log(
+                'Analytics batch skipped because a previous run is still in progress.',
+                'notice',
+                array( 'lock' => self::LOCK_TRANSIENT )
             );
+            return;
+        }
 
-            $channels = get_post_meta( $post_id, '_tts_social_channel', true );
-            $channels = is_array( $channels ) ? $channels : array( $channels );
+        set_transient( self::LOCK_TRANSIENT, 1, 30 * MINUTE_IN_SECONDS );
 
-            $metrics = array();
-            foreach ( $channels as $ch ) {
-                $method = 'fetch_' . $ch . '_metrics';
-                if ( method_exists( __CLASS__, $method ) ) {
-                    $creds  = isset( $tokens[ $ch ] ) ? $tokens[ $ch ] : '';
-                    $result = call_user_func( array( __CLASS__, $method ), $post_id, $creds );
-                    if ( ! is_wp_error( $result ) ) {
-                        $metrics[ $ch ] = self::count_interactions( (array) $result );
+        $overall_start     = microtime( true );
+        $batch_size        = (int) apply_filters( 'tts_analytics_batch_size', 75 );
+        $batch_size        = max( 1, $batch_size );
+        $max_batches       = (int) apply_filters( 'tts_analytics_max_batches_per_run', 5 );
+        $max_batches       = max( 1, $max_batches );
+        $pointer           = (int) get_option( self::OPTION_LAST_PROCESSED_ID, 0 );
+        $total_processed   = 0;
+        $total_scheduled   = 0;
+        $total_immediate   = 0;
+        $total_already_set = 0;
+        $batches_executed  = 0;
+        $scheduler_enabled = function_exists( 'as_schedule_single_action' );
+
+        try {
+            for ( $batch_index = 0; $batch_index < $max_batches; $batch_index++ ) {
+                $batch_start = microtime( true );
+                $post_ids    = self::query_batch_after( $pointer, $batch_size );
+
+                if ( empty( $post_ids ) ) {
+                    if ( 0 !== $pointer ) {
+                        TTS_Logger::log(
+                            'Analytics batch run reached the end of the dataset. Resetting pointer.',
+                            'debug',
+                            array(
+                                'last_pointer' => $pointer,
+                                'batch_size'   => $batch_size,
+                            )
+                        );
                     }
+
+                    $pointer = 0;
+                    update_option( self::OPTION_LAST_PROCESSED_ID, $pointer, false );
+                    break;
+                }
+
+                $batches_executed++;
+                $scheduled_in_batch = 0;
+                $immediate_in_batch = 0;
+                $already_in_queue   = 0;
+
+                foreach ( $post_ids as $post_id ) {
+                    $total_processed++;
+                    if ( $scheduler_enabled ) {
+                        $scheduled = self::schedule_async_job( $post_id );
+                        if ( $scheduled ) {
+                            $scheduled_in_batch++;
+                            $total_scheduled++;
+                        } else {
+                            $already_in_queue++;
+                            $total_already_set++;
+                        }
+                    } else {
+                        self::process_post_metrics( $post_id );
+                        $immediate_in_batch++;
+                        $total_immediate++;
+                    }
+                }
+
+                $pointer      = (int) end( $post_ids );
+                $batch_time   = (int) round( ( microtime( true ) - $batch_start ) * 1000 );
+                $has_more     = count( $post_ids ) >= $batch_size;
+                $batch_context = array(
+                    'pointer'             => $pointer,
+                    'processed'           => count( $post_ids ),
+                    'duration_ms'         => $batch_time,
+                    'scheduled'           => $scheduled_in_batch,
+                    'immediate'           => $immediate_in_batch,
+                    'already_in_queue'    => $already_in_queue,
+                    'scheduler_available' => $scheduler_enabled,
+                    'batch'               => $batch_index + 1,
+                );
+
+                TTS_Logger::log( 'Analytics batch processed.', 'info', $batch_context );
+
+                update_option( self::OPTION_LAST_PROCESSED_ID, $pointer, false );
+
+                if ( ! $has_more ) {
+                    $pointer = 0;
+                    update_option( self::OPTION_LAST_PROCESSED_ID, $pointer, false );
+                    break;
                 }
             }
 
-            if ( ! empty( $metrics ) ) {
-                update_post_meta( $post_id, '_tts_metrics', $metrics );
+            if ( $batches_executed >= $max_batches && $pointer > 0 ) {
+                TTS_Logger::log(
+                    'Analytics fetch paused after reaching the batch limit; processing will resume on the next run.',
+                    'notice',
+                    array(
+                        'pointer'     => $pointer,
+                        'max_batches' => $max_batches,
+                    )
+                );
             }
+
+            $overall_duration = (int) round( ( microtime( true ) - $overall_start ) * 1000 );
+            update_option(
+                self::OPTION_LAST_RUN,
+                array(
+                    'timestamp'        => current_time( 'timestamp' ),
+                    'duration_ms'      => $overall_duration,
+                    'processed'        => $total_processed,
+                    'batches'          => $batches_executed,
+                    'batch_size'       => $batch_size,
+                    'max_batches'      => $max_batches,
+                    'scheduled'        => $total_scheduled,
+                    'immediate'        => $total_immediate,
+                    'already_in_queue' => $total_already_set,
+                    'pointer'          => $pointer,
+                ),
+                false
+            );
+
+            TTS_Logger::log(
+                'Analytics fetch run completed.',
+                'notice',
+                array(
+                    'processed'        => $total_processed,
+                    'duration_ms'      => $overall_duration,
+                    'batches'          => $batches_executed,
+                    'batch_size'       => $batch_size,
+                    'max_batches'      => $max_batches,
+                    'scheduled'        => $total_scheduled,
+                    'immediate'        => $total_immediate,
+                    'already_in_queue' => $total_already_set,
+                    'pointer'          => $pointer,
+                )
+            );
+        } catch ( Throwable $throwable ) {
+            $error_duration = (int) round( ( microtime( true ) - $overall_start ) * 1000 );
+            TTS_Logger::log(
+                'Analytics batch execution failed: ' . $throwable->getMessage(),
+                'error',
+                array(
+                    'duration_ms' => $error_duration,
+                    'pointer'     => $pointer,
+                    'processed'   => $total_processed,
+                )
+            );
+        } finally {
+            delete_transient( self::LOCK_TRANSIENT );
+        }
+    }
+
+    /**
+     * Query the next batch of posts after the provided pointer.
+     *
+     * @param int $pointer   Last processed post ID.
+     * @param int $batch_size Number of posts to fetch.
+     *
+     * @return int[]
+     */
+    private static function query_batch_after( $pointer, $batch_size ) {
+        $args = array(
+            'post_type'              => 'tts_social_post',
+            'post_status'            => 'any',
+            'posts_per_page'         => $batch_size,
+            'orderby'                => 'ID',
+            'order'                  => 'ASC',
+            'fields'                 => 'ids',
+            'no_found_rows'          => true,
+            'update_post_term_cache' => false,
+            'update_post_meta_cache' => false,
+            'meta_query'             => array(
+                array(
+                    'key'   => '_published_status',
+                    'value' => 'published',
+                ),
+            ),
+        );
+
+        $filter = null;
+        if ( $pointer > 0 ) {
+            $filter = function ( $where ) use ( $pointer ) {
+                global $wpdb;
+                return $where . $wpdb->prepare( ' AND ' . $wpdb->posts . '.ID > %d', $pointer );
+            };
+            add_filter( 'posts_where', $filter );
+        }
+
+        if ( ! class_exists( 'WP_Query' ) ) {
+            require_once ABSPATH . WPINC . '/class-wp-query.php';
+        }
+
+        try {
+            $query = new WP_Query( $args );
+        } finally {
+            if ( $filter ) {
+                remove_filter( 'posts_where', $filter );
+            }
+        }
+
+        if ( ! isset( $query->posts ) || ! is_array( $query->posts ) ) {
+            return array();
+        }
+
+        return array_map( 'intval', $query->posts );
+    }
+
+    /**
+     * Schedule an asynchronous analytics job for the provided post ID.
+     *
+     * @param int $post_id Post ID.
+     *
+     * @return bool True when the job has been scheduled, false if it was already queued or scheduling is unavailable.
+     */
+    private static function schedule_async_job( $post_id ) {
+        if ( ! function_exists( 'as_schedule_single_action' ) ) {
+            return false;
+        }
+
+        $args = array( (int) $post_id );
+
+        if ( function_exists( 'as_next_scheduled_action' ) ) {
+            $existing = as_next_scheduled_action( self::ASYNC_ACTION_HOOK, $args, 'tts_analytics' );
+            if ( $existing ) {
+                return false;
+            }
+        }
+
+        static $offset = 0;
+        $spacing   = (int) apply_filters( 'tts_analytics_schedule_interval', 30 );
+        $spacing   = max( 0, $spacing );
+        $timestamp = time();
+
+        if ( $spacing > 0 ) {
+            $timestamp += $offset * $spacing;
+        }
+
+        as_schedule_single_action( $timestamp, self::ASYNC_ACTION_HOOK, $args, 'tts_analytics' );
+
+        if ( $spacing > 0 ) {
+            $offset++;
+        }
+
+        return true;
+    }
+
+    /**
+     * Process metrics for a single post (used both synchronously and via Action Scheduler).
+     *
+     * @param int $post_id Post ID.
+     */
+    public static function process_post_metrics( $post_id ) {
+        $post_id = (int) $post_id;
+        if ( $post_id <= 0 ) {
+            return;
+        }
+
+        $start_time = microtime( true );
+        $client_id  = (int) get_post_meta( $post_id, '_tts_client_id', true );
+
+        if ( ! $client_id ) {
+            TTS_Logger::log(
+                'Skipping analytics processing because the post has no associated client.',
+                'debug',
+                array( 'post_id' => $post_id )
+            );
+            return;
+        }
+
+        $tokens = array(
+            'facebook'  => get_post_meta( $client_id, '_tts_fb_token', true ),
+            'instagram' => get_post_meta( $client_id, '_tts_ig_token', true ),
+            'youtube'   => get_post_meta( $client_id, '_tts_yt_token', true ),
+            'tiktok'    => get_post_meta( $client_id, '_tts_tt_token', true ),
+        );
+
+        $channels_meta = get_post_meta( $post_id, '_tts_social_channel', true );
+        $channels      = is_array( $channels_meta ) ? array_filter( $channels_meta ) : array_filter( array( $channels_meta ) );
+
+        if ( empty( $channels ) ) {
+            TTS_Logger::log(
+                'Skipping analytics processing because no channels are associated with the post.',
+                'debug',
+                array( 'post_id' => $post_id )
+            );
+            return;
+        }
+
+        $metrics = array();
+        $errors  = array();
+
+        foreach ( $channels as $channel ) {
+            $method = 'fetch_' . $channel . '_metrics';
+            if ( ! method_exists( __CLASS__, $method ) ) {
+                $errors[ $channel ] = 'Metrics fetcher not available for channel.';
+                continue;
+            }
+
+            $credentials = isset( $tokens[ $channel ] ) ? $tokens[ $channel ] : '';
+            $result      = call_user_func( array( __CLASS__, $method ), $post_id, $credentials );
+
+            if ( is_wp_error( $result ) ) {
+                $errors[ $channel ] = $result->get_error_message();
+                continue;
+            }
+
+            $metrics[ $channel ] = self::count_interactions( (array) $result );
+        }
+
+        if ( ! empty( $metrics ) ) {
+            update_post_meta( $post_id, '_tts_metrics', $metrics );
+        }
+
+        $duration_ms = (int) round( ( microtime( true ) - $start_time ) * 1000 );
+        $context     = array(
+            'post_id'     => $post_id,
+            'client_id'   => $client_id,
+            'channels'    => array_values( $channels ),
+            'metrics_set' => count( $metrics ),
+            'duration_ms' => $duration_ms,
+        );
+
+        if ( ! empty( $errors ) ) {
+            $context['errors'] = $errors;
+            TTS_Logger::log( 'Analytics metrics processed with partial failures.', 'warning', $context );
+        } else {
+            TTS_Logger::log( 'Analytics metrics processed successfully.', 'debug', $context );
         }
     }
 

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -622,6 +622,9 @@ add_action( 'plugins_loaded', function () {
     // Attach the refresh action to the token refresh handler.
     add_action( 'tts_refresh_tokens', array( 'TTS_Token_Refresh', 'refresh_tokens' ) );
 
+    // Register async analytics processor.
+    add_action( 'init', array( 'TTS_Analytics', 'register_async_hook' ) );
+
     // Schedule daily metrics fetching.
     add_action( 'init', function () {
         if ( ! wp_next_scheduled( 'tts_fetch_metrics' ) ) {
@@ -639,21 +642,43 @@ add_action( 'plugins_loaded', function () {
         }
     } );
 
-    // Hook the link checker.
+    // Hook the link checker with batching to avoid large queries.
     add_action( 'tts_check_links', function () {
-        $posts = get_posts(
-            array(
-                'post_type'      => 'tts_social_post',
-                'post_status'    => 'any',
-                'posts_per_page' => -1,
-                'fields'         => 'ids',
-                'meta_key'       => '_published_status',
-                'meta_value'     => 'scheduled',
-            )
-        );
+        $batch_size = (int) apply_filters( 'tts_link_check_batch_size', 75 );
+        $batch_size = max( 1, $batch_size );
+        $paged      = 1;
 
-        foreach ( $posts as $post_id ) {
-            TTS_Link_Checker::verify_urls( $post_id );
-        }
+        do {
+            $query = new WP_Query(
+                array(
+                    'post_type'              => 'tts_social_post',
+                    'post_status'            => 'any',
+                    'posts_per_page'         => $batch_size,
+                    'paged'                  => $paged,
+                    'fields'                 => 'ids',
+                    'orderby'                => 'ID',
+                    'order'                  => 'ASC',
+                    'meta_key'               => '_published_status',
+                    'meta_value'             => 'scheduled',
+                    'no_found_rows'          => true,
+                    'update_post_term_cache' => false,
+                    'update_post_meta_cache' => false,
+                )
+            );
+
+            if ( empty( $query->posts ) ) {
+                break;
+            }
+
+            foreach ( $query->posts as $post_id ) {
+                TTS_Link_Checker::verify_urls( (int) $post_id );
+            }
+
+            if ( count( $query->posts ) < $batch_size ) {
+                break;
+            }
+
+            $paged++;
+        } while ( true );
     } );
 } );

--- a/wp-content/plugins/trello-social-auto-publisher/uninstall.php
+++ b/wp-content/plugins/trello-social-auto-publisher/uninstall.php
@@ -43,6 +43,7 @@ if ( function_exists( 'as_unschedule_all_actions' ) ) {
         'tts_publish_social_post',
         'tts_integration_sync_single',
         'tts_process_channel_job',
+        'tts_fetch_post_metrics',
     );
 
     foreach ( $action_scheduler_hooks as $hook ) {
@@ -120,6 +121,8 @@ $options_to_delete = array(
     'tts_youtube_daily_usage',
     'tts_first_activation',
     'tts_integration_hub_db_version',
+    'tts_analytics_last_processed_id',
+    'tts_analytics_last_run',
 );
 
 foreach ( $options_to_delete as $option_name ) {


### PR DESCRIPTION
## Summary
- add locking and resumable batching to the analytics fetcher while delegating per-post processing to Action Scheduler
- record batch metrics with throttled job scheduling and persist last-run metadata for observability
- batch the link checker query and ensure uninstall routines clean up new scheduler hooks and options

## Testing
- php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
- php -l wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
- php -l wp-content/plugins/trello-social-auto-publisher/uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68d68e6c4e78832f86c45bdb6b6650d8