### PR TITLE
docs(ui): document ui kit and add demo showcase

### DIFF
--- a/fp-digital-publisher/.rebuild-state.json
+++ b/fp-digital-publisher/.rebuild-state.json
@@ -1,9 +1,12 @@
 {
-  "current_phase": 14,
+  "current_phase": "U9",
   "done": true,
   "todos": [],
   "last_files_touched": [
-    "docs/FINAL-AUDIT.md"
+    "assets/ui/pages/_demo/UiShowcase.tsx",
+    "README.md",
+    "docs/UI-GUIDE.md",
+    ".rebuild-state.json"
   ],
   "errors": []
 }

--- a/fp-digital-publisher/README.md
+++ b/fp-digital-publisher/README.md
@@ -36,3 +36,100 @@ FP Digital Publisher è un plugin WordPress progettato per orchestrare campagne 
 ## Testing
 - `composer validate` per verificare la correttezza del `composer.json`.
 - `composer test` (dopo `composer install`) per avviare gli stub di test PHP con bootstrap e output TestDox (`./vendor/bin/phpunit --bootstrap tests/bootstrap.php --testdox tests`).
+
+## UI Polish Delta
+- Fase U0: introdotti design token condivisi, palette e reset controlli di base per l'SPA amministrativa.
+- Fase U1: aggiunti componenti riutilizzabili (badge di stato, toolbar sticky, empty state, skeleton, tooltip, modal e toast host) con styling coerente e bus notifiche minimale.
+- Fase U2: migliorata la pagina Calendario con toggle densità, schede drag con handle, skeleton di caricamento, azione "Suggerisci orario" e CTA "Importa da Trello" per le giornate vuote.
+- Fase U3: arricchito il Composer con stepper di avanzamento, chip Preflight interattivo, anteprima hashtag nel primo commento e validazioni inline con tooltip bloccanti.
+- Fase U4: introdotto workflow approvazioni con timeline, CTA "Approva e invia", gestione richieste modifiche e commenti con menzioni @ e annunci aria-live.
+- Fase U5: rifinite le viste Alert & Log con tab tematiche, filtri brand/canale, azioni contestuali e copia rapida di payload e stack con badge di stato.
+- Fase U6: rinnovata la gestione Short Link con tabella compatta, menu azioni (apri/copia/modifica/disattiva) e modal di creazione/modifica con validazione URL e anteprima UTM.
+- Fase U7: introdotto focus outline coerente, attributi aria-expanded/controls sui toggle, annunci polite per Preflight e Toast, oltre a centralizzare le stringhe UI Short Link/Composer nelle funzioni di traduzione.
+- Fase U8: aggiunta vetrina demo dei componenti UI, guida documentale e sezione README “UI Kit” con snippet di utilizzo.
+
+## UI Kit
+
+La libreria UI dell’admin SPA offre token condivisi e componenti accessibili riutilizzabili. Di seguito alcuni esempi rapidi.
+
+### StatusBadge
+
+```tsx
+import StatusBadge from 'assets/ui/components/StatusBadge';
+
+export const Example = () => <StatusBadge status="approved" />;
+```
+
+_Screenshot: badge di stato nelle varianti principali_
+
+### StickyToolbar + DensityToggle
+
+```tsx
+import { useState } from 'react';
+import StickyToolbar from 'assets/ui/components/StickyToolbar';
+import DensityToggle from 'assets/ui/components/DensityToggle';
+
+export const ToolbarExample = () => {
+  const [mode, setMode] = useState<'compact' | 'comfort'>('comfort');
+
+  return (
+    <StickyToolbar>
+      <h2>Elenco contenuti</h2>
+      <DensityToggle mode={mode} onChange={setMode} />
+    </StickyToolbar>
+  );
+};
+```
+
+_Screenshot: toolbar con toggle densità sopra un elenco_
+
+### EmptyState, SkeletonCard e ToastHost
+
+```tsx
+import EmptyState from 'assets/ui/components/EmptyState';
+import SkeletonCard from 'assets/ui/components/SkeletonCard';
+import ToastHost, { pushToast } from 'assets/ui/components/ToastHost';
+
+export const FeedbackExample = () => (
+  <>
+    <ToastHost placement="top-end" />
+    <SkeletonCard lines={3} />
+    <EmptyState
+      title="Nessun elemento"
+      primaryAction={{
+        label: 'Crea',
+        onClick: () => pushToast({ title: 'Creato!' }),
+      }}
+    />
+  </>
+);
+```
+
+_Screenshot: skeleton, empty state e toast host in pagina_
+
+### Modal e Tooltip
+
+```tsx
+import { useState } from 'react';
+import Tooltip from 'assets/ui/components/Tooltip';
+import Modal from 'assets/ui/components/Modal';
+
+export const ModalExample = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Tooltip content="Apri dettaglio">
+        <button type="button" onClick={() => setOpen(true)}>
+          Dettagli
+        </button>
+      </Tooltip>
+      <Modal isOpen={open} onDismiss={() => setOpen(false)} title="Anteprima">
+        …
+      </Modal>
+    </>
+  );
+};
+```
+
+_Screenshot: bottone con tooltip e modale aperta_

--- a/fp-digital-publisher/assets/admin/index.css
+++ b/fp-digital-publisher/assets/admin/index.css
@@ -76,6 +76,469 @@
   color: #646970;
 }
 
+.fp-composer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.fp-composer__header h2 {
+  margin-bottom: 4px;
+}
+
+.fp-composer__subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: #50575e;
+}
+
+.fp-stepper {
+  background: #fff;
+  border-radius: 8px;
+  padding: 12px 16px;
+  border: 1px solid #dcdcde;
+}
+
+.fp-stepper__list {
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+
+.fp-stepper__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #6c7781;
+  text-align: center;
+  min-width: 72px;
+}
+
+.fp-stepper__bullet {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  background: #f0f0f1;
+  color: #50575e;
+  border: 1px solid transparent;
+}
+
+.fp-stepper__item.is-active .fp-stepper__bullet {
+  background: #2271b1;
+  color: #fff;
+  border-color: #1e5f96;
+}
+
+.fp-stepper__item.is-active .fp-stepper__label {
+  color: #1d2327;
+  font-weight: 600;
+}
+
+.fp-stepper__item.is-complete .fp-stepper__bullet {
+  background: #2ecc71;
+  border-color: #25a35b;
+  color: #fff;
+}
+
+.fp-stepper__item.is-complete .fp-stepper__label {
+  color: #1d2327;
+}
+
+.fp-stepper__item.is-upcoming .fp-stepper__bullet {
+  background: #f6f7f7;
+  border-color: #dcdcde;
+}
+
+.fp-preflight-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 6px 12px;
+  border: 1px solid #d0d7e2;
+  background: #fff;
+  color: #1d2327;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.fp-preflight-chip:hover,
+.fp-preflight-chip:focus-visible {
+  border-color: #2271b1;
+  outline: none;
+  color: #1d2327;
+}
+
+.fp-preflight-chip__label {
+  font-weight: 600;
+}
+
+.fp-preflight-chip__score {
+  font-variant-numeric: tabular-nums;
+}
+
+.fp-preflight-chip[data-tone='positive'] {
+  background: #e8f5ec;
+  border-color: #2ecc71;
+}
+
+.fp-preflight-chip[data-tone='warning'] {
+  background: #fff4e5;
+  border-color: #f2a33c;
+}
+
+.fp-preflight-chip[data-tone='danger'] {
+  background: #fdecea;
+  border-color: #f15340;
+}
+
+.fp-composer__form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.fp-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fp-field label {
+  font-weight: 600;
+  color: #1d2327;
+}
+
+.fp-field input,
+.fp-field textarea {
+  border-radius: 6px;
+  border: 1px solid #ccd0d4;
+  padding: 8px 10px;
+  font-size: 14px;
+  color: #2c3338;
+  background: #fff;
+}
+
+.fp-field input:focus,
+.fp-field textarea:focus {
+  border-color: #2271b1;
+  box-shadow: 0 0 0 1px #2271b1;
+  outline: none;
+}
+
+.fp-field__hint {
+  margin: 0;
+  font-size: 12px;
+  color: #6c7781;
+}
+
+.fp-field--inline {
+  max-width: 280px;
+}
+
+.fp-composer__toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fp-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.fp-switch input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.fp-switch__control {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #dcdcde;
+  position: relative;
+  transition: background-color 0.2s ease;
+}
+
+.fp-switch__control::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s ease;
+}
+
+.fp-switch input:checked + .fp-switch__control {
+  background: #2271b1;
+}
+
+.fp-switch input:checked + .fp-switch__control::after {
+  transform: translateX(18px);
+}
+
+.fp-switch__label {
+  color: #1d2327;
+  font-size: 14px;
+}
+
+.fp-composer__hint {
+  margin: 0;
+  font-size: 12px;
+  color: #6c7781;
+}
+
+.fp-composer__preview {
+  border: 1px solid #d0d7e2;
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: #fff;
+}
+
+.fp-composer__preview h3 {
+  margin: 0 0 6px;
+  font-size: 13px;
+  color: #1d2327;
+}
+
+.fp-composer__preview p {
+  margin: 0;
+  font-size: 13px;
+  color: #2c3338;
+}
+
+.fp-composer__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.fp-composer__issues {
+  margin: 0;
+  font-size: 12px;
+  color: #1d2327;
+}
+
+.fp-composer__issues.is-error {
+  color: #b32d2e;
+}
+
+.fp-composer__feedback {
+  font-size: 13px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  display: none;
+}
+
+.fp-composer__feedback.is-success {
+  display: block;
+  background: #e7f7ed;
+  color: #0f5132;
+  border: 1px solid #badbcc;
+}
+
+.fp-composer__feedback.is-error {
+  display: block;
+  background: #fdecea;
+  color: #611a15;
+  border: 1px solid #f5c2c0;
+}
+
+button[disabled][data-tooltip] {
+  position: relative;
+}
+
+button[disabled][data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  background: #1d2327;
+  color: #fff;
+  padding: 8px 10px;
+  border-radius: 6px;
+  white-space: pre-line;
+  width: max-content;
+  max-width: 220px;
+  font-size: 12px;
+  line-height: 1.3;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 10;
+}
+
+button[disabled][data-tooltip]:hover::after,
+button[disabled][data-tooltip]:focus-visible::after {
+  opacity: 1;
+}
+
+.fp-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.fp-modal.is-open {
+  display: flex;
+}
+
+.fp-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(30, 32, 37, 0.45);
+}
+
+.fp-modal__dialog {
+  position: relative;
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 20px 50px rgba(30, 32, 37, 0.28);
+  max-width: 420px;
+  width: calc(100% - 48px);
+  z-index: 1;
+}
+
+.fp-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.fp-modal__header h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #1d2327;
+}
+
+.fp-modal__close {
+  border: none;
+  background: transparent;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: #50575e;
+}
+
+.fp-modal__close:hover,
+.fp-modal__close:focus-visible {
+  color: #1d2327;
+  outline: none;
+}
+
+.fp-modal__score {
+  margin: 0 0 16px;
+  font-size: 14px;
+  color: #1d2327;
+  font-weight: 600;
+}
+
+.fp-modal__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fp-modal__item {
+  border-radius: 8px;
+  border: 1px solid #d0d7e2;
+  padding: 12px 14px;
+  background: #f8f9fa;
+}
+
+.fp-modal__item[data-status='done'] {
+  border-color: #2ecc71;
+  background: #e7f7ed;
+}
+
+.fp-modal__item[data-status='pending'] {
+  border-color: #f2a33c;
+  background: #fff7ec;
+}
+
+.fp-modal__item-label {
+  font-weight: 600;
+  color: #1d2327;
+}
+
+.fp-modal__item-status {
+  font-size: 12px;
+  color: #50575e;
+  margin-left: 6px;
+}
+
+.fp-modal__item p {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: #2c3338;
+}
+
+.fp-widget__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fp-calendar__toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.fp-calendar__density-button {
+  border-radius: 999px;
+  border: 1px solid #d0d7e2;
+  background: #fff;
+  color: #1d2327;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 12px;
+  line-height: 1;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.fp-calendar__density-button:hover {
+  border-color: #2271b1;
+  color: #1d2327;
+}
+
+.fp-calendar__density-button.is-active {
+  background: #2271b1;
+  border-color: #1e5f96;
+  color: #fff;
+}
+
 .fp-publisher-calendar {
   width: 100%;
   border-collapse: collapse;
@@ -86,11 +549,22 @@
 
 .fp-publisher-calendar th,
 .fp-publisher-calendar td {
-  padding: 10px;
-  text-align: center;
   border: 1px solid #e2e4e7;
   font-size: 13px;
   color: #2c3338;
+}
+
+.fp-publisher-calendar th {
+  padding: 10px;
+  text-align: center;
+  background: #f6f7f7;
+}
+
+.fp-publisher-calendar td {
+  padding: 10px;
+  text-align: left;
+  vertical-align: top;
+  background: #fff;
 }
 
 .fp-publisher-calendar td.is-empty {
@@ -106,6 +580,228 @@
   border-radius: 50%;
   font-weight: 600;
   background: #fff;
+}
+
+.fp-calendar__cell {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 128px;
+}
+
+.fp-calendar__cell .fp-calendar-day {
+  align-self: flex-start;
+  background: #f6f7f7;
+}
+
+.fp-calendar__items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fp-calendar__items:empty {
+  display: none;
+}
+
+.fp-calendar__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: #f8f9fa;
+  border: 1px solid #e2e4e7;
+  border-left: 3px solid #c3c4c7;
+  text-align: left;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.fp-calendar__item:hover {
+  border-color: #2271b1;
+}
+
+.fp-calendar__item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fp-calendar__item-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1d2327;
+}
+
+.fp-calendar__item-meta {
+  font-size: 12px;
+  color: #50575e;
+}
+
+.fp-calendar__item-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #6c7781;
+  flex-shrink: 0;
+}
+
+.fp-calendar__item[data-status='draft'] {
+  border-left-color: #6c7781;
+}
+
+.fp-calendar__item[data-status='ready'] {
+  border-left-color: #2271b1;
+}
+
+.fp-calendar__item[data-status='approved'] {
+  border-left-color: #1e8c2f;
+}
+
+.fp-calendar__item[data-status='scheduled'] {
+  border-left-color: #f6a51a;
+}
+
+.fp-calendar__item[data-status='published'] {
+  border-left-color: #008a20;
+}
+
+.fp-calendar__item[data-status='failed'] {
+  border-left-color: #d63638;
+}
+
+.fp-calendar__item[data-status='retrying'] {
+  border-left-color: #a86008;
+}
+
+.fp-calendar__slot-action {
+  align-self: flex-start;
+  border: 1px dashed #2271b1;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 12px;
+  color: #2271b1;
+  background: transparent;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.fp-calendar__slot-action:hover {
+  background: rgba(34, 113, 177, 0.08);
+}
+
+.fp-calendar__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 32px 24px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px #dcdcde;
+  text-align: center;
+}
+
+.fp-calendar__empty h3 {
+  margin: 0;
+  font-size: 18px;
+  color: #1d2327;
+}
+
+.fp-calendar__empty p {
+  margin: 0;
+  font-size: 13px;
+  color: #50575e;
+  max-width: 320px;
+}
+
+.fp-calendar__error {
+  margin: 0;
+  padding: 16px;
+  border-radius: 8px;
+  background: #fce8e6;
+  border: 1px solid #d63638;
+  color: #d63638;
+  font-size: 13px;
+}
+
+.fp-publisher-calendar.is-compact td {
+  padding: 6px;
+}
+
+.fp-publisher-calendar.is-compact .fp-calendar__cell {
+  gap: 6px;
+  min-height: 104px;
+}
+
+.fp-publisher-calendar.is-compact .fp-calendar__items {
+  gap: 4px;
+}
+
+.fp-publisher-calendar.is-compact .fp-calendar__item {
+  padding: 6px 8px;
+}
+
+.fp-publisher-calendar.is-compact .fp-calendar-day {
+  width: 24px;
+  height: 24px;
+  font-size: 12px;
+}
+
+.fp-publisher-calendar.is-compact .fp-calendar__slot-action {
+  padding: 3px 10px;
+  font-size: 11px;
+}
+
+@keyframes fp-calendar-shimmer {
+  0% {
+    background-position: -180px 0;
+  }
+  100% {
+    background-position: calc(180px + 100%) 0;
+  }
+}
+
+.fp-calendar__skeleton {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.fp-calendar__skeleton-card {
+  padding: 16px;
+  border-radius: 8px;
+  background: #f0f0f1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.fp-calendar__skeleton-bar {
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.6) 50%, rgba(255, 255, 255, 0) 100%);
+  background-size: 180px 100%;
+  animation: fp-calendar-shimmer 1.2s ease-in-out infinite;
+}
+
+.fp-calendar__skeleton-bar.is-short {
+  width: 60%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fp-calendar__skeleton-bar {
+    animation: none;
+  }
+}
+
+.fp-besttime__context {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: #1d2327;
+  font-weight: 600;
 }
 
 .fp-kanban {
@@ -196,6 +892,144 @@
   color: #50575e;
 }
 
+.fp-approvals {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fp-approvals__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.fp-approvals__header h3 {
+  margin: 0;
+  font-size: 16px;
+  color: #1d2327;
+}
+
+.fp-approvals__hint {
+  margin: 4px 0 0;
+  color: #50575e;
+  font-size: 13px;
+}
+
+.fp-approvals__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.fp-approvals__timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.fp-approvals__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 12px;
+  box-shadow: inset 0 0 0 1px #dcdcde;
+}
+
+.fp-approvals__avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #2271b1;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.fp-approvals__content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fp-approvals__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.fp-approvals__meta strong {
+  color: #1d2327;
+}
+
+.fp-approvals__meta time {
+  font-size: 12px;
+  color: #646970;
+}
+
+.fp-approvals__badge {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.fp-approvals__badge[data-tone='positive'] {
+  background: #e8f5ec;
+  color: #137547;
+}
+
+.fp-approvals__badge[data-tone='neutral'] {
+  background: #f0f0f1;
+  color: #2c3338;
+}
+
+.fp-approvals__badge[data-tone='warning'] {
+  background: #fff4e5;
+  color: #8a4600;
+}
+
+.fp-approvals__note {
+  margin: 0;
+  font-size: 13px;
+  color: #2c3338;
+}
+
+.fp-approvals__placeholder {
+  margin: 0;
+  padding: 12px;
+  border-radius: 8px;
+  background: #f6f7f7;
+  font-size: 13px;
+  color: #50575e;
+  text-align: center;
+}
+
+.fp-approvals__placeholder--error {
+  color: #8a1f11;
+  background: #fdecea;
+}
+
+.fp-comments__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .fp-comments__header {
   display: flex;
   justify-content: space-between;
@@ -240,6 +1074,11 @@
   color: #2c3338;
 }
 
+.fp-comments__mention-token {
+  color: #2271b1;
+  font-weight: 600;
+}
+
 .fp-comments__loading,
 .fp-comments__error,
 .fp-comments__empty {
@@ -254,6 +1093,11 @@
   gap: 10px;
 }
 
+.fp-comments__field {
+  display: flex;
+  flex-direction: column;
+}
+
 .fp-comments__form textarea {
   width: 100%;
   padding: 10px;
@@ -261,6 +1105,71 @@
   border: 1px solid #dcdcde;
   font-size: 13px;
   resize: vertical;
+}
+
+.fp-comments__mentions {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  border: 1px solid #dcdcde;
+  border-radius: 6px;
+  background: #fff;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.12);
+  max-height: 220px;
+  overflow-y: auto;
+  position: relative;
+  z-index: 1;
+}
+
+.fp-comments__mention {
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  cursor: pointer;
+}
+
+.fp-comments__mention strong {
+  font-size: 13px;
+  color: #1d2327;
+}
+
+.fp-comments__mention span {
+  font-size: 12px;
+  color: #646970;
+}
+
+.fp-comments__mention.is-active,
+.fp-comments__mention:hover {
+  background: #f0f6fb;
+}
+
+.fp-comments__mention[aria-disabled='true'] {
+  cursor: default;
+  color: #646970;
+}
+
+.fp-comments__mention--loading,
+.fp-comments__mention--empty,
+.fp-comments__mention--error,
+.fp-comments__mention--hint {
+  font-size: 12px;
+  color: #646970;
+  text-align: left;
+}
+
+.fp-comments__submit {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.fp-comments__hint {
+  margin: 0;
+  font-size: 12px;
+  color: #646970;
 }
 
 .fp-publisher-admin__mount.has-error .fp-publisher-shell__message {
@@ -271,54 +1180,623 @@
   color: #646970;
 }
 
-.fp-shortlink__form {
+.fp-shortlink__body {
   display: grid;
-  gap: 8px;
-  margin-top: 8px;
+  gap: 16px;
 }
 
-.fp-shortlink__form label {
+.fp-shortlink__feedback {
+  margin: 0;
+  font-size: 14px;
+  color: #646970;
+}
+
+.fp-shortlink__feedback[data-tone='success'] {
+  color: #1d6f42;
+}
+
+.fp-shortlink__feedback[data-tone='error'] {
+  color: #b32d2e;
+}
+
+.fp-shortlink__table {
+  position: relative;
+  border: 1px solid #dcdcde;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.fp-shortlink__table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.fp-shortlink__table thead {
+  background: #f6f7f7;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  font-size: 12px;
+  color: #50575e;
+}
+
+.fp-shortlink__table th,
+.fp-shortlink__table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid #eceef0;
+  text-align: left;
+}
+
+.fp-shortlink__table tbody tr:last-child th,
+.fp-shortlink__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.fp-shortlink__slug {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 13px;
+  background: #f0f0f1;
+  padding: 2px 8px;
+  border-radius: 6px;
+  display: inline-block;
+}
+
+.fp-shortlink__target {
+  display: inline-block;
+  max-width: 320px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
+
+.fp-shortlink__metric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: #1d2327;
+}
+
+.fp-shortlink__actions {
+  text-align: right;
+}
+
+.fp-shortlink__menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.fp-shortlink__menu-toggle {
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  padding: 4px 8px;
+  cursor: pointer;
+  color: #3c434a;
+}
+
+.fp-shortlink__menu-toggle:hover,
+.fp-shortlink__menu-toggle:focus-visible,
+.fp-shortlink__menu-toggle.is-open {
+  border-color: #94a3b8;
+  background: #f0f4ff;
+  color: #1d2327;
+}
+
+.fp-shortlink__menu-icon {
+  display: inline-flex;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.fp-shortlink__menu-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 180px;
+  padding: 6px;
+  border-radius: 10px;
+  background: #ffffff;
+  border: 1px solid #dcdcde;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
   display: grid;
   gap: 4px;
+  z-index: 15;
+}
+
+.fp-shortlink__menu-panel button {
+  width: 100%;
+  text-align: left;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  font-size: 13px;
+  color: #1d2327;
+  cursor: pointer;
+}
+
+.fp-shortlink__menu-panel button:hover,
+.fp-shortlink__menu-panel button:focus-visible {
+  background: #f0f4ff;
+}
+
+.fp-shortlink__skeleton {
+  display: none;
+  gap: 8px;
+  padding: 16px;
+}
+
+.fp-shortlink__skeleton-row {
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #f1f5f9 0%, #e2e8f0 50%, #f1f5f9 100%);
+  background-size: 200% 100%;
+  animation: fp-calendar-shimmer 1.4s ease infinite;
+}
+
+.fp-shortlink__table[data-loading] table {
+  opacity: 0.45;
+}
+
+.fp-shortlink__table[data-loading] .fp-shortlink__skeleton {
+  display: grid;
+}
+
+.fp-shortlink__empty {
+  margin: 0;
+  font-size: 14px;
+  color: #646970;
+}
+
+.fp-shortlink__form {
+  display: grid;
+  gap: 12px;
+}
+
+.fp-shortlink__field {
+  display: grid;
+  gap: 6px;
   font-weight: 600;
 }
 
-.fp-shortlink__form input {
-  padding: 8px;
-  border: 1px solid #ccd0d4;
-  border-radius: 4px;
+.fp-shortlink__field input {
+  padding: 10px 12px;
+  border: 1px solid #c3c4c7;
+  border-radius: 8px;
+  font-size: 14px;
 }
 
-.fp-shortlink__form input:focus {
+.fp-shortlink__field input:focus {
   border-color: #2271b1;
   box-shadow: 0 0 0 1px #2271b1;
   outline: none;
 }
 
-.fp-shortlink__result {
-  margin-top: 10px;
-  font-size: 14px;
-  line-height: 1.4;
+.fp-shortlink__preview {
+  font-size: 13px;
+  line-height: 1.5;
+  background: #f6f7f7;
+  border-radius: 10px;
+  padding: 12px;
+  color: #1d2327;
 }
 
-.fp-shortlink__result code {
-  background: #f0f0f1;
+.fp-shortlink__preview code {
+  background: #ffffff;
   padding: 2px 6px;
-  border-radius: 3px;
-}
-
-.fp-shortlink__success {
-  color: #1d6f42;
+  border-radius: 6px;
 }
 
 .fp-shortlink__error {
+  margin: 0;
+  font-size: 13px;
   color: #b32d2e;
 }
 
-.fp-shortlink__loading {
-  color: #555d66;
+.fp-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
 }
 
-.fp-shortlink__empty {
+.fp-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: #f3f4f6;
+  color: #1d2327;
+  border: 1px solid #dcdcde;
+}
+
+.fp-status-badge[data-tone='positive'] {
+  background: rgba(5, 150, 105, 0.12);
+  border-color: rgba(5, 150, 105, 0.32);
+  color: #0f5132;
+}
+
+.fp-status-badge[data-tone='warning'] {
+  background: rgba(217, 119, 6, 0.12);
+  border-color: rgba(217, 119, 6, 0.32);
+  color: #7c4405;
+}
+
+.fp-status-badge[data-tone='danger'] {
+  background: rgba(220, 38, 38, 0.12);
+  border-color: rgba(220, 38, 38, 0.32);
+  color: #891b1b;
+}
+
+.fp-status-badge[data-tone='neutral'] {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+  color: #374151;
+}
+
+.fp-alerts {
+  display: grid;
+  gap: 16px;
+}
+
+.fp-alerts__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.fp-alerts__hint {
+  margin: 4px 0 0;
+  font-size: 13px;
   color: #646970;
+}
+
+.fp-alerts__filters {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.fp-alerts__filter {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: #50575e;
+}
+
+.fp-alerts__filter select {
+  min-width: 160px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid #dcdcde;
+  background: #fff;
+  font-size: 13px;
+  color: #1d2327;
+}
+
+.fp-alerts__filter select:focus {
+  border-color: #2271b1;
+  box-shadow: 0 0 0 1px #2271b1;
+  outline: none;
+}
+
+.fp-alerts__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.fp-alerts__tab {
+  border: 1px solid #dcdcde;
+  border-radius: 999px;
+  padding: 6px 14px;
+  background: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  color: #2c3338;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.fp-alerts__tab.is-active {
+  background: #2271b1;
+  color: #fff;
+  border-color: #135e96;
+  box-shadow: 0 2px 6px rgba(30, 80, 140, 0.18);
+}
+
+.fp-alerts__panel {
+  display: grid;
+  gap: 12px;
+}
+
+.fp-alerts__loading,
+.fp-alerts__empty,
+.fp-alerts__error {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px dashed #dcdcde;
+  background: #f6f7f7;
+  font-size: 13px;
+  color: #50575e;
+}
+
+.fp-alerts__error {
+  border-style: solid;
+  border-color: rgba(220, 38, 38, 0.28);
+  background: rgba(220, 38, 38, 0.08);
+  color: #a60018;
+}
+
+.fp-alerts__item {
+  border: 1px solid #dcdcde;
+  border-radius: 10px;
+  padding: 14px;
+  background: #fff;
+  display: grid;
+  gap: 10px;
+  border-left: 4px solid #dcdcde;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.04);
+}
+
+.fp-alerts__item[data-severity='critical'] {
+  border-left-color: #dc2626;
+}
+
+.fp-alerts__item[data-severity='warning'] {
+  border-left-color: #d97706;
+}
+
+.fp-alerts__item[data-severity='info'] {
+  border-left-color: #2271b1;
+}
+
+.fp-alerts__item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.fp-alerts__item-heading {
+  display: grid;
+  gap: 2px;
+  font-size: 13px;
+  color: #1d2327;
+}
+
+.fp-alerts__item-heading time {
+  font-size: 12px;
+  color: #646970;
+}
+
+.fp-alerts__detail {
+  margin: 0;
+  font-size: 13px;
+  color: #2c3338;
+  line-height: 1.5;
+}
+
+.fp-alerts__meta {
+  margin: 0;
+  font-size: 12px;
+  color: #646970;
+}
+
+.fp-alerts__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.fp-alerts__action {
+  font-size: 12px;
+  padding: 6px 14px;
+  border-radius: 999px;
+}
+
+.fp-logs {
+  display: grid;
+  gap: 16px;
+}
+
+.fp-logs__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.fp-logs__hint {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: #646970;
+}
+
+.fp-logs__search {
+  margin: 0;
+}
+
+.fp-logs__search input {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid #dcdcde;
+  background: #fff;
+  font-size: 13px;
+  min-width: 220px;
+}
+
+.fp-logs__search input:focus {
+  border-color: #2271b1;
+  box-shadow: 0 0 0 1px #2271b1;
+  outline: none;
+}
+
+.fp-logs__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.fp-logs__filter {
+  border: 1px solid #dcdcde;
+  border-radius: 999px;
+  padding: 6px 12px;
+  background: #fff;
+  font-size: 12px;
+  color: #2c3338;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.fp-logs__filter.is-active {
+  background: #1d2327;
+  color: #fff;
+  border-color: #1d2327;
+}
+
+.fp-logs__list {
+  display: grid;
+  gap: 12px;
+}
+
+.fp-logs__loading,
+.fp-logs__empty,
+.fp-logs__error {
+  margin: 0;
+  padding: 14px;
+  border-radius: 8px;
+  border: 1px dashed #dcdcde;
+  background: #f6f7f7;
+  font-size: 13px;
+  color: #50575e;
+}
+
+.fp-logs__error {
+  border-style: solid;
+  border-color: rgba(220, 38, 38, 0.24);
+  background: rgba(220, 38, 38, 0.08);
+  color: #a60018;
+}
+
+.fp-logs__entry {
+  border: 1px solid #dcdcde;
+  border-radius: 10px;
+  padding: 16px;
+  background: #fff;
+  display: grid;
+  gap: 12px;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.06);
+}
+
+.fp-logs__entry-header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.fp-logs__entry-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #646970;
+}
+
+.fp-logs__channel {
+  font-weight: 600;
+  color: #1d2327;
+}
+
+.fp-logs__message {
+  margin: 0;
+  font-size: 13px;
+  color: #1d2327;
+  line-height: 1.5;
+}
+
+.fp-logs__blocks {
+  display: grid;
+  gap: 12px;
+}
+
+@media (min-width: 720px) {
+  .fp-logs__blocks {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.fp-logs__block {
+  border: 1px solid #e2e4e7;
+  border-radius: 8px;
+  padding: 12px;
+  background: #f9fafb;
+  display: grid;
+  gap: 8px;
+}
+
+.fp-logs__block-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.fp-logs__block-header h4 {
+  margin: 0;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #50575e;
+}
+
+.fp-logs__code {
+  margin: 0;
+  padding: 12px;
+  background: #1f2937;
+  color: #f9fafb;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.fp-logs__copy {
+  font-size: 11px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid #dcdcde;
+  background: #fff;
+  color: #1d2327;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.fp-logs__copy.is-copied {
+  background: rgba(5, 150, 105, 0.16);
+  border-color: rgba(5, 150, 105, 0.4);
+  color: #0f5132;
+}
+
+.fp-logs__copy.has-error {
+  background: rgba(220, 38, 38, 0.16);
+  border-color: rgba(220, 38, 38, 0.4);
+  color: #891b1b;
 }

--- a/fp-digital-publisher/assets/admin/index.tsx
+++ b/fp-digital-publisher/assets/admin/index.tsx
@@ -1,3 +1,7 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+const TEXT_DOMAIN = 'fp_publisher';
+
 interface BootConfig {
   restBase: string;
   nonce: string;
@@ -24,12 +28,285 @@ type CommentItem = {
   };
 };
 
+type ApprovalEvent = {
+  id: number;
+  status: 'submitted' | 'in_review' | 'approved' | 'changes_requested';
+  note?: string | null;
+  actor: {
+    display_name: string;
+  };
+  occurred_at: string;
+};
+
+type MentionSuggestion = {
+  id: number;
+  name: string;
+  slug?: string;
+  description?: string | null;
+};
+
+type WPUser = {
+  id: number;
+  name: string;
+  slug?: string;
+  description?: string | null;
+};
+
 type ShortLink = {
   slug: string;
   target_url: string;
   clicks: number;
   last_click_at?: string | null;
 };
+
+type AlertSeverity = 'info' | 'warning' | 'critical';
+
+type AlertRecord = {
+  id: string;
+  title: string;
+  detail: string;
+  severity: AlertSeverity;
+  occurred_at?: string | null;
+  meta?: string | null;
+  action_label?: string | null;
+  action_href?: string | null;
+  action_type?: 'calendar' | 'job' | 'token';
+  action_target?: string | null;
+};
+
+type AlertsResponse = {
+  items?: AlertRecord[];
+};
+
+type LogStatus = 'ok' | 'warning' | 'error';
+
+type LogEntry = {
+  id: string;
+  message: string;
+  channel: string;
+  status: LogStatus;
+  payload?: string | null;
+  stack?: string | null;
+  created_at: string;
+};
+
+type LogsResponse = {
+  items?: LogEntry[];
+};
+
+type ComposerState = {
+  title: string;
+  caption: string;
+  scheduledAt: string;
+  hashtagsFirst: boolean;
+  issues: string[];
+  notes: string[];
+  score: number;
+};
+
+type PreflightInsight = {
+  id: string;
+  label: string;
+  description: string;
+  impact: number;
+};
+
+type CalendarSlotPayload = {
+  channel?: string;
+  scheduled_at?: string;
+};
+
+type CalendarPlanPayload = {
+  id?: number;
+  title?: string;
+  status?: string;
+  template?: { name?: string } | null;
+  slots?: CalendarSlotPayload[];
+};
+
+type CalendarResponse = {
+  items?: CalendarPlanPayload[];
+};
+
+type CalendarCellItem = {
+  id: string;
+  title: string;
+  status: string;
+  channel: string;
+  isoDate: string;
+  timeLabel: string;
+  timestamp: number;
+};
+
+const copy = {
+  common: {
+    close: __('Chiudi', TEXT_DOMAIN),
+  },
+  composer: {
+    header: __('Composer contenuti', TEXT_DOMAIN),
+    subtitle: __('Completa le informazioni chiave prima della programmazione.', TEXT_DOMAIN),
+    stepperLabel: __('Progressione composer', TEXT_DOMAIN),
+    steps: {
+      content: __('Contenuto', TEXT_DOMAIN),
+      variants: __('Varianti', TEXT_DOMAIN),
+      media: __('Media', TEXT_DOMAIN),
+      schedule: __('Programma', TEXT_DOMAIN),
+      review: __('Review', TEXT_DOMAIN),
+    },
+    fields: {
+      title: {
+        label: __('Titolo contenuto', TEXT_DOMAIN),
+        placeholder: __('Es. Lancio nuovo prodotto', TEXT_DOMAIN),
+      },
+      caption: {
+        label: __('Didascalia', TEXT_DOMAIN),
+        placeholder: __('Racconta la storia del contenuto e aggiungi le call-to-action.', TEXT_DOMAIN),
+        hint: __('Suggerimento: includi CTA, mention e short link.', TEXT_DOMAIN),
+      },
+      schedule: {
+        label: __('Programma', TEXT_DOMAIN),
+      },
+    },
+    hashtagToggle: {
+      label: __('Hashtag nel primo commento (IG)', TEXT_DOMAIN),
+      description: __('Sposta automaticamente gli hashtag nel primo commento per mantenere pulita la didascalia.', TEXT_DOMAIN),
+      previewTitle: __('Anteprima commento', TEXT_DOMAIN),
+      previewBody: __(' #marketing #launchday #fpDigitalPublisher', TEXT_DOMAIN).trimStart(),
+    },
+    actions: {
+      saveDraft: __('Salva bozza', TEXT_DOMAIN),
+      submit: __('Programma contenuto', TEXT_DOMAIN),
+    },
+    feedback: {
+      blocking: __('Risolvi gli elementi bloccanti prima di programmare.', TEXT_DOMAIN),
+      scheduled: __('Contenuto programmato per %s.', TEXT_DOMAIN),
+      fallbackDate: __('data da definire', TEXT_DOMAIN),
+      issuesPrefix: __('Correggi: %s', TEXT_DOMAIN),
+      noIssues: __('Nessuna criticità bloccante.', TEXT_DOMAIN),
+      draftSaved: __('Bozza salvata nei contenuti in lavorazione.', TEXT_DOMAIN),
+    },
+    validation: {
+      titleShort: __('Aggiungi un titolo descrittivo (minimo 5 caratteri).', TEXT_DOMAIN),
+      captionShort: __('Completa la didascalia con almeno 15 caratteri.', TEXT_DOMAIN),
+      captionDetail: __('Aggiungi ulteriori dettagli o CTA nella didascalia.', TEXT_DOMAIN),
+      scheduleInvalid: __('Imposta una data di pubblicazione futura.', TEXT_DOMAIN),
+      hashtagsOff: __('Attiva gli hashtag nel primo commento per ottimizzare la reach IG.', TEXT_DOMAIN),
+    },
+  },
+  preflight: {
+    chipLabel: __('Preflight', TEXT_DOMAIN),
+    modalTitle: __('Dettagli Preflight', TEXT_DOMAIN),
+  },
+  shortlinks: {
+    empty: __('Nessun short link configurato. Crea il primo per iniziare a tracciare le campagne.', TEXT_DOMAIN),
+    feedback: {
+      loading: __('Caricamento short link…', TEXT_DOMAIN),
+      empty: __('Nessun short link configurato. Crea il primo per tracciare le campagne.', TEXT_DOMAIN),
+      open: __('Apertura di %s in una nuova scheda.', TEXT_DOMAIN),
+      copySuccess: __('URL copiato negli appunti.', TEXT_DOMAIN),
+      copyError: __('Impossibile copiare negli appunti.', TEXT_DOMAIN),
+      disabling: __('Disattivazione in corso…', TEXT_DOMAIN),
+      disabledEmpty: __('Short link disattivato. Non ci sono altri link attivi.', TEXT_DOMAIN),
+      disabled: __('Short link disattivato correttamente.', TEXT_DOMAIN),
+      updated: __('Short link aggiornato correttamente.', TEXT_DOMAIN),
+      created: __('Short link creato con successo.', TEXT_DOMAIN),
+    },
+    section: {
+      title: __('Short link', TEXT_DOMAIN),
+      subtitle: __('Gestisci redirect e campagne rapide', TEXT_DOMAIN),
+      createButton: __('Nuovo short link', TEXT_DOMAIN),
+    },
+    validation: {
+      slugMissing: __('Inserisci uno slug.', TEXT_DOMAIN),
+      slugFormat: __('Lo slug può contenere solo lettere, numeri e trattini.', TEXT_DOMAIN),
+      targetMissing: __('Inserisci un URL di destinazione.', TEXT_DOMAIN),
+      targetInvalid: __('Inserisci un URL valido (es. https://esempio.com).', TEXT_DOMAIN),
+    },
+    preview: {
+      shortlinkLabel: __('Short link:', TEXT_DOMAIN),
+      utmLabel: __('Destinazione UTM:', TEXT_DOMAIN),
+      waiting: __('In attesa di un URL valido per calcolare le UTM.', TEXT_DOMAIN),
+    },
+    errors: {
+      disable: __('Errore durante la disattivazione (%s).', TEXT_DOMAIN),
+      save: __('Errore durante il salvataggio (%s).', TEXT_DOMAIN),
+    },
+    table: {
+      slug: __('Slug', TEXT_DOMAIN),
+      target: __('Destinazione', TEXT_DOMAIN),
+      clicks: __('Click', TEXT_DOMAIN),
+      lastClick: __('Ultimo click', TEXT_DOMAIN),
+      actions: __('Azioni', TEXT_DOMAIN),
+    },
+    actions: {
+      open: __('Apri', TEXT_DOMAIN),
+      copy: __('Copia URL', TEXT_DOMAIN),
+      edit: __('Modifica', TEXT_DOMAIN),
+      disable: __('Disattiva', TEXT_DOMAIN),
+    },
+    menuLabel: __('Azioni per %s', TEXT_DOMAIN),
+    modal: {
+      createTitle: __('Nuovo short link', TEXT_DOMAIN),
+      editTitle: __('Modifica short link', TEXT_DOMAIN),
+      slugLabel: __('Slug', TEXT_DOMAIN),
+      slugPlaceholder: __('promo-social', TEXT_DOMAIN),
+      targetLabel: __('URL di destinazione', TEXT_DOMAIN),
+      targetPlaceholder: __('https://esempio.com/promo', TEXT_DOMAIN),
+      previewDefault: __('Compila destinazione per generare l\'anteprima UTM.', TEXT_DOMAIN),
+      cancel: __('Annulla', TEXT_DOMAIN),
+      create: __('Crea short link', TEXT_DOMAIN),
+      update: __('Aggiorna link', TEXT_DOMAIN),
+    },
+  },
+};
+
+const GRIP_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M5 4.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5z"/><path d="M5 8.75A1.25 1.25 0 1 1 5 11a1.25 1.25 0 0 1 0-2.5zm5 0A1.25 1.25 0 1 1 10 11a1.25 1.25 0 0 1 0-2.5zm5 0A1.25 1.25 0 1 1 15 11a1.25 1.25 0 0 1 0-2.5z"/><path d="M5 13.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5z"/></svg>';
+
+const PREFLIGHT_INSIGHTS: PreflightInsight[] = [
+  {
+    id: 'title',
+    label: __('Titolo', TEXT_DOMAIN),
+    description: __('Utilizza un titolo descrittivo per aiutare il team a capire il focus del contenuto.', TEXT_DOMAIN),
+    impact: 30,
+  },
+  {
+    id: 'caption',
+    label: __('Didascalia', TEXT_DOMAIN),
+    description: __('Completa la didascalia con call-to-action e riferimenti di brand.', TEXT_DOMAIN),
+    impact: 30,
+  },
+  {
+    id: 'schedule',
+    label: __('Programmazione', TEXT_DOMAIN),
+    description: __('Definisci data e orario futuri per evitare conflitti con altri contenuti.', TEXT_DOMAIN),
+    impact: 25,
+  },
+  {
+    id: 'hashtags',
+    label: __('Hashtag', TEXT_DOMAIN),
+    description: __('Conferma gli hashtag nel primo commento per aumentare la reach su Instagram.', TEXT_DOMAIN),
+    impact: 15,
+  },
+];
+
+const composerState: ComposerState = {
+  title: '',
+  caption: '',
+  scheduledAt: '',
+  hashtagsFirst: false,
+  issues: [],
+  notes: [],
+  score: 100,
+};
+
+const composerInsightStatus = new Map<string, boolean>();
+let preflightModalReturnFocus: HTMLElement | null = null;
+let shortLinks: ShortLink[] = [];
+let shortLinkModalReturnFocus: HTMLElement | null = null;
+let shortLinkEditingSlug: string | null = null;
+let activeShortLinkMenu: HTMLButtonElement | null = null;
+let shortLinkModalKeydownHandler: ((event: KeyboardEvent) => void) | null = null;
 
 const adminWindow = window as AdminWindow;
 const config: BootConfig = adminWindow.fpPublisherAdmin ?? {
@@ -44,37 +321,1404 @@ const mount = document.getElementById('fp-publisher-admin-app');
 const now = new Date();
 const monthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
 const activeChannel = 'instagram';
+let calendarDensity: 'comfort' | 'compact' = 'comfort';
+
+type AlertTabKey = 'empty-week' | 'token-expiry' | 'failed-jobs';
+
+const ALERT_TAB_CONFIG: Record<AlertTabKey, { label: string; endpoint: string; empty: string }> = {
+  'empty-week': {
+    label: 'Settimana vuota',
+    endpoint: 'alerts/empty-week',
+    empty: 'Nessun buco rilevato per la settimana corrente.',
+  },
+  'token-expiry': {
+    label: 'Token in scadenza',
+    endpoint: 'alerts/token-expiry',
+    empty: 'Tutti i token risultano aggiornati.',
+  },
+  'failed-jobs': {
+    label: 'Job falliti',
+    endpoint: 'alerts/failed-jobs',
+    empty: 'Nessun job in errore nelle ultime 24 ore.',
+  },
+};
+
+const ALERT_BRANDS = ['brand-demo', 'brand-nord', 'brand-sud'];
+const ALERT_CHANNELS = ['instagram', 'facebook', 'linkedin', 'tiktok'];
+const ALERT_SEVERITY_LABELS: Record<AlertSeverity, string> = {
+  info: 'Informativo',
+  warning: 'Avviso',
+  critical: 'Critico',
+};
+
+let activeAlertTab: AlertTabKey = 'empty-week';
+let alertBrandFilter = config.brand ?? 'brand-demo';
+let alertChannelFilter: string = activeChannel;
+
+const LOG_STATUS_LABELS: Record<LogStatus, string> = {
+  ok: 'Operativo',
+  warning: 'Attenzione',
+  error: 'Errore',
+};
+
+const LOG_STATUS_TONES: Record<LogStatus, 'positive' | 'warning' | 'danger'> = {
+  ok: 'positive',
+  warning: 'warning',
+  error: 'danger',
+};
+
+const LOG_CHANNEL_OPTIONS = ['all', 'instagram', 'facebook', 'linkedin', 'tiktok'];
+const LOG_STATUS_OPTIONS: (LogStatus | 'all')[] = ['all', 'ok', 'warning', 'error'];
+
+let logsChannelFilter: string = 'all';
+let logsStatusFilter: LogStatus | 'all' = 'all';
+let logsSearchTerm = '';
+let logsSearchTimeout: number | undefined;
+
+const logCopyCache = new Map<string, { payload?: string | null; stack?: string | null }>();
+
+const adminBaseUrl = `${window.location.origin.replace(/\/$/, '')}/wp-admin/`;
+
+const APPROVAL_STATUS_LABELS: Record<ApprovalEvent['status'], string> = {
+  submitted: 'Inviato per revisione',
+  in_review: 'In revisione',
+  approved: 'Approvato',
+  changes_requested: 'Richieste modifiche',
+};
+
+const APPROVAL_STATUS_TONES: Record<ApprovalEvent['status'], 'positive' | 'neutral' | 'warning'> = {
+  submitted: 'neutral',
+  in_review: 'neutral',
+  approved: 'positive',
+  changes_requested: 'warning',
+};
+
+type MentionState = {
+  anchor: number;
+  query: string;
+  suggestions: MentionSuggestion[];
+  activeIndex: number;
+  list: HTMLUListElement | null;
+  textarea: HTMLTextAreaElement | null;
+};
+
+const mentionState: MentionState = {
+  anchor: -1,
+  query: '',
+  suggestions: [],
+  activeIndex: -1,
+  list: null,
+  textarea: null,
+};
+
+let mentionFetchTimeout: number | undefined;
+let mentionRequestId = 0;
 
 function formatDate(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 }
 
-function renderCalendar(container: HTMLElement): void {
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatHumanDate(date: Date): string {
+  return date.toLocaleDateString([], {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  });
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>'"]/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#039;';
+      default:
+        return char;
+    }
+  });
+}
+
+function toDomId(prefix: string, value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase();
+  return `${prefix}-${sanitized}`;
+}
+
+function truncateText(value: string, max = 72): string {
+  if (value.length <= max) {
+    return value;
+  }
+
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function formatLastClickAt(iso?: string | null): string {
+  if (!iso) {
+    return '—';
+  }
+
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) {
+    return '—';
+  }
+
+  return parsed.toLocaleString(undefined, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function buildShortLinkUrl(slug: string): string {
+  const origin = window.location.origin.replace(/\/$/, '');
+  return `${origin}/go/${slug}`;
+}
+
+function initialsForName(name: string): string {
+  const segments = name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2);
+  if (!segments.length) {
+    return '??';
+  }
+
+  return segments
+    .map((segment) => segment.charAt(0).toUpperCase())
+    .join('');
+}
+
+function formatCommentBody(body: string): string {
+  const escaped = escapeHtml(body);
+  return escaped
+    .replace(/(@[\w._-]+)/g, '<span class="fp-comments__mention-token">$1</span>')
+    .replace(/\n/g, '<br />');
+}
+
+function announceCommentUpdate(message: string): void {
+  const region = document.getElementById('fp-comments-announcer');
+  if (region) {
+    region.textContent = message;
+  }
+}
+
+function announceApprovalsUpdate(message: string): void {
+  const region = document.getElementById('fp-approvals-announcer');
+  if (region) {
+    region.textContent = message;
+  }
+}
+
+function announceAlertsUpdate(message: string): void {
+  const region = document.getElementById('fp-alerts-announcer');
+  if (region) {
+    region.textContent = message;
+  }
+}
+
+function announceLogsUpdate(message: string): void {
+  const region = document.getElementById('fp-logs-announcer');
+  if (region) {
+    region.textContent = message;
+  }
+}
+
+function resolvePlanTitle(plan: CalendarPlanPayload): string {
+  const rawTitle = (plan.title ?? plan.template?.name ?? '').trim();
+  if (rawTitle) {
+    return rawTitle;
+  }
+
+  if (plan.id) {
+    return `Piano #${plan.id}`;
+  }
+
+  return 'Piano senza titolo';
+}
+
+function humanizeLabel(value: string): string {
+  if (!value) {
+    return value;
+  }
+
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+function buildSelectOptions(values: string[], current: string): string {
+  return values
+    .filter((value) => value && typeof value === 'string')
+    .map((value) => {
+      const normalized = value.trim();
+      const selected = normalized === current ? ' selected' : '';
+      return `<option value="${escapeHtml(normalized)}"${selected}>${escapeHtml(humanizeLabel(normalized))}</option>`;
+    })
+    .join('');
+}
+
+function updateAlertTabs(activeKey: AlertTabKey): void {
+  const buttons = document.querySelectorAll<HTMLButtonElement>('[data-alert-tab]');
+  buttons.forEach((button) => {
+    const key = (button.dataset.alertTab as AlertTabKey | undefined) ?? 'empty-week';
+    const isActive = key === activeKey;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    button.setAttribute('tabindex', isActive ? '0' : '-1');
+  });
+}
+
+function renderAlertAction(item: AlertRecord): string {
+  if (item.action_href) {
+    const href = escapeHtml(item.action_href);
+    const label = escapeHtml(item.action_label ?? 'Apri dettagli');
+    return `<a class="button fp-alerts__action" href="${href}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+  }
+
+  if (item.action_type) {
+    const label = escapeHtml(item.action_label ?? 'Apri dettagli');
+    const targetAttr = item.action_target ? ` data-alert-target="${escapeHtml(item.action_target)}"` : '';
+    return `<button type="button" class="button fp-alerts__action" data-alert-action="${item.action_type}"${targetAttr}>${label}</button>`;
+  }
+
+  return '';
+}
+
+function alertSeverityTone(severity: AlertSeverity): 'neutral' | 'warning' | 'danger' {
+  if (severity === 'critical') {
+    return 'danger';
+  }
+  if (severity === 'warning') {
+    return 'warning';
+  }
+  return 'neutral';
+}
+
+function renderAlertItems(items: AlertRecord[]): string {
+  const listItems = items
+    .map((item) => {
+      const severity = item.severity ?? 'info';
+      const tone = alertSeverityTone(severity);
+      const severityLabel = ALERT_SEVERITY_LABELS[severity] ?? ALERT_SEVERITY_LABELS.info;
+      const timestamp = item.occurred_at
+        ? `<time datetime="${escapeHtml(item.occurred_at)}">${new Date(item.occurred_at).toLocaleString()}</time>`
+        : '';
+      const metaParts = [] as string[];
+      if (item.meta) {
+        metaParts.push(escapeHtml(item.meta));
+      }
+      const metaMarkup = metaParts.length
+        ? `<p class="fp-alerts__meta">${metaParts.join(' · ')}</p>`
+        : '';
+      const detailMarkup = item.detail ? `<p class="fp-alerts__detail">${escapeHtml(item.detail)}</p>` : '';
+      const actionMarkup = renderAlertAction(item);
+      const actionsWrapper = actionMarkup ? `<div class="fp-alerts__actions">${actionMarkup}</div>` : '';
+
+      return `
+        <li class="fp-alerts__item" role="listitem" data-severity="${escapeHtml(severity)}">
+          <header class="fp-alerts__item-header">
+            <span class="fp-status-badge" data-tone="${tone}">${escapeHtml(severityLabel)}</span>
+            <div class="fp-alerts__item-heading">
+              <strong>${escapeHtml(item.title)}</strong>
+              ${timestamp}
+            </div>
+          </header>
+          ${detailMarkup}
+          ${metaMarkup}
+          ${actionsWrapper}
+        </li>
+      `;
+    })
+    .join('');
+
+  return `<ul class="fp-alerts__list" role="list">${listItems}</ul>`;
+}
+
+async function loadAlertsData(tabKey: AlertTabKey): Promise<void> {
+  const panel = document.getElementById('fp-alerts-panel');
+  if (!panel) {
+    return;
+  }
+
+  activeAlertTab = tabKey;
+  updateAlertTabs(tabKey);
+
+  panel.innerHTML = '<p class="fp-alerts__loading">Caricamento alert…</p>';
+
+  const tabConfig = ALERT_TAB_CONFIG[tabKey];
+  const params = new URLSearchParams();
+  if (alertBrandFilter) {
+    params.set('brand', alertBrandFilter);
+  }
+  if (alertChannelFilter) {
+    params.set('channel', alertChannelFilter);
+  }
+
+  try {
+    const query = params.toString();
+    const url = `${config.restBase}/${tabConfig.endpoint}${query ? `?${query}` : ''}`;
+    const response = await fetchJSON<AlertsResponse>(url);
+    const items = Array.isArray(response.items) ? response.items : [];
+
+    if (!items.length) {
+      panel.innerHTML = `<p class="fp-alerts__empty">${escapeHtml(tabConfig.empty)}</p>`;
+      announceAlertsUpdate(tabConfig.empty);
+      return;
+    }
+
+    panel.innerHTML = renderAlertItems(items);
+    announceAlertsUpdate(`${items.length} alert aggiornati per la vista ${tabConfig.label}.`);
+  } catch (error) {
+    panel.innerHTML = `<p class="fp-alerts__error">Impossibile caricare gli alert (${escapeHtml((error as Error).message)}).</p>`;
+    announceAlertsUpdate('Errore durante il recupero degli alert.');
+  }
+}
+
+function renderAlertsWidget(container: HTMLElement): void {
+  const brandOptions = Array.from(new Set([alertBrandFilter, config.brand ?? '', ...ALERT_BRANDS])).filter(Boolean);
+  const channelOptions = Array.from(new Set([alertChannelFilter, activeChannel, ...ALERT_CHANNELS])).filter(Boolean);
+  const tabKeys = Object.keys(ALERT_TAB_CONFIG) as AlertTabKey[];
+
+  container.innerHTML = `
+    <section class="fp-alerts" aria-labelledby="fp-alerts-title">
+      <header class="fp-alerts__header">
+        <div>
+          <h2 id="fp-alerts-title">Alert operativi</h2>
+          <p class="fp-alerts__hint">Priorità della settimana per il team marketing.</p>
+        </div>
+        <div class="fp-alerts__filters">
+          <label class="fp-alerts__filter">
+            <span>Brand</span>
+            <select id="fp-alerts-brand">${buildSelectOptions(brandOptions, alertBrandFilter)}</select>
+          </label>
+          <label class="fp-alerts__filter">
+            <span>Canale</span>
+            <select id="fp-alerts-channel">${buildSelectOptions(channelOptions, alertChannelFilter)}</select>
+          </label>
+        </div>
+      </header>
+      <nav class="fp-alerts__tabs" role="tablist" aria-label="Categorie di alert">
+        ${tabKeys
+          .map((key) => {
+            const tab = ALERT_TAB_CONFIG[key];
+            const isActive = key === activeAlertTab;
+            return `<button type="button" class="fp-alerts__tab${isActive ? ' is-active' : ''}" role="tab" data-alert-tab="${key}" aria-controls="fp-alerts-panel" aria-selected="${isActive ? 'true' : 'false'}">${tab.label}</button>`;
+          })
+          .join('')}
+      </nav>
+      <div id="fp-alerts-panel" class="fp-alerts__panel" role="tabpanel" tabindex="0" aria-live="polite"></div>
+      <div id="fp-alerts-announcer" class="screen-reader-text" aria-live="polite"></div>
+    </section>
+  `;
+
+  const brandSelect = container.querySelector<HTMLSelectElement>('#fp-alerts-brand');
+  brandSelect?.addEventListener('change', () => {
+    alertBrandFilter = brandSelect.value;
+    void loadAlertsData(activeAlertTab);
+  });
+
+  const channelSelect = container.querySelector<HTMLSelectElement>('#fp-alerts-channel');
+  channelSelect?.addEventListener('change', () => {
+    alertChannelFilter = channelSelect.value;
+    void loadAlertsData(activeAlertTab);
+  });
+
+  const tabButtons = container.querySelectorAll<HTMLButtonElement>('[data-alert-tab]');
+  tabButtons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      const key = (button.dataset.alertTab as AlertTabKey | undefined) ?? 'empty-week';
+      void loadAlertsData(key);
+    });
+  });
+
+  container.addEventListener('click', (event) => {
+    const target = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-alert-action]');
+    if (!target) {
+      return;
+    }
+
+    event.preventDefault();
+    handleAlertAction(target);
+  });
+
+  updateAlertTabs(activeAlertTab);
+  void loadAlertsData(activeAlertTab);
+}
+
+function resolveAdminUrl(path: string): string {
+  if (/^https?:/i.test(path)) {
+    return path;
+  }
+
+  const normalized = path.replace(/^\/+/, '');
+  return `${adminBaseUrl}${normalized}`;
+}
+
+function handleAlertAction(button: HTMLButtonElement): void {
+  const action = (button.dataset.alertAction as AlertRecord['action_type'] | undefined) ?? null;
+  if (!action) {
+    return;
+  }
+
+  if (action === 'calendar') {
+    const calendar = document.getElementById('fp-calendar');
+    calendar?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    announceAlertsUpdate('Calendario messo a fuoco per pianificare la settimana vuota.');
+    return;
+  }
+
+  if (action === 'job') {
+    const jobId = button.dataset.alertTarget ?? '';
+    const url = jobId
+      ? `${adminBaseUrl}admin.php?page=fp-jobs&job=${encodeURIComponent(jobId)}`
+      : `${adminBaseUrl}admin.php?page=fp-jobs`;
+    window.open(url, '_blank', 'noopener');
+    announceAlertsUpdate('Job aperto in una nuova scheda.');
+    return;
+  }
+
+  if (action === 'token') {
+    const target = button.dataset.alertTarget ?? 'admin.php?page=fp-integrations';
+    const url = resolveAdminUrl(target);
+    window.open(url, '_blank', 'noopener');
+    announceAlertsUpdate('Pagina integrazioni aperta per il rinnovo token.');
+  }
+}
+
+function renderLogsEntries(entries: LogEntry[]): string {
+  const listItems = entries
+    .map((entry) => {
+      const tone = LOG_STATUS_TONES[entry.status] ?? 'warning';
+      const label = LOG_STATUS_LABELS[entry.status] ?? humanizeLabel(entry.status);
+      const timestamp = new Date(entry.created_at).toLocaleString();
+      const payloadDisabled = !entry.payload;
+      const stackDisabled = !entry.stack;
+
+      return `
+        <li class="fp-logs__entry" role="listitem" data-status="${escapeHtml(entry.status)}">
+          <header class="fp-logs__entry-header">
+            <span class="fp-status-badge" data-tone="${tone}">${escapeHtml(label)}</span>
+            <div class="fp-logs__entry-meta">
+              <span class="fp-logs__channel">${escapeHtml(entry.channel)}</span>
+              <time datetime="${escapeHtml(entry.created_at)}">${timestamp}</time>
+            </div>
+          </header>
+          <p class="fp-logs__message">${escapeHtml(entry.message)}</p>
+          <div class="fp-logs__blocks">
+            <section class="fp-logs__block">
+              <header class="fp-logs__block-header">
+                <h4>Payload</h4>
+                <button
+                  type="button"
+                  class="button fp-logs__copy"
+                  data-log-copy="payload"
+                  data-log-id="${escapeHtml(entry.id)}"
+                  data-label="Copia payload"
+                  aria-label="Copia payload log ${escapeHtml(entry.id)}"
+                  ${payloadDisabled ? 'disabled' : ''}
+                >Copia payload</button>
+              </header>
+              <pre class="fp-logs__code">${entry.payload ? escapeHtml(entry.payload) : '—'}</pre>
+            </section>
+            <section class="fp-logs__block">
+              <header class="fp-logs__block-header">
+                <h4>Stack trace</h4>
+                <button
+                  type="button"
+                  class="button fp-logs__copy"
+                  data-log-copy="stack"
+                  data-log-id="${escapeHtml(entry.id)}"
+                  data-label="Copia stack"
+                  aria-label="Copia stack log ${escapeHtml(entry.id)}"
+                  ${stackDisabled ? 'disabled' : ''}
+                >Copia stack</button>
+              </header>
+              <pre class="fp-logs__code">${entry.stack ? escapeHtml(entry.stack) : '—'}</pre>
+            </section>
+          </div>
+        </li>
+      `;
+    })
+    .join('');
+
+  return `<ul class="fp-logs__list-items" role="list">${listItems}</ul>`;
+}
+
+async function loadLogs(): Promise<void> {
+  const list = document.getElementById('fp-logs-list');
+  if (!list) {
+    return;
+  }
+
+  list.innerHTML = '<p class="fp-logs__loading">Caricamento log…</p>';
+
+  const params = new URLSearchParams();
+  if (config.brand) {
+    params.set('brand', config.brand);
+  }
+  if (logsChannelFilter !== 'all') {
+    params.set('channel', logsChannelFilter);
+  }
+  if (logsStatusFilter !== 'all') {
+    params.set('status', logsStatusFilter);
+  }
+  if (logsSearchTerm) {
+    params.set('search', logsSearchTerm);
+  }
+
+  try {
+    const query = params.toString();
+    const endpoint = `${config.restBase}/logs${query ? `?${query}` : ''}`;
+    const data = await fetchJSON<LogsResponse>(endpoint);
+    const items = Array.isArray(data.items) ? data.items : [];
+
+    if (!items.length) {
+      list.innerHTML = '<p class="fp-logs__empty">Nessun log trovato con i filtri correnti.</p>';
+      announceLogsUpdate('Nessun log disponibile per i filtri selezionati.');
+      logCopyCache.clear();
+      return;
+    }
+
+    logCopyCache.clear();
+    items.forEach((entry) => {
+      logCopyCache.set(entry.id, { payload: entry.payload, stack: entry.stack });
+    });
+
+    list.innerHTML = renderLogsEntries(items);
+    announceLogsUpdate(`${items.length} log caricati.`);
+  } catch (error) {
+    list.innerHTML = `<p class="fp-logs__error">Impossibile caricare i log (${escapeHtml((error as Error).message)}).</p>`;
+    announceLogsUpdate('Errore durante il recupero dei log.');
+  }
+}
+
+function renderLogsWidget(container: HTMLElement): void {
+  const channelButtons = LOG_CHANNEL_OPTIONS.map((value) => {
+    const isActive = value === logsChannelFilter;
+    const label = value === 'all' ? 'Tutti i canali' : humanizeLabel(value);
+    return `<button type="button" class="fp-logs__filter${isActive ? ' is-active' : ''}" data-log-channel="${value}" aria-pressed="${isActive ? 'true' : 'false'}">${label}</button>`;
+  }).join('');
+
+  const statusButtons = LOG_STATUS_OPTIONS.map((value) => {
+    const isActive = value === logsStatusFilter;
+    const label = value === 'all' ? 'Tutti gli stati' : LOG_STATUS_LABELS[value] ?? humanizeLabel(String(value));
+    return `<button type="button" class="fp-logs__filter${isActive ? ' is-active' : ''}" data-log-status="${value}" aria-pressed="${isActive ? 'true' : 'false'}">${label}</button>`;
+  }).join('');
+
+  container.innerHTML = `
+    <section class="fp-logs" aria-labelledby="fp-logs-title">
+      <header class="fp-logs__header">
+        <div>
+          <h2 id="fp-logs-title">Log operativi</h2>
+          <p class="fp-logs__hint">Monitoraggio job e diagnostica in tempo reale.</p>
+        </div>
+        <form class="fp-logs__search" role="search">
+          <label class="screen-reader-text" for="fp-logs-search">Cerca nei log</label>
+          <input type="search" id="fp-logs-search" placeholder="Cerca per messaggio o ID" value="${escapeHtml(logsSearchTerm)}" />
+        </form>
+      </header>
+      <div class="fp-logs__filters" data-log-filter="channel" role="group" aria-label="Filtra per canale">
+        ${channelButtons}
+      </div>
+      <div class="fp-logs__filters" data-log-filter="status" role="group" aria-label="Filtra per stato">
+        ${statusButtons}
+      </div>
+      <div id="fp-logs-list" class="fp-logs__list" aria-live="polite"></div>
+      <div id="fp-logs-announcer" class="screen-reader-text" aria-live="polite"></div>
+    </section>
+  `;
+
+  const searchInput = container.querySelector<HTMLInputElement>('#fp-logs-search');
+  searchInput?.addEventListener('input', () => {
+    logsSearchTerm = searchInput.value.trim();
+    if (logsSearchTimeout) {
+      window.clearTimeout(logsSearchTimeout);
+    }
+    logsSearchTimeout = window.setTimeout(() => {
+      void loadLogs();
+    }, 240);
+  });
+
+  const channelGroup = container.querySelector('[data-log-filter="channel"]');
+  channelGroup?.querySelectorAll<HTMLButtonElement>('button[data-log-channel]').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      const value = button.dataset.logChannel ?? 'all';
+      logsChannelFilter = value;
+      channelGroup.querySelectorAll<HTMLButtonElement>('button[data-log-channel]').forEach((btn) => {
+        const isActive = btn.dataset.logChannel === value;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+      void loadLogs();
+    });
+  });
+
+  const statusGroup = container.querySelector('[data-log-filter="status"]');
+  statusGroup?.querySelectorAll<HTMLButtonElement>('button[data-log-status]').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      const value = (button.dataset.logStatus as LogStatus | 'all' | undefined) ?? 'all';
+      logsStatusFilter = value;
+      statusGroup.querySelectorAll<HTMLButtonElement>('button[data-log-status]').forEach((btn) => {
+        const isActive = btn.dataset.logStatus === value;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+      void loadLogs();
+    });
+  });
+
+  container.addEventListener('click', (event) => {
+    const target = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-log-copy]');
+    if (!target) {
+      return;
+    }
+
+    event.preventDefault();
+    const field = target.dataset.logCopy === 'stack' ? 'stack' : 'payload';
+    void copyLogField(target, field);
+  });
+
+  void loadLogs();
+}
+
+async function writeClipboardText(value: string): Promise<void> {
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.setAttribute('readonly', 'true');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+}
+
+async function copyLogField(button: HTMLButtonElement, field: 'payload' | 'stack'): Promise<void> {
+  if (button.disabled) {
+    return;
+  }
+
+  const logId = button.dataset.logId ?? '';
+  if (!logId) {
+    return;
+  }
+
+  const entry = logCopyCache.get(logId);
+  if (!entry) {
+    return;
+  }
+
+  const value = field === 'payload' ? entry.payload : entry.stack;
+  if (!value) {
+    return;
+  }
+
+  const originalLabel = button.dataset.label ?? button.textContent ?? '';
+
+  try {
+    await writeClipboardText(value);
+    button.classList.add('is-copied');
+    button.textContent = 'Copiato';
+    announceLogsUpdate(`${field === 'payload' ? 'Payload' : 'Stack'} copiato negli appunti.`);
+  } catch (error) {
+    console.error('Impossibile copiare il log', error);
+    button.classList.add('has-error');
+    button.textContent = 'Errore copia';
+    announceLogsUpdate('Impossibile copiare negli appunti.');
+  } finally {
+    window.setTimeout(() => {
+      button.classList.remove('is-copied', 'has-error');
+      button.textContent = originalLabel;
+    }, 1800);
+  }
+}
+
+function renderComposer(container: HTMLElement): void {
+  container.innerHTML = `
+    <header class="fp-composer__header">
+      <div>
+        <h2>${copy.composer.header}</h2>
+        <p class="fp-composer__subtitle">${copy.composer.subtitle}</p>
+      </div>
+      <button
+        type="button"
+        class="fp-preflight-chip"
+        id="fp-preflight-chip"
+        aria-haspopup="dialog"
+        aria-controls="fp-preflight-modal"
+        aria-expanded="false"
+      >
+        <span class="fp-preflight-chip__label">${copy.preflight.chipLabel}</span>
+        <span class="fp-preflight-chip__score" id="fp-preflight-chip-score" aria-live="polite">100</span>
+      </button>
+    </header>
+    <nav class="fp-stepper" aria-label="${copy.composer.stepperLabel}">
+      <ol class="fp-stepper__list">
+        <li class="fp-stepper__item is-active" data-step="content">
+          <span class="fp-stepper__bullet" aria-hidden="true">1</span>
+          <span class="fp-stepper__label">${copy.composer.steps.content}</span>
+        </li>
+        <li class="fp-stepper__item" data-step="variants">
+          <span class="fp-stepper__bullet" aria-hidden="true">2</span>
+          <span class="fp-stepper__label">${copy.composer.steps.variants}</span>
+        </li>
+        <li class="fp-stepper__item" data-step="media">
+          <span class="fp-stepper__bullet" aria-hidden="true">3</span>
+          <span class="fp-stepper__label">${copy.composer.steps.media}</span>
+        </li>
+        <li class="fp-stepper__item" data-step="programma">
+          <span class="fp-stepper__bullet" aria-hidden="true">4</span>
+          <span class="fp-stepper__label">${copy.composer.steps.schedule}</span>
+        </li>
+        <li class="fp-stepper__item" data-step="review">
+          <span class="fp-stepper__bullet" aria-hidden="true">5</span>
+          <span class="fp-stepper__label">${copy.composer.steps.review}</span>
+        </li>
+      </ol>
+    </nav>
+    <form id="fp-composer-form" class="fp-composer__form" novalidate>
+      <div class="fp-field">
+        <label for="fp-composer-title">${copy.composer.fields.title.label}</label>
+        <input type="text" id="fp-composer-title" name="title" placeholder="${copy.composer.fields.title.placeholder}" required />
+      </div>
+      <div class="fp-field">
+        <label for="fp-composer-caption">${copy.composer.fields.caption.label}</label>
+        <textarea
+          id="fp-composer-caption"
+          name="caption"
+          rows="4"
+          placeholder="${copy.composer.fields.caption.placeholder}"
+          required
+        ></textarea>
+        <p class="fp-field__hint">${copy.composer.fields.caption.hint}</p>
+      </div>
+      <div class="fp-field fp-field--inline">
+        <label for="fp-composer-schedule">${copy.composer.fields.schedule.label}</label>
+        <input type="datetime-local" id="fp-composer-schedule" name="scheduled_at" required />
+      </div>
+      <div class="fp-composer__toggle">
+        <label class="fp-switch" for="fp-hashtag-toggle">
+          <input
+            type="checkbox"
+            id="fp-hashtag-toggle"
+            aria-describedby="fp-hashtag-hint"
+            aria-controls="fp-hashtag-preview"
+            aria-expanded="false"
+          />
+          <span class="fp-switch__control" aria-hidden="true"></span>
+          <span class="fp-switch__label">${copy.composer.hashtagToggle.label}</span>
+        </label>
+        <p id="fp-hashtag-hint" class="fp-composer__hint">
+          ${copy.composer.hashtagToggle.description}
+        </p>
+      </div>
+      <section id="fp-hashtag-preview" class="fp-composer__preview" hidden aria-live="polite">
+        <h3>${copy.composer.hashtagToggle.previewTitle}</h3>
+        <p>${copy.composer.hashtagToggle.previewBody}</p>
+      </section>
+      <div class="fp-composer__actions">
+        <button type="button" class="button" id="fp-composer-save-draft">${copy.composer.actions.saveDraft}</button>
+        <button type="submit" class="button button-primary" id="fp-composer-submit" data-tooltip-position="top">
+          ${copy.composer.actions.submit}
+        </button>
+      </div>
+      <p id="fp-composer-issues" class="fp-composer__issues" role="status" aria-live="polite"></p>
+      <div id="fp-composer-feedback" class="fp-composer__feedback" aria-live="polite"></div>
+    </form>
+    <div class="fp-modal" id="fp-preflight-modal" role="dialog" aria-modal="true" aria-labelledby="fp-preflight-title" hidden>
+      <div class="fp-modal__backdrop" data-modal-overlay></div>
+      <div class="fp-modal__dialog" role="document">
+        <header class="fp-modal__header">
+          <h2 id="fp-preflight-title">${copy.preflight.modalTitle}</h2>
+          <button type="button" class="fp-modal__close" data-modal-close aria-label="${escapeHtml(copy.common.close)}">×</button>
+        </header>
+        <p id="fp-preflight-score" class="fp-modal__score" aria-live="polite"></p>
+        <ul id="fp-preflight-list" class="fp-modal__list"></ul>
+      </div>
+    </div>
+  `;
+}
+
+function initComposer(): void {
+  const composer = document.getElementById('fp-composer');
+  if (!composer) {
+    return;
+  }
+
+  const form = composer.querySelector<HTMLFormElement>('#fp-composer-form');
+  const titleInput = form?.querySelector<HTMLInputElement>('#fp-composer-title') ?? null;
+  const captionInput = form?.querySelector<HTMLTextAreaElement>('#fp-composer-caption') ?? null;
+  const scheduleInput = form?.querySelector<HTMLInputElement>('#fp-composer-schedule') ?? null;
+  const submitButton = form?.querySelector<HTMLButtonElement>('#fp-composer-submit') ?? null;
+  const saveDraftButton = form?.querySelector<HTMLButtonElement>('#fp-composer-save-draft') ?? null;
+  const issuesOutput = form?.querySelector<HTMLParagraphElement>('#fp-composer-issues') ?? null;
+  const feedbackOutput = form?.querySelector<HTMLDivElement>('#fp-composer-feedback') ?? null;
+  const hashtagToggle = form?.querySelector<HTMLInputElement>('#fp-hashtag-toggle') ?? null;
+  const hashtagPreview = form?.querySelector<HTMLElement>('#fp-hashtag-preview') ?? null;
+  const stepperItems = Array.from(composer.querySelectorAll<HTMLElement>('.fp-stepper__item'));
+  const preflightChip = composer.querySelector<HTMLButtonElement>('#fp-preflight-chip');
+  const preflightChipScore = composer.querySelector<HTMLElement>('#fp-preflight-chip-score');
+  const modal = composer.querySelector<HTMLElement>('#fp-preflight-modal');
+  const modalList = modal?.querySelector<HTMLUListElement>('#fp-preflight-list') ?? null;
+  const modalScore = modal?.querySelector<HTMLElement>('#fp-preflight-score') ?? null;
+  const modalClose = modal?.querySelector<HTMLButtonElement>('[data-modal-close]') ?? null;
+  const modalOverlay = modal?.querySelector<HTMLElement>('[data-modal-overlay]') ?? null;
+
+  if (
+    !form ||
+    !titleInput ||
+    !captionInput ||
+    !scheduleInput ||
+    !submitButton ||
+    !preflightChip ||
+    !preflightChipScore ||
+    !modal ||
+    !modalList ||
+    !modalScore ||
+    !modalClose ||
+    !modalOverlay ||
+    !issuesOutput ||
+    !feedbackOutput ||
+    !hashtagToggle ||
+    !hashtagPreview
+  ) {
+    return;
+  }
+
+  const getFocusable = (root: HTMLElement): HTMLElement[] => {
+    return Array.from(
+      root.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((node) => node.offsetParent !== null);
+  };
+
+  const updatePreflightModal = (): void => {
+    modalScore.textContent = `Score complessivo: ${composerState.score}/100`;
+    modalList.innerHTML = PREFLIGHT_INSIGHTS.map((insight) => {
+      const resolved = composerInsightStatus.get(insight.id) === true;
+      const status = resolved ? 'Completato' : 'Da rivedere';
+      return `
+        <li class="fp-modal__item" data-status="${resolved ? 'done' : 'pending'}">
+          <div>
+            <span class="fp-modal__item-label">${insight.label}</span>
+            <span class="fp-modal__item-status">${status}</span>
+          </div>
+          <p>${insight.description}</p>
+        </li>
+      `;
+    }).join('');
+  };
+
+  const updatePreflightChip = (): void => {
+    const tone = composerState.score >= 80 ? 'positive' : composerState.score >= 60 ? 'warning' : 'danger';
+    preflightChip.dataset.tone = tone;
+    preflightChipScore.textContent = String(composerState.score);
+    updatePreflightModal();
+  };
+
+  const updateStepper = (): void => {
+    const hasTitle = composerInsightStatus.get('title') === true;
+    const hasCaption = composerInsightStatus.get('caption') === true;
+    const hasSchedule = composerInsightStatus.get('schedule') === true;
+    const hashtagsReady = composerInsightStatus.get('hashtags') === true;
+    const steps = ['content', 'variants', 'media', 'programma', 'review'];
+
+    const completion: Record<string, boolean> = {
+      content: hasTitle,
+      variants: hasCaption,
+      media: hasCaption,
+      programma: hasSchedule,
+      review: hasSchedule && hashtagsReady,
+    };
+
+    const firstPending = steps.find((step) => !completion[step]) ?? 'review';
+
+    stepperItems.forEach((item) => {
+      const step = item.dataset.step ?? '';
+      item.classList.remove('is-active', 'is-complete', 'is-upcoming');
+
+      if (completion[step]) {
+        item.classList.add('is-complete');
+        return;
+      }
+
+      if (step === firstPending) {
+        item.classList.add('is-active');
+      } else {
+        item.classList.add('is-upcoming');
+      }
+    });
+  };
+
+  const updateIssues = (): void => {
+    const issues = composerState.issues;
+    const messages =
+      issues.length > 0
+        ? sprintf(copy.composer.feedback.issuesPrefix, issues.join(' · '))
+        : copy.composer.feedback.noIssues;
+    issuesOutput.textContent = messages;
+    if (issues.length > 0) {
+      issuesOutput.classList.add('is-error');
+    } else {
+      issuesOutput.classList.remove('is-error');
+    }
+  };
+
+  const updateSubmitState = (): void => {
+    const tooltipMessage = composerState.issues.join('\n');
+    if (composerState.issues.length > 0) {
+      submitButton.disabled = true;
+      submitButton.dataset.tooltip = tooltipMessage;
+      submitButton.setAttribute('aria-describedby', issuesOutput.id);
+    } else {
+      submitButton.disabled = false;
+      submitButton.removeAttribute('data-tooltip');
+      submitButton.removeAttribute('aria-describedby');
+    }
+  };
+
+  const updateHashtagPreview = (): void => {
+    if (composerState.hashtagsFirst) {
+      hashtagPreview.removeAttribute('hidden');
+      hashtagToggle.setAttribute('aria-expanded', 'true');
+    } else {
+      hashtagPreview.setAttribute('hidden', '');
+      hashtagToggle.setAttribute('aria-expanded', 'false');
+    }
+  };
+
+  const evaluateComposer = (): void => {
+    composerState.title = titleInput.value;
+    composerState.caption = captionInput.value;
+    composerState.scheduledAt = scheduleInput.value;
+    composerState.hashtagsFirst = hashtagToggle.checked;
+    composerState.issues = [];
+    composerState.notes = [];
+    composerInsightStatus.clear();
+
+    let score = 100;
+
+    const title = composerState.title.trim();
+    if (title.length < 5) {
+      composerState.issues.push(copy.composer.validation.titleShort);
+      composerInsightStatus.set('title', false);
+      score -= 30;
+    } else {
+      composerInsightStatus.set('title', true);
+    }
+
+    const caption = composerState.caption.trim();
+    if (caption.length < 15) {
+      composerState.issues.push(copy.composer.validation.captionShort);
+      composerInsightStatus.set('caption', false);
+      score -= 30;
+    } else {
+      composerInsightStatus.set('caption', true);
+      if (caption.length < 80) {
+        composerState.notes.push(copy.composer.validation.captionDetail);
+      }
+    }
+
+    const scheduledValue = composerState.scheduledAt;
+    const scheduledDate = scheduledValue ? new Date(scheduledValue) : null;
+    if (!scheduledDate || Number.isNaN(scheduledDate.getTime()) || scheduledDate.getTime() <= Date.now()) {
+      composerState.issues.push(copy.composer.validation.scheduleInvalid);
+      composerInsightStatus.set('schedule', false);
+      score -= 25;
+    } else {
+      composerInsightStatus.set('schedule', true);
+    }
+
+    if (composerState.hashtagsFirst) {
+      composerInsightStatus.set('hashtags', true);
+    } else {
+      composerInsightStatus.set('hashtags', false);
+      composerState.notes.push(copy.composer.validation.hashtagsOff);
+      score -= 10;
+    }
+
+    composerState.score = Math.max(0, Math.min(100, score));
+
+    updatePreflightChip();
+    updateStepper();
+    updateIssues();
+    updateSubmitState();
+    updateHashtagPreview();
+
+    if (feedbackOutput.textContent) {
+      feedbackOutput.textContent = '';
+      feedbackOutput.classList.remove('is-success', 'is-error');
+    }
+  };
+
+  const closePreflightModal = (): void => {
+    modal.setAttribute('hidden', '');
+    modal.classList.remove('is-open');
+    modal.removeEventListener('keydown', handleModalKeydown);
+    preflightChip.setAttribute('aria-expanded', 'false');
+    if (preflightModalReturnFocus) {
+      preflightModalReturnFocus.focus();
+    }
+  };
+
+  const handleModalKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closePreflightModal();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      const focusable = getFocusable(modal);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  const openPreflightModal = (): void => {
+    preflightModalReturnFocus = (document.activeElement as HTMLElement) ?? null;
+    modal.removeAttribute('hidden');
+    modal.classList.add('is-open');
+    modal.addEventListener('keydown', handleModalKeydown);
+    preflightChip.setAttribute('aria-expanded', 'true');
+    const focusable = getFocusable(modal);
+    (focusable[0] ?? modalClose).focus();
+  };
+
+  titleInput.addEventListener('input', evaluateComposer);
+  captionInput.addEventListener('input', evaluateComposer);
+  scheduleInput.addEventListener('input', evaluateComposer);
+  hashtagToggle.addEventListener('change', () => {
+    composerState.hashtagsFirst = hashtagToggle.checked;
+    evaluateComposer();
+  });
+
+  preflightChip.addEventListener('click', (event) => {
+    event.preventDefault();
+    openPreflightModal();
+  });
+
+  modalClose.addEventListener('click', (event) => {
+    event.preventDefault();
+    closePreflightModal();
+  });
+
+  modalOverlay.addEventListener('click', () => {
+    closePreflightModal();
+  });
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    evaluateComposer();
+    if (composerState.issues.length > 0) {
+      feedbackOutput.textContent = copy.composer.feedback.blocking;
+      feedbackOutput.classList.remove('is-success');
+      feedbackOutput.classList.add('is-error');
+      return;
+    }
+
+    const scheduledDate = composerState.scheduledAt ? new Date(composerState.scheduledAt) : null;
+    const timeLabel = scheduledDate ? scheduledDate.toLocaleString() : copy.composer.feedback.fallbackDate;
+    feedbackOutput.textContent = sprintf(copy.composer.feedback.scheduled, timeLabel);
+    feedbackOutput.classList.remove('is-error');
+    feedbackOutput.classList.add('is-success');
+  });
+
+  saveDraftButton?.addEventListener('click', (event) => {
+    event.preventDefault();
+    feedbackOutput.textContent = copy.composer.feedback.draftSaved;
+    feedbackOutput.classList.remove('is-error');
+    feedbackOutput.classList.add('is-success');
+  });
+
+  evaluateComposer();
+}
+
+async function renderCalendar(container: HTMLElement): Promise<void> {
+  renderCalendarSkeleton(container);
+
+  const params = new URLSearchParams({
+    brand: config.brand ?? 'brand-demo',
+    channel: activeChannel,
+    month: monthKey,
+  });
+
+  try {
+    const data = await fetchJSON<CalendarResponse>(`${config.restBase}/plans?${params.toString()}`);
+    const items = Array.isArray(data.items) ? data.items : [];
+
+    if (items.length === 0) {
+      renderCalendarEmpty(container);
+      return;
+    }
+
+    renderCalendarGrid(container, items);
+  } catch (error) {
+    const message = (error as Error)?.message ?? 'Errore sconosciuto';
+    container.innerHTML = `<p class="fp-calendar__error">Impossibile caricare il calendario (${escapeHtml(message)}).</p>`;
+  }
+}
+
+function renderCalendarSkeleton(container: HTMLElement): void {
+  const placeholders = Array.from({ length: 6 })
+    .map(
+      () =>
+        '<div class="fp-calendar__skeleton-card" aria-hidden="true"><div class="fp-calendar__skeleton-bar"></div><div class="fp-calendar__skeleton-bar is-short"></div></div>',
+    )
+    .join('');
+
+  container.innerHTML = `
+    <div class="fp-calendar__skeleton" role="status" aria-live="polite">
+      <span class="screen-reader-text">Caricamento pianificazioni…</span>
+      ${placeholders}
+    </div>
+  `;
+}
+
+function renderCalendarEmpty(container: HTMLElement): void {
+  container.innerHTML = `
+    <div class="fp-calendar__empty" role="alert">
+      <h3>Calendario vuoto</h3>
+      <p>Importa le pianificazioni da Trello per iniziare.</p>
+      <button type="button" class="button button-primary" data-action="calendar-import">Importa da Trello</button>
+    </div>
+  `;
+}
+
+function collectCalendarItems(plans: CalendarPlanPayload[]): Map<string, CalendarCellItem[]> {
+  const buckets = new Map<string, CalendarCellItem[]>();
+
+  plans.forEach((plan) => {
+    if (!plan) {
+      return;
+    }
+
+    const slots = Array.isArray(plan.slots) ? plan.slots : [];
+    const title = resolvePlanTitle(plan);
+    const status = typeof plan.status === 'string' && plan.status.trim() !== '' ? plan.status : 'draft';
+
+    slots.forEach((slot, index) => {
+      if (!slot || typeof slot.scheduled_at !== 'string' || slot.scheduled_at === '') {
+        return;
+      }
+
+      const scheduledAt = new Date(slot.scheduled_at);
+      if (Number.isNaN(scheduledAt.getTime())) {
+        return;
+      }
+
+      const isoDate = formatDate(scheduledAt);
+      const channel = typeof slot.channel === 'string' && slot.channel !== '' ? slot.channel : activeChannel;
+      const entry: CalendarCellItem = {
+        id: `${plan.id ?? 'plan'}-${index}`,
+        title,
+        status,
+        channel,
+        isoDate,
+        timeLabel: formatTime(scheduledAt),
+        timestamp: scheduledAt.getTime(),
+      };
+
+      const bucket = buckets.get(isoDate);
+      if (bucket) {
+        bucket.push(entry);
+      } else {
+        buckets.set(isoDate, [entry]);
+      }
+    });
+  });
+
+  buckets.forEach((bucket) => {
+    bucket.sort((a, b) => a.timestamp - b.timestamp);
+  });
+
+  return buckets;
+}
+
+function renderCalendarGrid(container: HTMLElement, plans: CalendarPlanPayload[]): void {
+  const itemsByDate = collectCalendarItems(plans);
   const current = new Date(now.getFullYear(), now.getMonth(), 1);
   const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-  let html = '<table class="fp-publisher-calendar"><thead><tr>';
   const weekdays = ['Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab', 'Dom'];
-  html += weekdays.map((day) => `<th>${day}</th>`).join('');
+
+  let html = '<table class="fp-publisher-calendar"><thead><tr>';
+  html += weekdays.map((day) => `<th scope="col">${day}</th>`).join('');
   html += '</tr></thead><tbody>';
 
   let day = 1;
-  const startOffset = (current.getDay() + 6) % 7; // convert Sunday=0 to Monday=0
+  const startOffset = (current.getDay() + 6) % 7;
   for (let row = 0; row < 6 && day <= daysInMonth; row += 1) {
     html += '<tr>';
     for (let col = 0; col < 7; col += 1) {
       const cellIndex = row * 7 + col;
       if (cellIndex < startOffset || day > daysInMonth) {
-        html += '<td class="is-empty"></td>';
-      } else {
-        const iso = formatDate(new Date(now.getFullYear(), now.getMonth(), day));
-        html += `<td data-date="${iso}"><span class="fp-calendar-day">${day}</span></td>`;
-        day += 1;
+        html += '<td class="is-empty" aria-disabled="true"></td>';
+        continue;
       }
+
+      const cellDate = new Date(now.getFullYear(), now.getMonth(), day);
+      const iso = formatDate(cellDate);
+      const cellItems = itemsByDate.get(iso) ?? [];
+      const itemsMarkup = cellItems
+        .map((item) => {
+          const tooltip = `${item.title} — ${item.channel} • ${item.timeLabel}`;
+          const meta = `${item.channel} · ${item.timeLabel}`;
+          return `
+            <article class="fp-calendar__item" data-status="${escapeHtml(item.status)}" title="${escapeHtml(tooltip)}">
+              <span class="fp-calendar__item-handle" aria-hidden="true">${GRIP_ICON}</span>
+              <div class="fp-calendar__item-body">
+                <span class="fp-calendar__item-title">${escapeHtml(item.title)}</span>
+                <span class="fp-calendar__item-meta">${escapeHtml(meta)}</span>
+              </div>
+            </article>
+          `;
+        })
+        .join('');
+
+      const actionMarkup = `
+        <button type="button" class="fp-calendar__slot-action" data-date="${iso}" aria-label="Suggerisci orario per il ${escapeHtml(
+        formatHumanDate(cellDate),
+      )}">Suggerisci orario</button>
+      `;
+
+      html += `
+        <td data-date="${iso}">
+          <div class="fp-calendar__cell">
+            <span class="fp-calendar-day">${day}</span>
+            <div class="fp-calendar__items">${itemsMarkup}</div>
+            ${cellItems.length === 0 ? actionMarkup : ''}
+          </div>
+        </td>
+      `;
+
+      day += 1;
     }
     html += '</tr>';
   }
+
   html += '</tbody></table>';
   container.innerHTML = html;
+  applyCalendarDensity(container);
+}
+
+function applyCalendarDensity(container: HTMLElement): void {
+  const table = container.querySelector<HTMLTableElement>('.fp-publisher-calendar');
+  if (!table) {
+    return;
+  }
+
+  if (calendarDensity === 'compact') {
+    table.classList.add('is-compact');
+  } else {
+    table.classList.remove('is-compact');
+  }
+}
+
+function syncCalendarDensityButtons(): void {
+  const buttons = document.querySelectorAll<HTMLButtonElement>('[data-calendar-density]');
+  buttons.forEach((button) => {
+    const mode = button.dataset.calendarDensity === 'compact' ? 'compact' : 'comfort';
+    const isActive = mode === calendarDensity;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+}
+
+function setCalendarDensity(mode: 'comfort' | 'compact'): void {
+  if (calendarDensity === mode) {
+    return;
+  }
+
+  calendarDensity = mode;
+  const calendarContainer = document.getElementById('fp-calendar');
+  if (calendarContainer) {
+    applyCalendarDensity(calendarContainer);
+  }
+  syncCalendarDensityButtons();
+}
+
+async function handleSlotSuggestion(button: HTMLButtonElement, date: string): Promise<void> {
+  if (!date) {
+    return;
+  }
+
+  const originalLabel = button.textContent ?? '';
+  button.disabled = true;
+  button.textContent = 'Caricamento…';
+
+  try {
+    await loadSuggestions(date);
+    document.getElementById('fp-besttime-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } finally {
+    button.textContent = originalLabel;
+    button.disabled = false;
+  }
+}
+
+async function importCalendarFromTrello(button: HTMLButtonElement): Promise<void> {
+  const originalLabel = button.textContent ?? '';
+  button.disabled = true;
+  button.textContent = 'Importazione…';
+
+  try {
+    await fetchJSON(`${config.restBase}/ingest/trello`, {
+      method: 'POST',
+      body: JSON.stringify({ month: monthKey, channel: activeChannel }),
+    });
+    button.textContent = 'Importazione completata';
+    const calendarContainer = document.getElementById('fp-calendar');
+    if (calendarContainer) {
+      await renderCalendar(calendarContainer);
+    }
+  } catch (error) {
+    console.error('Impossibile importare da Trello', error);
+    button.textContent = 'Errore, riprova';
+  } finally {
+    window.setTimeout(() => {
+      button.textContent = originalLabel;
+      button.disabled = false;
+    }, 1600);
+  }
 }
 
 function renderKanban(container: HTMLElement): void {
@@ -119,28 +1763,432 @@ function hydrateKanban(): void {
 
 function renderComments(container: HTMLElement): void {
   container.innerHTML = `
-    <header class="fp-comments__header">
-      <h3>Commenti piano</h3>
-      <button type="button" class="button" id="fp-refresh-comments">Aggiorna</button>
-    </header>
-    <div id="fp-comments-list" class="fp-comments__list" aria-live="polite"></div>
-    <form id="fp-comments-form" class="fp-comments__form">
-      <label>
-        <span class="screen-reader-text">Nuovo commento</span>
-        <textarea name="body" rows="3" required placeholder="Scrivi un commento… (usa @utente per menzionare)"></textarea>
-      </label>
-      <button type="submit" class="button button-primary">Invia</button>
-    </form>
+    <section class="fp-approvals">
+      <header class="fp-approvals__header">
+        <div>
+          <h3>Workflow approvazioni</h3>
+          <p class="fp-approvals__hint">Monitora le decisioni chiave e chiudile con un clic.</p>
+        </div>
+        <div class="fp-approvals__actions">
+          <button type="button" class="button button-primary" id="fp-approvals-approve">Approva e invia</button>
+          <button type="button" class="button" id="fp-approvals-request">Richiedi modifiche</button>
+        </div>
+      </header>
+      <ol id="fp-approvals-timeline" class="fp-approvals__timeline" aria-live="polite"></ol>
+      <div id="fp-approvals-announcer" class="screen-reader-text" aria-live="polite"></div>
+    </section>
+
+    <section class="fp-comments__section">
+      <header class="fp-comments__header">
+        <div>
+          <h3>Commenti piano</h3>
+          <p class="fp-comments__hint" id="fp-comments-hint">Usa @ per menzionare un collega e notificare il tuo feedback.</p>
+        </div>
+        <button type="button" class="button" id="fp-refresh-comments">Aggiorna</button>
+      </header>
+      <div id="fp-comments-list" class="fp-comments__list" aria-live="polite"></div>
+      <form id="fp-comments-form" class="fp-comments__form">
+        <label class="fp-comments__field">
+          <span class="screen-reader-text">Nuovo commento</span>
+          <textarea
+            name="body"
+            rows="3"
+            required
+            placeholder="Scrivi un commento…"
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-owns="fp-mentions-list"
+            aria-describedby="fp-comments-hint"
+          ></textarea>
+        </label>
+        <ul id="fp-mentions-list" class="fp-comments__mentions" role="listbox" aria-label="Suggerimenti menzioni" hidden></ul>
+        <div class="fp-comments__submit">
+          <span class="fp-comments__hint">I commenti vengono notificati al team editoriale.</span>
+          <button type="submit" class="button button-primary">Invia</button>
+        </div>
+        <div id="fp-comments-announcer" class="screen-reader-text" aria-live="polite"></div>
+      </form>
+    </section>
   `;
 }
 
-function renderSuggestions(container: HTMLElement, suggestions: Suggestion[]): void {
-  if (suggestions.length === 0) {
-    container.innerHTML = '<p class="fp-besttime__empty">Nessun suggerimento disponibile per il periodo selezionato.</p>';
+function approvalTone(status: ApprovalEvent['status']): 'positive' | 'neutral' | 'warning' {
+  return APPROVAL_STATUS_TONES[status] ?? 'neutral';
+}
+
+function renderApprovalEvent(event: ApprovalEvent): string {
+  const tone = approvalTone(event.status);
+  const badgeLabel = APPROVAL_STATUS_LABELS[event.status] ?? event.status;
+  const note = event.note ? `<p class="fp-approvals__note">${escapeHtml(event.note)}</p>` : '';
+
+  return `
+    <li class="fp-approvals__item">
+      <span class="fp-approvals__avatar" aria-hidden="true">${initialsForName(event.actor.display_name)}</span>
+      <div class="fp-approvals__content">
+        <header class="fp-approvals__meta">
+          <strong>${escapeHtml(event.actor.display_name)}</strong>
+          <time>${new Date(event.occurred_at).toLocaleString()}</time>
+        </header>
+        <span class="fp-approvals__badge" data-tone="${tone}">${badgeLabel}</span>
+        ${note}
+      </div>
+    </li>
+  `;
+}
+
+async function loadApprovalsTimeline(): Promise<void> {
+  const timeline = document.getElementById('fp-approvals-timeline');
+  if (!timeline) {
     return;
   }
 
-  container.innerHTML = suggestions
+  timeline.innerHTML = '<li class="fp-approvals__placeholder">Caricamento workflow…</li>';
+  try {
+    const data = await fetchJSON<{ items: ApprovalEvent[] }>(`${config.restBase}/plans/1/approvals`);
+    if (!data.items.length) {
+      timeline.innerHTML = '<li class="fp-approvals__placeholder">Nessuna attività registrata nel workflow.</li>';
+      announceApprovalsUpdate('Nessuna attività nel workflow di approvazione.');
+      return;
+    }
+
+    timeline.innerHTML = data.items.map(renderApprovalEvent).join('');
+    announceApprovalsUpdate('Workflow approvazioni aggiornato.');
+  } catch (error) {
+    timeline.innerHTML = `<li class="fp-approvals__placeholder fp-approvals__placeholder--error">Impossibile recuperare il workflow (${escapeHtml((error as Error).message)}).</li>`;
+    announceApprovalsUpdate('Impossibile aggiornare il workflow approvazioni.');
+  }
+}
+
+function mentionOptionId(index: number): string {
+  const suggestion = mentionState.suggestions[index];
+  return `fp-mention-option-${suggestion?.id ?? index}`;
+}
+
+function resetMentionState(): void {
+  mentionState.anchor = -1;
+  mentionState.query = '';
+  mentionState.suggestions = [];
+  mentionState.activeIndex = -1;
+}
+
+function hideMentionSuggestions(): void {
+  const { list, textarea } = mentionState;
+  if (list) {
+    list.hidden = true;
+    list.innerHTML = '';
+  }
+  textarea?.setAttribute('aria-expanded', 'false');
+  textarea?.removeAttribute('aria-activedescendant');
+  if (mentionFetchTimeout) {
+    window.clearTimeout(mentionFetchTimeout);
+    mentionFetchTimeout = undefined;
+  }
+  resetMentionState();
+}
+
+function updateActiveMention(): void {
+  const { list, activeIndex, textarea } = mentionState;
+  if (!list) {
+    return;
+  }
+
+  const items = Array.from(list.querySelectorAll<HTMLLIElement>('[data-mention-index]'));
+  items.forEach((item) => {
+    const index = Number(item.dataset.mentionIndex ?? '-1');
+    const isActive = index === activeIndex;
+    item.classList.toggle('is-active', isActive);
+    item.setAttribute('aria-selected', isActive ? 'true' : 'false');
+  });
+
+  if (textarea) {
+    if (activeIndex >= 0 && mentionState.suggestions[activeIndex]) {
+      textarea.setAttribute('aria-activedescendant', mentionOptionId(activeIndex));
+    } else {
+      textarea.removeAttribute('aria-activedescendant');
+    }
+  }
+}
+
+function renderMentionSuggestionsList(): void {
+  const { list, suggestions, textarea, activeIndex } = mentionState;
+  if (!list) {
+    return;
+  }
+
+  if (!suggestions.length) {
+    list.innerHTML = '<li class="fp-comments__mention fp-comments__mention--empty" role="option" aria-disabled="true">Nessun utente trovato.</li>';
+    list.hidden = false;
+    textarea?.setAttribute('aria-expanded', 'true');
+    textarea?.removeAttribute('aria-activedescendant');
+    return;
+  }
+
+  list.innerHTML = suggestions
+    .map((suggestion, index) => {
+      const description = suggestion.description ? `<span>${escapeHtml(suggestion.description)}</span>` : '';
+      return `
+        <li
+          class="fp-comments__mention${activeIndex === index ? ' is-active' : ''}"
+          data-mention-index="${index}"
+          role="option"
+          id="${mentionOptionId(index)}"
+          aria-selected="${activeIndex === index ? 'true' : 'false'}"
+        >
+          <strong>${escapeHtml(suggestion.name)}</strong>
+          ${description}
+        </li>
+      `;
+    })
+    .join('');
+
+  list.hidden = false;
+  textarea?.setAttribute('aria-expanded', 'true');
+  updateActiveMention();
+}
+
+async function fetchMentionSuggestions(query: string): Promise<MentionSuggestion[]> {
+  const endpoint = `/wp-json/wp/v2/users?per_page=5&search=${encodeURIComponent(query)}`;
+  const response = await fetch(endpoint, {
+    credentials: 'same-origin',
+    headers: {
+      'X-WP-Nonce': config.nonce,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const payload = (await response.json()) as WPUser[];
+  return payload.map((user) => ({
+    id: user.id,
+    name: user.name,
+    slug: user.slug,
+    description: user.description,
+  }));
+}
+
+async function requestMentionSuggestions(query: string): Promise<void> {
+  const { list, textarea } = mentionState;
+  if (!list || !textarea) {
+    return;
+  }
+
+  const requestId = ++mentionRequestId;
+  list.hidden = false;
+  list.innerHTML = '<li class="fp-comments__mention fp-comments__mention--loading" role="option" aria-disabled="true">Ricerca utenti…</li>';
+  textarea.setAttribute('aria-expanded', 'true');
+
+  try {
+    const suggestions = await fetchMentionSuggestions(query);
+    if (requestId !== mentionRequestId) {
+      return;
+    }
+    mentionState.suggestions = suggestions;
+    mentionState.activeIndex = suggestions.length ? 0 : -1;
+    renderMentionSuggestionsList();
+    if (suggestions.length) {
+      announceCommentUpdate(`${suggestions.length} suggerimenti trovati.`);
+    }
+  } catch (error) {
+    if (requestId !== mentionRequestId) {
+      return;
+    }
+    list.innerHTML = `<li class="fp-comments__mention fp-comments__mention--error" role="option" aria-disabled="true">Errore durante la ricerca (${escapeHtml((error as Error).message)}).</li>`;
+    announceCommentUpdate('Impossibile recuperare le menzioni.');
+  }
+}
+
+function applyMentionSuggestion(index: number): void {
+  const suggestion = mentionState.suggestions[index];
+  const textarea = mentionState.textarea;
+  if (!suggestion || !textarea) {
+    return;
+  }
+
+  const caret = textarea.selectionStart ?? textarea.value.length;
+  const before = textarea.value.slice(0, mentionState.anchor);
+  const after = textarea.value.slice(caret);
+  const handle = suggestion.slug || suggestion.name.replace(/\s+/g, '').toLowerCase();
+  const mentionText = `@${handle}`;
+
+  textarea.value = `${before}${mentionText} ${after.replace(/^\s*/, '')}`;
+  const newCaret = before.length + mentionText.length + 1;
+  textarea.setSelectionRange(newCaret, newCaret);
+  announceCommentUpdate(`${suggestion.name} aggiunto al commento.`);
+  hideMentionSuggestions();
+}
+
+function handleMentionInput(event: Event): void {
+  const textarea = event.currentTarget as HTMLTextAreaElement;
+  mentionState.textarea = textarea;
+  const list = mentionState.list;
+  if (!list) {
+    return;
+  }
+
+  const caret = textarea.selectionStart ?? textarea.value.length;
+  const value = textarea.value;
+  const uptoCaret = value.slice(0, caret);
+  const triggerIndex = uptoCaret.lastIndexOf('@');
+
+  if (triggerIndex === -1) {
+    hideMentionSuggestions();
+    return;
+  }
+
+  if (triggerIndex > 0) {
+    const prevChar = uptoCaret.charAt(triggerIndex - 1);
+    if (prevChar && /[\w@]/.test(prevChar)) {
+      hideMentionSuggestions();
+      return;
+    }
+  }
+
+  const query = uptoCaret.slice(triggerIndex + 1);
+  if (!/^[\w._-]*$/.test(query)) {
+    hideMentionSuggestions();
+    return;
+  }
+
+  mentionState.anchor = triggerIndex;
+
+  if (query.length < 2) {
+    mentionState.query = query;
+    mentionState.suggestions = [];
+    mentionState.activeIndex = -1;
+    list.hidden = false;
+    list.innerHTML = '<li class="fp-comments__mention fp-comments__mention--hint" role="option" aria-disabled="true">Digita almeno due caratteri per cercare un utente.</li>';
+    textarea.setAttribute('aria-expanded', 'true');
+    textarea.removeAttribute('aria-activedescendant');
+    return;
+  }
+
+  if (query === mentionState.query && !list.hidden) {
+    return;
+  }
+
+  mentionState.query = query;
+  if (mentionFetchTimeout) {
+    window.clearTimeout(mentionFetchTimeout);
+  }
+  mentionFetchTimeout = window.setTimeout(() => {
+    void requestMentionSuggestions(query);
+  }, 180);
+}
+
+function handleMentionKeyDown(event: KeyboardEvent): void {
+  const { list, suggestions } = mentionState;
+  if (!list || list.hidden) {
+    return;
+  }
+
+  if (event.key === 'ArrowDown') {
+    if (!suggestions.length) {
+      return;
+    }
+    event.preventDefault();
+    mentionState.activeIndex = (mentionState.activeIndex + 1) % suggestions.length;
+    updateActiveMention();
+    return;
+  }
+
+  if (event.key === 'ArrowUp') {
+    if (!suggestions.length) {
+      return;
+    }
+    event.preventDefault();
+    mentionState.activeIndex =
+      (mentionState.activeIndex - 1 + suggestions.length) % suggestions.length;
+    updateActiveMention();
+    return;
+  }
+
+  if (event.key === 'Enter' || event.key === 'Tab') {
+    if (mentionState.activeIndex >= 0 && suggestions[mentionState.activeIndex]) {
+      event.preventDefault();
+      applyMentionSuggestion(mentionState.activeIndex);
+    }
+    return;
+  }
+
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    hideMentionSuggestions();
+  }
+}
+
+function initMentionAutocomplete(textarea: HTMLTextAreaElement, list: HTMLUListElement): void {
+  mentionState.textarea = textarea;
+  mentionState.list = list;
+  textarea.addEventListener('input', handleMentionInput);
+  textarea.addEventListener('keydown', handleMentionKeyDown);
+  textarea.addEventListener('blur', () => {
+    window.setTimeout(() => {
+      hideMentionSuggestions();
+    }, 120);
+  });
+
+  list.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+  });
+
+  list.addEventListener('click', (event) => {
+    const target = (event.target as HTMLElement).closest<HTMLLIElement>('[data-mention-index]');
+    if (!target) {
+      return;
+    }
+    const index = Number(target.dataset.mentionIndex ?? '-1');
+    if (Number.isNaN(index)) {
+      return;
+    }
+    applyMentionSuggestion(index);
+  });
+}
+
+async function handleApprovalAction(action: 'approved' | 'changes_requested'): Promise<void> {
+  const approveBtn = document.getElementById('fp-approvals-approve') as HTMLButtonElement | null;
+  const requestBtn = document.getElementById('fp-approvals-request') as HTMLButtonElement | null;
+  approveBtn?.setAttribute('disabled', 'true');
+  requestBtn?.setAttribute('disabled', 'true');
+
+  try {
+    await fetchJSON(`${config.restBase}/plans/1/approvals`, {
+      method: 'POST',
+      body: JSON.stringify({ status: action }),
+    });
+    await loadApprovalsTimeline();
+    if (action === 'approved') {
+      announceApprovalsUpdate('Piano approvato e inviato al team.');
+    } else {
+      announceApprovalsUpdate('Richiesta di modifiche inviata agli autori.');
+    }
+  } catch (error) {
+    announceApprovalsUpdate(`Errore durante l\'aggiornamento del workflow: ${(error as Error).message}`);
+  } finally {
+    approveBtn?.removeAttribute('disabled');
+    requestBtn?.removeAttribute('disabled');
+  }
+}
+
+function renderSuggestions(
+  container: HTMLElement,
+  suggestions: Suggestion[],
+  contextLabel?: string,
+): void {
+  if (suggestions.length === 0) {
+    const emptyLabel = contextLabel
+      ? `Nessun suggerimento disponibile per ${escapeHtml(contextLabel)}.`
+      : 'Nessun suggerimento disponibile per il periodo selezionato.';
+    container.innerHTML = `<p class="fp-besttime__empty">${emptyLabel}</p>`;
+    return;
+  }
+
+  const contextMarkup = contextLabel
+    ? `<p class="fp-besttime__context">Suggerimenti per ${escapeHtml(contextLabel)}</p>`
+    : '';
+
+  const itemsMarkup = suggestions
     .slice(0, 6)
     .map(
       (item) => `
@@ -152,39 +2200,68 @@ function renderSuggestions(container: HTMLElement, suggestions: Suggestion[]): v
       `,
     )
     .join('');
+
+  container.innerHTML = `${contextMarkup}${itemsMarkup}`;
 }
 
-async function fetchJSON<T>(url: string, options: RequestInit = {}): Promise<T> {
+async function sendRequest(url: string, options: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(options.headers ?? {});
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  if (!headers.has('X-WP-Nonce')) {
+    headers.set('X-WP-Nonce', config.nonce);
+  }
+
   const response = await fetch(url, {
     credentials: 'same-origin',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-WP-Nonce': config.nonce,
-    },
     ...options,
+    headers,
   });
 
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}`);
   }
 
+  return response;
+}
+
+async function fetchJSON<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const response = await sendRequest(url, options);
   return response.json() as Promise<T>;
 }
 
-async function loadSuggestions(): Promise<void> {
+async function loadSuggestions(day?: string): Promise<void> {
   const container = document.getElementById('fp-besttime-results');
   if (!container) {
     return;
   }
 
   container.innerHTML = '<p class="fp-besttime__loading">Calcolo suggerimenti…</p>';
+
+  const params = new URLSearchParams({
+    brand: config.brand ?? 'brand-demo',
+    channel: activeChannel,
+    month: monthKey,
+  });
+
+  let contextLabel: string | undefined;
+  if (day) {
+    params.set('day', day);
+    const parsed = new Date(day);
+    if (!Number.isNaN(parsed.getTime())) {
+      contextLabel = formatHumanDate(parsed);
+    }
+  }
+
   try {
     const data = await fetchJSON<{ suggestions: Suggestion[] }>(
-      `${config.restBase}/besttime?brand=${encodeURIComponent(config.brand ?? 'brand-demo')}&channel=${activeChannel}&month=${monthKey}`,
+      `${config.restBase}/besttime?${params.toString()}`,
     );
-    renderSuggestions(container, data.suggestions);
+    renderSuggestions(container, data.suggestions, contextLabel);
   } catch (error) {
-    container.innerHTML = `<p class="fp-besttime__error">Impossibile recuperare i suggerimenti (${(error as Error).message}).</p>`;
+    const message = (error as Error)?.message ?? 'Errore sconosciuto';
+    container.innerHTML = `<p class="fp-besttime__error">Impossibile recuperare i suggerimenti (${escapeHtml(message)}).</p>`;
   }
 }
 
@@ -199,6 +2276,7 @@ async function loadComments(): Promise<void> {
     const data = await fetchJSON<{ items: CommentItem[] }>(`${config.restBase}/plans/1/comments`);
     if (!data.items.length) {
       list.innerHTML = '<p class="fp-comments__empty">Nessun commento disponibile.</p>';
+      announceCommentUpdate('Nessun commento presente.');
       return;
     }
 
@@ -210,40 +2288,522 @@ async function loadComments(): Promise<void> {
               <strong>${item.author.display_name}</strong>
               <time>${new Date(item.created_at).toLocaleString()}</time>
             </header>
-            <p>${item.body}</p>
+            <p>${formatCommentBody(item.body)}</p>
           </article>
         `,
       )
       .join('');
+    announceCommentUpdate('Commenti aggiornati.');
   } catch (error) {
     list.innerHTML = `<p class="fp-comments__error">Impossibile caricare i commenti (${(error as Error).message}).</p>`;
+    announceCommentUpdate('Errore durante il caricamento dei commenti.');
   }
 }
 
 async function loadShortLinks(): Promise<void> {
-  const container = document.getElementById('fp-shortlink-result');
-  if (!container) {
+  const table = document.getElementById('fp-shortlink-table');
+  const skeleton = document.getElementById('fp-shortlink-skeleton');
+  if (!table || !skeleton) {
     return;
   }
 
-  container.innerHTML = '<p class="fp-shortlink__loading">Caricamento short link…</p>';
+  table.setAttribute('data-loading', 'true');
+  table.setAttribute('aria-busy', 'true');
+  skeleton.removeAttribute('hidden');
+  setShortLinkFeedback(copy.shortlinks.feedback.loading, 'muted');
+
   try {
-    const data = await fetchJSON<{ items: ShortLink[] }>(`${config.restBase}/links`);
-    if (!data.items.length) {
-      container.innerHTML = '<p class="fp-shortlink__empty">Nessun short link configurato.</p>';
+    const data = await fetchJSON<{ items?: ShortLink[] }>(`${config.restBase}/links`);
+    shortLinks = Array.isArray(data.items) ? data.items : [];
+    renderShortLinkTable();
+    if (shortLinks.length === 0) {
+      setShortLinkFeedback(copy.shortlinks.feedback.empty, 'muted');
+    } else {
+      setShortLinkFeedback(null);
+    }
+  } catch (error) {
+    shortLinks = [];
+    renderShortLinkTable();
+    setShortLinkFeedback(
+      `Impossibile caricare i link (${(error as Error).message}).`,
+      'error',
+    );
+  } finally {
+    table.removeAttribute('data-loading');
+    table.setAttribute('aria-busy', 'false');
+    skeleton.setAttribute('hidden', '');
+  }
+}
+
+function setShortLinkFeedback(message: string | null, tone: 'muted' | 'success' | 'error' = 'muted'): void {
+  const feedback = document.getElementById('fp-shortlink-feedback');
+  if (!feedback) {
+    return;
+  }
+
+  if (!message) {
+    feedback.textContent = '';
+    feedback.setAttribute('hidden', '');
+    feedback.removeAttribute('data-tone');
+    return;
+  }
+
+  feedback.textContent = message;
+  feedback.dataset.tone = tone;
+  feedback.removeAttribute('hidden');
+}
+
+function renderShortLinkTable(): void {
+  const body = document.getElementById('fp-shortlink-rows');
+  const empty = document.getElementById('fp-shortlink-empty');
+  const table = document.getElementById('fp-shortlink-table');
+  if (!body || !empty || !table) {
+    return;
+  }
+
+  if (shortLinks.length === 0) {
+    body.innerHTML = '';
+    empty.textContent = copy.shortlinks.empty;
+    empty.removeAttribute('hidden');
+    table.setAttribute('data-empty', 'true');
+    return;
+  }
+
+  empty.setAttribute('hidden', '');
+  table.removeAttribute('data-empty');
+
+  const formatter = new Intl.NumberFormat();
+  body.innerHTML = shortLinks
+    .map((link) => {
+      const slug = escapeHtml(link.slug);
+      const target = escapeHtml(link.target_url);
+      const truncatedTarget = escapeHtml(truncateText(link.target_url));
+      const goUrl = escapeHtml(buildShortLinkUrl(link.slug));
+      const clicks = formatter.format(Math.max(0, Number.isFinite(link.clicks) ? link.clicks : 0));
+      const lastClick = escapeHtml(formatLastClickAt(link.last_click_at));
+      const toggleBase = toDomId('fp-shortlink-menu', link.slug);
+      const toggleId = `${toggleBase}-toggle`;
+      const panelId = `${toggleBase}-panel`;
+      const menuLabel = escapeHtml(sprintf(copy.shortlinks.menuLabel, link.slug));
+      const actionOpen = escapeHtml(copy.shortlinks.actions.open);
+      const actionCopy = escapeHtml(copy.shortlinks.actions.copy);
+      const actionEdit = escapeHtml(copy.shortlinks.actions.edit);
+      const actionDisable = escapeHtml(copy.shortlinks.actions.disable);
+
+      return `
+        <tr data-slug="${slug}">
+          <th scope="row"><code class="fp-shortlink__slug">${slug}</code></th>
+          <td><span class="fp-shortlink__target" title="${target}">${truncatedTarget}</span></td>
+          <td class="fp-shortlink__metric">${clicks}</td>
+          <td class="fp-shortlink__metric">${lastClick}</td>
+          <td class="fp-shortlink__actions">
+            <div class="fp-shortlink__menu">
+              <button
+                type="button"
+                class="fp-shortlink__menu-toggle"
+                id="${toggleId}"
+                data-shortlink-menu
+                data-slug="${slug}"
+                data-url="${goUrl}"
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-controls="${panelId}"
+              >
+                <span class="screen-reader-text">${menuLabel}</span>
+                <span aria-hidden="true" class="fp-shortlink__menu-icon">⋮</span>
+              </button>
+              <div class="fp-shortlink__menu-panel" role="menu" id="${panelId}" aria-labelledby="${toggleId}" hidden>
+                <button type="button" role="menuitem" data-shortlink-action="open" data-slug="${slug}" data-url="${goUrl}" data-target="${target}">${actionOpen}</button>
+                <button type="button" role="menuitem" data-shortlink-action="copy" data-slug="${slug}" data-url="${goUrl}">${actionCopy}</button>
+                <button type="button" role="menuitem" data-shortlink-action="edit" data-slug="${slug}">${actionEdit}</button>
+                <button type="button" role="menuitem" data-shortlink-action="disable" data-slug="${slug}">${actionDisable}</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      `;
+    })
+    .join('');
+}
+
+function getFocusableElements(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((node) => node.offsetParent !== null);
+}
+
+function closeShortLinkMenu(): void {
+  if (!activeShortLinkMenu) {
+    return;
+  }
+
+  const panel = activeShortLinkMenu.nextElementSibling as HTMLElement | null;
+  activeShortLinkMenu.classList.remove('is-open');
+  activeShortLinkMenu.setAttribute('aria-expanded', 'false');
+  panel?.setAttribute('hidden', '');
+  activeShortLinkMenu = null;
+}
+
+function toggleShortLinkMenu(button: HTMLButtonElement): void {
+  if (activeShortLinkMenu === button) {
+    closeShortLinkMenu();
+    return;
+  }
+
+  closeShortLinkMenu();
+  const panel = button.nextElementSibling as HTMLElement | null;
+  if (!panel) {
+    return;
+  }
+
+  button.classList.add('is-open');
+  button.setAttribute('aria-expanded', 'true');
+  panel.removeAttribute('hidden');
+  activeShortLinkMenu = button;
+
+  const firstItem = panel.querySelector<HTMLElement>('[role="menuitem"]');
+  firstItem?.focus();
+}
+
+async function copyToClipboard(value: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch (error) {
+    console.warn('Clipboard API non disponibile', error);
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.setAttribute('readonly', 'true');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const result = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return result;
+  } catch (error) {
+    console.warn('Fallback clipboard copy fallito', error);
+    return false;
+  }
+}
+
+async function handleShortLinkAction(button: HTMLButtonElement): Promise<void> {
+  const action = button.dataset.shortlinkAction;
+  const slug = button.dataset.slug ?? '';
+
+  if (!action || !slug) {
+    return;
+  }
+
+  if (action === 'open') {
+    const url = button.dataset.url ?? buildShortLinkUrl(slug);
+    const newWindow = window.open(url, '_blank', 'noopener');
+    if (newWindow) {
+      newWindow.opener = null;
+    }
+    setShortLinkFeedback(sprintf(copy.shortlinks.feedback.open, slug), 'success');
+    return;
+  }
+
+  if (action === 'copy') {
+    const url = button.dataset.url ?? buildShortLinkUrl(slug);
+    const copied = await copyToClipboard(url);
+    if (copied) {
+      setShortLinkFeedback(copy.shortlinks.feedback.copySuccess, 'success');
+    } else {
+      setShortLinkFeedback(copy.shortlinks.feedback.copyError, 'error');
+    }
+    return;
+  }
+
+  if (action === 'edit') {
+    const link = shortLinks.find((item) => item.slug === slug);
+    openShortLinkModal('edit', link);
+    return;
+  }
+
+  if (action === 'disable') {
+    await disableShortLink(slug);
+  }
+}
+
+async function disableShortLink(slug: string): Promise<void> {
+  if (!slug) {
+    return;
+  }
+
+  setShortLinkFeedback(copy.shortlinks.feedback.disabling, 'muted');
+
+  try {
+    await sendRequest(`${config.restBase}/links/${encodeURIComponent(slug)}`, {
+      method: 'DELETE',
+    });
+    shortLinks = shortLinks.filter((item) => item.slug !== slug);
+    renderShortLinkTable();
+    if (shortLinks.length === 0) {
+      setShortLinkFeedback(copy.shortlinks.feedback.disabledEmpty, 'success');
+    } else {
+      setShortLinkFeedback(copy.shortlinks.feedback.disabled, 'success');
+    }
+  } catch (error) {
+    setShortLinkFeedback(
+      sprintf(copy.shortlinks.errors.disable, (error as Error).message),
+      'error',
+    );
+  }
+}
+
+function getShortLinkModalElements(): {
+  modal: HTMLElement;
+  form: HTMLFormElement;
+  title: HTMLElement;
+  slugInput: HTMLInputElement;
+  targetInput: HTMLInputElement;
+  preview: HTMLElement;
+  error: HTMLElement;
+  submit: HTMLButtonElement;
+  cancel: HTMLButtonElement;
+  close: HTMLButtonElement;
+  overlay: HTMLElement;
+} | null {
+  const modal = document.getElementById('fp-shortlink-modal');
+  if (!(modal instanceof HTMLElement)) {
+    return null;
+  }
+
+  const form = modal.querySelector<HTMLFormElement>('#fp-shortlink-modal-form');
+  const title = modal.querySelector<HTMLElement>('#fp-shortlink-modal-title');
+  const slugInput = modal.querySelector<HTMLInputElement>('#fp-shortlink-input-slug');
+  const targetInput = modal.querySelector<HTMLInputElement>('#fp-shortlink-input-target');
+  const preview = modal.querySelector<HTMLElement>('#fp-shortlink-modal-preview');
+  const error = modal.querySelector<HTMLElement>('#fp-shortlink-modal-error');
+  const submit = modal.querySelector<HTMLButtonElement>('#fp-shortlink-modal-submit');
+  const cancel = modal.querySelector<HTMLButtonElement>('#fp-shortlink-modal-cancel');
+  const close = modal.querySelector<HTMLButtonElement>('[data-shortlink-modal-close]');
+  const overlay = modal.querySelector<HTMLElement>('[data-shortlink-modal-overlay]');
+
+  if (!form || !title || !slugInput || !targetInput || !preview || !error || !submit || !cancel || !close || !overlay) {
+    return null;
+  }
+
+  return {
+    modal,
+    form,
+    title,
+    slugInput,
+    targetInput,
+    preview,
+    error,
+    submit,
+    cancel,
+    close,
+    overlay,
+  };
+}
+
+function updateShortLinkModalPreview(): void {
+  const elements = getShortLinkModalElements();
+  if (!elements) {
+    return;
+  }
+
+  const { slugInput, targetInput, preview, error, submit } = elements;
+  const slugValue = slugInput.value.trim();
+  const targetValue = targetInput.value.trim();
+
+  const messages: string[] = [];
+  if (!slugValue) {
+    messages.push(copy.shortlinks.validation.slugMissing);
+  } else if (!/^[a-z0-9-]+$/i.test(slugValue)) {
+    messages.push(copy.shortlinks.validation.slugFormat);
+  }
+
+  let destination: URL | null = null;
+  if (!targetValue) {
+    messages.push(copy.shortlinks.validation.targetMissing);
+  } else {
+    try {
+      destination = new URL(targetValue);
+    } catch {
+      messages.push(copy.shortlinks.validation.targetInvalid);
+    }
+  }
+
+  let utmPreview = '';
+  if (destination) {
+    const utmUrl = new URL(destination.toString());
+    utmUrl.searchParams.set('utm_source', 'fp_publisher');
+    utmUrl.searchParams.set('utm_medium', 'social');
+    utmUrl.searchParams.set('utm_campaign', slugValue || 'shortlink');
+    utmPreview = utmUrl.toString();
+  }
+
+  if (messages.length > 0) {
+    error.textContent = messages.join(' ');
+    error.removeAttribute('hidden');
+    submit.disabled = true;
+  } else {
+    error.textContent = '';
+    error.setAttribute('hidden', '');
+    submit.disabled = false;
+  }
+
+  const goUrl = slugValue ? buildShortLinkUrl(slugValue) : buildShortLinkUrl('preview');
+  const shortlinkLabel = escapeHtml(copy.shortlinks.preview.shortlinkLabel);
+  const utmLabel = escapeHtml(copy.shortlinks.preview.utmLabel);
+  const waitingMessage = escapeHtml(copy.shortlinks.preview.waiting);
+  const previewDefault = escapeHtml(copy.shortlinks.modal.previewDefault);
+
+  const previewLines: string[] = [`<p><strong>${shortlinkLabel}</strong> <code>${escapeHtml(goUrl)}</code></p>`];
+
+  if (utmPreview) {
+    previewLines.push(
+      `<p><strong>${utmLabel}</strong> <span title="${escapeHtml(utmPreview)}">${escapeHtml(truncateText(
+        utmPreview,
+        96,
+      ))}</span></p>`,
+    );
+  } else if (targetValue) {
+    previewLines.push(`<p>${waitingMessage}</p>`);
+  } else {
+    previewLines.push(`<p>${previewDefault}</p>`);
+  }
+
+  preview.innerHTML = previewLines.join('');
+}
+
+function closeShortLinkModal(): void {
+  const elements = getShortLinkModalElements();
+  if (!elements) {
+    return;
+  }
+
+  const { modal, form, error, preview } = elements;
+  modal.setAttribute('hidden', '');
+  modal.classList.remove('is-open');
+  if (shortLinkModalKeydownHandler) {
+    modal.removeEventListener('keydown', shortLinkModalKeydownHandler);
+    shortLinkModalKeydownHandler = null;
+  }
+
+  form.reset();
+  error.textContent = '';
+  error.setAttribute('hidden', '');
+  preview.innerHTML = `<p>${escapeHtml(copy.shortlinks.modal.previewDefault)}</p>`;
+
+  if (shortLinkModalReturnFocus) {
+    shortLinkModalReturnFocus.focus();
+  }
+  shortLinkModalReturnFocus = null;
+  shortLinkEditingSlug = null;
+}
+
+function openShortLinkModal(mode: 'create' | 'edit', link?: ShortLink): void {
+  const elements = getShortLinkModalElements();
+  if (!elements) {
+    return;
+  }
+
+  const { modal, title, slugInput, targetInput, submit } = elements;
+  shortLinkModalReturnFocus = (document.activeElement as HTMLElement) ?? null;
+  modal.dataset.mode = mode;
+  title.textContent = mode === 'edit' ? copy.shortlinks.modal.editTitle : copy.shortlinks.modal.createTitle;
+  submit.textContent = mode === 'edit' ? copy.shortlinks.modal.update : copy.shortlinks.modal.create;
+  slugInput.value = link?.slug ?? '';
+  targetInput.value = link?.target_url ?? '';
+  shortLinkEditingSlug = link?.slug ?? null;
+
+  updateShortLinkModalPreview();
+
+  modal.removeAttribute('hidden');
+  modal.classList.add('is-open');
+
+  const handleKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeShortLinkModal();
       return;
     }
 
-    const latest = data.items[0];
-    const goUrl = `${window.location.origin.replace(/\/$/, '')}/go/${latest.slug}`;
-    container.innerHTML = `
-      <p class="fp-shortlink__preview">
-        Ultimo link: <code>${goUrl}</code><br />
-        <span>${latest.target_url}</span>
-      </p>
-    `;
-  } catch (error) {
-    container.innerHTML = `<p class="fp-shortlink__error">Impossibile caricare i link (${(error as Error).message}).</p>`;
+    if (event.key === 'Tab') {
+      const focusable = getFocusableElements(modal);
+      if (focusable.length === 0) {
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  shortLinkModalKeydownHandler = handleKeydown;
+  modal.addEventListener('keydown', handleKeydown);
+
+  slugInput.focus();
+}
+
+async function handleShortLinkModalSubmit(event: Event): Promise<void> {
+  event.preventDefault();
+  const elements = getShortLinkModalElements();
+  if (!elements) {
+    return;
+  }
+
+  const { modal, slugInput, targetInput, error, submit } = elements;
+  updateShortLinkModalPreview();
+
+  if (submit.disabled) {
+    return;
+  }
+
+  const slugValue = slugInput.value.trim();
+  const targetValue = targetInput.value.trim();
+  const mode = modal.dataset.mode === 'edit' ? 'edit' : 'create';
+
+  submit.disabled = true;
+  submit.setAttribute('aria-busy', 'true');
+
+  try {
+    const payload = { slug: slugValue, target_url: targetValue };
+    if (mode === 'edit') {
+      const endpoint = `${config.restBase}/links/${encodeURIComponent(shortLinkEditingSlug ?? slugValue)}`;
+      await fetchJSON<{ link: ShortLink }>(endpoint, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      });
+      setShortLinkFeedback(copy.shortlinks.feedback.updated, 'success');
+    } else {
+      await fetchJSON<{ link: ShortLink }>(`${config.restBase}/links`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      setShortLinkFeedback(copy.shortlinks.feedback.created, 'success');
+    }
+
+    await loadShortLinks();
+    closeShortLinkModal();
+  } catch (errorRequest) {
+    error.textContent = sprintf(copy.shortlinks.errors.save, (errorRequest as Error).message);
+    error.removeAttribute('hidden');
+  } finally {
+    submit.disabled = false;
+    submit.removeAttribute('aria-busy');
   }
 }
 
@@ -251,6 +2811,35 @@ function bindInteractions(): void {
   const bestTimeBtn = document.getElementById('fp-besttime-trigger');
   bestTimeBtn?.addEventListener('click', () => {
     void loadSuggestions();
+  });
+
+  const densityToolbar = document.getElementById('fp-calendar-toolbar');
+  densityToolbar?.addEventListener('click', (event) => {
+    const target = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-calendar-density]');
+    if (!target) {
+      return;
+    }
+
+    event.preventDefault();
+    const mode = target.dataset.calendarDensity === 'compact' ? 'compact' : 'comfort';
+    setCalendarDensity(mode);
+  });
+
+  const calendarContainer = document.getElementById('fp-calendar');
+  calendarContainer?.addEventListener('click', (event) => {
+    const target = event.target as HTMLElement;
+    const slotButton = target.closest<HTMLButtonElement>('.fp-calendar__slot-action');
+    if (slotButton) {
+      event.preventDefault();
+      void handleSlotSuggestion(slotButton, slotButton.dataset.date ?? '');
+      return;
+    }
+
+    const importButton = target.closest<HTMLButtonElement>('[data-action="calendar-import"]');
+    if (importButton) {
+      event.preventDefault();
+      void importCalendarFromTrello(importButton);
+    }
   });
 
   const kanban = document.querySelector('.fp-kanban');
@@ -261,6 +2850,16 @@ function bindInteractions(): void {
       document.getElementById('fp-besttime-section')?.scrollIntoView({ behavior: 'smooth' });
       void loadSuggestions();
     }
+  });
+
+  document.getElementById('fp-approvals-approve')?.addEventListener('click', (event) => {
+    event.preventDefault();
+    void handleApprovalAction('approved');
+  });
+
+  document.getElementById('fp-approvals-request')?.addEventListener('click', (event) => {
+    event.preventDefault();
+    void handleApprovalAction('changes_requested');
   });
 
   document.getElementById('fp-refresh-comments')?.addEventListener('click', () => {
@@ -277,6 +2876,7 @@ function bindInteractions(): void {
 
     const body = textarea.value.trim();
     if (!body) {
+      announceCommentUpdate('Compilare il commento prima di inviare.');
       return;
     }
 
@@ -286,51 +2886,92 @@ function bindInteractions(): void {
         body: JSON.stringify({ body }),
       });
       textarea.value = '';
+      hideMentionSuggestions();
+      announceCommentUpdate('Commento inviato correttamente.');
       await loadComments();
     } catch (error) {
       const list = document.getElementById('fp-comments-list');
       if (list) {
         list.innerHTML = `<p class="fp-comments__error">Errore durante l\'invio (${(error as Error).message}).</p>`;
       }
+      announceCommentUpdate('Impossibile inviare il commento.');
     }
   });
 
-  const shortLinkForm = document.getElementById('fp-shortlink-form') as HTMLFormElement | null;
-  shortLinkForm?.addEventListener('submit', async (event) => {
-    event.preventDefault();
-    const result = document.getElementById('fp-shortlink-result');
-    if (!result) {
-      return;
+  if (form) {
+    const textarea = form.querySelector('textarea');
+    const mentionsList = document.getElementById('fp-mentions-list');
+    if (textarea instanceof HTMLTextAreaElement && mentionsList instanceof HTMLUListElement) {
+      initMentionAutocomplete(textarea, mentionsList);
     }
+  }
 
-    const formData = new FormData(shortLinkForm);
-    const slug = String(formData.get('slug') ?? '').trim();
-    const target = String(formData.get('target_url') ?? '').trim();
+  const shortLinkContainer = document.getElementById('fp-shortlink');
+  const createButton = document.getElementById('fp-shortlink-create');
+  if (createButton instanceof HTMLButtonElement) {
+    createButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      openShortLinkModal('create');
+    });
+  }
 
-    if (!slug || !target) {
-      result.innerHTML = '<p class="fp-shortlink__error">Compilare slug e URL di destinazione.</p>';
-      return;
-    }
+  if (shortLinkContainer instanceof HTMLElement) {
+    shortLinkContainer.addEventListener('click', (event) => {
+      const target = event.target as HTMLElement;
+      const toggle = target.closest<HTMLButtonElement>('[data-shortlink-menu]');
+      if (toggle) {
+        event.preventDefault();
+        toggleShortLinkMenu(toggle);
+        return;
+      }
 
-    result.innerHTML = '<p class="fp-shortlink__loading">Salvataggio link…</p>';
-    try {
-      const data = await fetchJSON<{ link: ShortLink }>(`${config.restBase}/links`, {
-        method: 'POST',
-        body: JSON.stringify({ slug, target_url: target }),
-      });
+      const actionButton = target.closest<HTMLButtonElement>('[data-shortlink-action]');
+      if (actionButton) {
+        event.preventDefault();
+        closeShortLinkMenu();
+        void handleShortLinkAction(actionButton);
+      }
+    });
+  }
 
-      const goUrl = `${window.location.origin.replace(/\/$/, '')}/go/${data.link.slug}`;
-      result.innerHTML = `
-        <p class="fp-shortlink__success">
-          Link pronto: <code>${goUrl}</code><br />
-          <span>${data.link.target_url}</span>
-        </p>
-      `;
-      shortLinkForm.reset();
-    } catch (error) {
-      result.innerHTML = `<p class="fp-shortlink__error">Errore durante il salvataggio (${(error as Error).message}).</p>`;
+  document.addEventListener('click', (event) => {
+    const target = event.target as HTMLElement;
+    if (activeShortLinkMenu && !target.closest('.fp-shortlink__menu')) {
+      closeShortLinkMenu();
     }
   });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && activeShortLinkMenu) {
+      const toggle = activeShortLinkMenu;
+      closeShortLinkMenu();
+      toggle.focus();
+    }
+  });
+
+  const shortLinkModal = getShortLinkModalElements();
+  if (shortLinkModal) {
+    const { form, slugInput, targetInput, cancel, close, overlay } = shortLinkModal;
+    form.addEventListener('submit', (event) => {
+      void handleShortLinkModalSubmit(event);
+    });
+    slugInput.addEventListener('input', updateShortLinkModalPreview);
+    targetInput.addEventListener('input', updateShortLinkModalPreview);
+    cancel.addEventListener('click', (event) => {
+      event.preventDefault();
+      closeShortLinkModal();
+    });
+    close.addEventListener('click', (event) => {
+      event.preventDefault();
+      closeShortLinkModal();
+    });
+    overlay.addEventListener('click', (event) => {
+      event.preventDefault();
+      closeShortLinkModal();
+    });
+  }
+
+  syncCalendarDensityButtons();
 }
 
 function renderApp(container: HTMLElement, status: { version?: string }): void {
@@ -349,8 +2990,26 @@ function renderApp(container: HTMLElement, status: { version?: string }): void {
       <section class="fp-publisher-shell__grid">
         <article class="fp-widget">
           <header class="fp-widget__header">
-            <h2>Calendario editoriale</h2>
-            <span>${monthKey}</span>
+            <div class="fp-widget__heading">
+              <h2>Calendario editoriale</h2>
+              <span>${monthKey}</span>
+            </div>
+            <div class="fp-calendar__toolbar" id="fp-calendar-toolbar" role="group" aria-label="Densità calendario">
+              <button
+                type="button"
+                class="fp-calendar__density-button is-active"
+                data-calendar-density="comfort"
+                aria-pressed="true"
+                aria-controls="fp-calendar"
+              >Comfort</button>
+              <button
+                type="button"
+                class="fp-calendar__density-button"
+                data-calendar-density="compact"
+                aria-pressed="false"
+                aria-controls="fp-calendar"
+              >Compatta</button>
+            </div>
           </header>
           <div id="fp-calendar"></div>
         </article>
@@ -371,26 +3030,107 @@ function renderApp(container: HTMLElement, status: { version?: string }): void {
           <div id="fp-besttime-results" class="fp-besttime"></div>
         </article>
 
+        <article class="fp-widget fp-composer" id="fp-composer"></article>
+
         <article class="fp-widget">
           <div id="fp-comments"></div>
         </article>
 
+        <article class="fp-widget" id="fp-alerts"></article>
+
+        <article class="fp-widget" id="fp-logs"></article>
+
         <article class="fp-widget" id="fp-shortlink">
           <header class="fp-widget__header">
-            <h2>Short link rapido</h2>
+            <div class="fp-widget__heading">
+              <h2 id="fp-shortlink-title">${escapeHtml(copy.shortlinks.section.title)}</h2>
+              <span>${escapeHtml(copy.shortlinks.section.subtitle)}</span>
+            </div>
+            <button type="button" class="button button-primary" id="fp-shortlink-create">${escapeHtml(copy.shortlinks.section.createButton)}</button>
           </header>
-          <form id="fp-shortlink-form" class="fp-shortlink__form">
-            <label>
-              <span>Slug</span>
-              <input type="text" name="slug" required placeholder="promo-social" />
-            </label>
-            <label>
-              <span>URL di destinazione</span>
-              <input type="url" name="target_url" required placeholder="https://esempio.com/promo" />
-            </label>
-            <button type="submit" class="button button-primary">Salva short link</button>
-          </form>
-          <div id="fp-shortlink-result" class="fp-shortlink__result" aria-live="polite"></div>
+          <div class="fp-shortlink__body">
+            <p id="fp-shortlink-feedback" class="fp-shortlink__feedback" aria-live="polite" hidden></p>
+            <div
+              class="fp-shortlink__table"
+              id="fp-shortlink-table"
+              role="region"
+              aria-labelledby="fp-shortlink-title"
+              aria-live="polite"
+            >
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">${escapeHtml(copy.shortlinks.table.slug)}</th>
+                    <th scope="col">${escapeHtml(copy.shortlinks.table.target)}</th>
+                    <th scope="col">${escapeHtml(copy.shortlinks.table.clicks)}</th>
+                    <th scope="col">${escapeHtml(copy.shortlinks.table.lastClick)}</th>
+                    <th scope="col" aria-label="${escapeHtml(copy.shortlinks.table.actions)}">⋯</th>
+                  </tr>
+                </thead>
+                <tbody id="fp-shortlink-rows"></tbody>
+              </table>
+              <div id="fp-shortlink-skeleton" class="fp-shortlink__skeleton" aria-hidden="true" hidden>
+                <div class="fp-shortlink__skeleton-row"></div>
+                <div class="fp-shortlink__skeleton-row"></div>
+                <div class="fp-shortlink__skeleton-row"></div>
+              </div>
+            </div>
+            <p id="fp-shortlink-empty" class="fp-shortlink__empty" hidden>
+              ${escapeHtml(copy.shortlinks.empty)}
+            </p>
+          </div>
+          <div
+            class="fp-modal"
+            id="fp-shortlink-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="fp-shortlink-modal-title"
+            hidden
+          >
+            <div class="fp-modal__backdrop" data-shortlink-modal-overlay></div>
+            <div class="fp-modal__dialog" role="document">
+              <header class="fp-modal__header">
+                <h2 id="fp-shortlink-modal-title">${escapeHtml(copy.shortlinks.modal.createTitle)}</h2>
+                <button
+                  type="button"
+                  class="fp-modal__close"
+                  data-shortlink-modal-close
+                  aria-label="${escapeHtml(copy.common.close)}"
+                >×</button>
+              </header>
+              <form id="fp-shortlink-modal-form" class="fp-shortlink__form" novalidate>
+                <label class="fp-shortlink__field">
+                  <span>${escapeHtml(copy.shortlinks.modal.slugLabel)}</span>
+                  <input
+                    type="text"
+                    id="fp-shortlink-input-slug"
+                    name="slug"
+                    autocomplete="off"
+                    required
+                    placeholder="${escapeHtml(copy.shortlinks.modal.slugPlaceholder)}"
+                  />
+                </label>
+                <label class="fp-shortlink__field">
+                  <span>${escapeHtml(copy.shortlinks.modal.targetLabel)}</span>
+                  <input
+                    type="url"
+                    id="fp-shortlink-input-target"
+                    name="target_url"
+                    required
+                    placeholder="${escapeHtml(copy.shortlinks.modal.targetPlaceholder)}"
+                  />
+                </label>
+                <div id="fp-shortlink-modal-preview" class="fp-shortlink__preview" aria-live="polite">
+                  <p>${escapeHtml(copy.shortlinks.modal.previewDefault)}</p>
+                </div>
+                <p id="fp-shortlink-modal-error" class="fp-shortlink__error" role="alert" hidden></p>
+                <footer class="fp-modal__footer">
+                  <button type="button" class="button" id="fp-shortlink-modal-cancel">${escapeHtml(copy.shortlinks.modal.cancel)}</button>
+                  <button type="submit" class="button button-primary" id="fp-shortlink-modal-submit">${escapeHtml(copy.shortlinks.modal.create)}</button>
+                </footer>
+              </form>
+            </div>
+          </div>
         </article>
       </section>
     </main>
@@ -398,7 +3138,7 @@ function renderApp(container: HTMLElement, status: { version?: string }): void {
 
   const calendar = document.getElementById('fp-calendar');
   if (calendar) {
-    renderCalendar(calendar);
+    void renderCalendar(calendar);
   }
 
   const kanbanContainer = document.getElementById('fp-kanban');
@@ -407,10 +3147,27 @@ function renderApp(container: HTMLElement, status: { version?: string }): void {
     hydrateKanban();
   }
 
+  const composerContainer = document.getElementById('fp-composer');
+  if (composerContainer) {
+    renderComposer(composerContainer);
+    initComposer();
+  }
+
   const commentsContainer = document.getElementById('fp-comments');
   if (commentsContainer) {
     renderComments(commentsContainer);
     void loadComments();
+    void loadApprovalsTimeline();
+  }
+
+  const alertsContainer = document.getElementById('fp-alerts');
+  if (alertsContainer) {
+    renderAlertsWidget(alertsContainer);
+  }
+
+  const logsContainer = document.getElementById('fp-logs');
+  if (logsContainer) {
+    renderLogsWidget(logsContainer);
   }
 
   void loadShortLinks();

--- a/fp-digital-publisher/assets/ui/components/DensityToggle.tsx
+++ b/fp-digital-publisher/assets/ui/components/DensityToggle.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { __ } from '@wordpress/i18n';
+
+export type DensityMode = 'comfort' | 'compact';
+
+export interface DensityToggleProps extends React.HTMLAttributes<HTMLDivElement> {
+  mode: DensityMode;
+  onChange: (mode: DensityMode) => void;
+  labels?: Partial<Record<DensityMode, string>>;
+}
+
+const DEFAULT_LABELS: Record<DensityMode, string> = {
+  comfort: __('Comfort', 'fp_publisher'),
+  compact: __('Compatta', 'fp_publisher'),
+};
+
+export const DensityToggle: React.FC<DensityToggleProps> = ({
+  mode,
+  onChange,
+  labels = DEFAULT_LABELS,
+  className,
+  ...rest
+}) => {
+  const handleClick = (nextMode: DensityMode) => {
+    if (nextMode === mode) {
+      return;
+    }
+    onChange(nextMode);
+  };
+
+  const mergedClassName = ['fp-ui-density-toggle', className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      {...rest}
+      className={mergedClassName}
+      role="group"
+      aria-label={__('Densità elenco', 'fp_publisher')}
+    >
+      {(Object.keys(DEFAULT_LABELS) as DensityMode[]).map((key) => (
+        <button
+          key={key}
+          type="button"
+          className={['fp-ui-density-toggle__button', mode === key ? 'is-active' : '']
+            .filter(Boolean)
+            .join(' ')}
+          aria-pressed={mode === key}
+          onClick={() => handleClick(key)}
+        >
+          {labels[key] ?? DEFAULT_LABELS[key]}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default DensityToggle;

--- a/fp-digital-publisher/assets/ui/components/EmptyState.tsx
+++ b/fp-digital-publisher/assets/ui/components/EmptyState.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+
+export interface EmptyStateAction {
+  label: string;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  href?: string;
+  target?: string;
+  rel?: string;
+}
+
+export interface EmptyStateProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: React.ReactNode;
+  hint?: React.ReactNode;
+  illustration?: React.ReactNode;
+  primaryAction?: EmptyStateAction;
+  secondaryAction?: EmptyStateAction;
+}
+
+const renderAction = (
+  action: EmptyStateAction | undefined,
+  variant: 'primary' | 'secondary'
+) => {
+  if (!action) {
+    return null;
+  }
+
+  const { href, label, onClick, target, rel } = action;
+  const computedRel = target === '_blank' && !rel ? 'noreferrer noopener' : rel;
+  const commonStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 'var(--space-1)',
+    minHeight: '36px',
+    padding: '0 var(--space-4)',
+    fontSize: 'var(--font-size-md)',
+    fontWeight: 'var(--font-weight-medium)',
+    borderRadius: 'calc(var(--radius) / 1.5)',
+    border: '1px solid transparent',
+    cursor: 'pointer',
+    transition: 'background-color 120ms ease, color 120ms ease, border-color 120ms ease',
+  };
+
+  const variantStyle: React.CSSProperties =
+    variant === 'primary'
+      ? {
+          backgroundColor: 'var(--primary)',
+          borderColor: 'var(--primary)',
+          color: '#fff',
+        }
+      : {
+          backgroundColor: 'transparent',
+          borderColor: 'var(--border)',
+          color: 'var(--text)',
+        };
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target={target}
+        rel={computedRel}
+        onClick={onClick as React.MouseEventHandler<HTMLAnchorElement>}
+        style={{ ...commonStyle, ...variantStyle, textDecoration: 'none' }}
+        className={`fp-ui-empty-state__action is-${variant}`}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick as React.MouseEventHandler<HTMLButtonElement>}
+      style={{ ...commonStyle, ...variantStyle }}
+      className={`fp-ui-empty-state__action is-${variant}`}
+    >
+      {label}
+    </button>
+  );
+};
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  title,
+  hint,
+  illustration,
+  primaryAction,
+  secondaryAction,
+  className,
+  style,
+  children,
+  ...rest
+}) => {
+  const mergedClassName = ['fp-ui-empty-state', className]
+    .filter(Boolean)
+    .join(' ');
+
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    padding: 'var(--space-6)',
+    gap: 'var(--space-3)',
+    backgroundColor: 'var(--panel)',
+    borderRadius: 'var(--radius)',
+    border: '1px dashed rgba(95, 107, 124, 0.25)',
+    color: 'var(--text)',
+    boxShadow: 'var(--shadow-1)',
+    ...style,
+  };
+
+  return (
+    <div {...rest} className={mergedClassName} style={containerStyle}>
+      {illustration}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+        <h3
+          style={{
+            fontSize: 'var(--font-size-xl)',
+            margin: 0,
+          }}
+        >
+          {title}
+        </h3>
+        {hint ? (
+          <p
+            style={{
+              margin: 0,
+              color: 'var(--muted)',
+              fontSize: 'var(--font-size-md)',
+            }}
+          >
+            {hint}
+          </p>
+        ) : null}
+      </div>
+      {children}
+      {primaryAction || secondaryAction ? (
+        <div
+          className="fp-ui-empty-state__actions"
+          style={{
+            display: 'flex',
+            gap: 'var(--space-2)',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+          }}
+        >
+          {primaryAction ? renderAction(primaryAction, 'primary') : null}
+          {secondaryAction ? renderAction(secondaryAction, 'secondary') : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/fp-digital-publisher/assets/ui/components/Icon.tsx
+++ b/fp-digital-publisher/assets/ui/components/Icon.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+
+export type IconName = 'grip' | 'calendar' | 'clock';
+
+const ICON_PATHS: Record<IconName, { viewBox: string; paths: string[] }> = {
+  grip: {
+    viewBox: '0 0 20 20',
+    paths: [
+      'M5 4.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5z',
+      'M5 8.75A1.25 1.25 0 1 1 5 11a1.25 1.25 0 0 1 0-2.5zm5 0A1.25 1.25 0 1 1 10 11a1.25 1.25 0 0 1 0-2.5zm5 0A1.25 1.25 0 1 1 15 11a1.25 1.25 0 0 1 0-2.5z',
+      'M5 13.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5zm5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5z',
+    ],
+  },
+  calendar: {
+    viewBox: '0 0 24 24',
+    paths: [
+      'M7 2a1 1 0 0 0-1 1v1H5a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3h-1V3a1 1 0 1 0-2 0v1H8V3a1 1 0 0 0-1-1zm12 6H5v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1z',
+    ],
+  },
+  clock: {
+    viewBox: '0 0 24 24',
+    paths: [
+      'M12 2a10 10 0 1 0 10 10A10.011 10.011 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8.009 8.009 0 0 1-8 8z',
+      'M12.75 7a.75.75 0 0 0-1.5 0v5.25a.75.75 0 0 0 .44.68l3.5 1.75a.75.75 0 1 0 .66-1.35L12.75 11.8z',
+    ],
+  },
+};
+
+export interface IconProps extends React.SVGAttributes<SVGElement> {
+  name: IconName;
+  size?: number;
+  title?: string;
+}
+
+export const Icon: React.FC<IconProps> = ({
+  name,
+  size = 16,
+  title,
+  role = 'img',
+  focusable = false,
+  ...rest
+}) => {
+  const definition = ICON_PATHS[name];
+  if (!definition) {
+    return null;
+  }
+
+  const { viewBox, paths } = definition;
+  const ariaHidden = rest['aria-hidden'] ?? (title ? undefined : true);
+
+  return (
+    <svg
+      {...rest}
+      role={role}
+      aria-hidden={ariaHidden}
+      width={size}
+      height={size}
+      viewBox={viewBox}
+      focusable={focusable}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+    >
+      {title ? <title>{title}</title> : null}
+      {paths.map((d, index) => (
+        <path key={index} d={d} fillRule="evenodd" clipRule="evenodd" />
+      ))}
+    </svg>
+  );
+};
+
+export default Icon;

--- a/fp-digital-publisher/assets/ui/components/Modal.tsx
+++ b/fp-digital-publisher/assets/ui/components/Modal.tsx
@@ -1,0 +1,282 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { __ } from '@wordpress/i18n';
+
+export type ModalSize = 'sm' | 'md' | 'lg';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onDismiss: () => void;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  size?: ModalSize;
+  closeLabel?: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+const FOCUSABLE_SELECTORS =
+  'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const getModalWidth = (size: ModalSize = 'md') => {
+  switch (size) {
+    case 'sm':
+      return '420px';
+    case 'lg':
+      return '880px';
+    case 'md':
+    default:
+      return '620px';
+  }
+};
+
+export const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onDismiss,
+  title,
+  description,
+  size = 'md',
+  closeLabel = __('Chiudi modale', 'fp_publisher'),
+  children,
+  footer,
+}) => {
+  const titleId = React.useId();
+  const descriptionId = React.useId();
+  const overlayRef = React.useRef<HTMLDivElement | null>(null);
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
+  const lastFocusedElement = React.useRef<HTMLElement | null>(null);
+  const [portalElement, setPortalElement] = React.useState<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    let container = document.querySelector<HTMLElement>('#fp-ui-modal-host');
+
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'fp-ui-modal-host';
+      document.body.appendChild(container);
+    }
+
+    setPortalElement(container);
+
+    return () => {
+      if (container && container.childElementCount === 0) {
+        container.remove();
+      }
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!isOpen || typeof document === 'undefined') {
+      return;
+    }
+
+    lastFocusedElement.current = document.activeElement as HTMLElement;
+
+    const previouslyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previouslyOverflow;
+      lastFocusedElement.current?.focus?.();
+    };
+  }, [isOpen]);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const node = contentRef.current;
+    if (!node) {
+      return;
+    }
+
+    const focusable = node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+    const focusTarget = focusable.length > 0 ? focusable[0] : node;
+
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => focusTarget.focus());
+    } else {
+      focusTarget.focus();
+    }
+  }, [isOpen]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      onDismiss();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      const node = contentRef.current;
+      if (!node) {
+        return;
+      }
+
+      const focusable = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+      ).filter((el) => !el.hasAttribute('data-focus-guard'));
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        node.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (active === first || !active) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === overlayRef.current) {
+      onDismiss();
+    }
+  };
+
+  if (!isOpen || !portalElement) {
+    return null;
+  }
+
+  const overlayStyle: React.CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    backgroundColor: 'rgba(15, 23, 42, 0.55)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 'var(--space-6)',
+    zIndex: 1000,
+  };
+
+  const contentStyle: React.CSSProperties = {
+    position: 'relative',
+    width: `min(100%, ${getModalWidth(size)})`,
+    maxHeight: '80vh',
+    overflowY: 'auto',
+    backgroundColor: 'var(--panel)',
+    borderRadius: 'calc(var(--radius) * 0.9)',
+    boxShadow: 'var(--shadow-2)',
+    border: '1px solid rgba(208, 215, 226, 0.7)',
+    padding: 'var(--space-5)',
+    outline: 'none',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--space-4)',
+  };
+
+  const closeButtonStyle: React.CSSProperties = {
+    position: 'absolute',
+    top: 'var(--space-3)',
+    right: 'var(--space-3)',
+    backgroundColor: 'rgba(255,255,255,0.8)',
+    border: '1px solid rgba(208, 215, 226, 0.8)',
+    borderRadius: '999px',
+    width: '32px',
+    height: '32px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+  };
+
+  return createPortal(
+    <div
+      ref={overlayRef}
+      role="presentation"
+      onMouseDown={handleOverlayClick}
+      className="fp-ui-modal__overlay"
+      style={overlayStyle}
+    >
+      <div
+        ref={contentRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
+        aria-describedby={description ? descriptionId : undefined}
+        tabIndex={-1}
+        className="fp-ui-modal__content"
+        style={contentStyle}
+        onKeyDown={handleKeyDown}
+      >
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label={closeLabel}
+          className="fp-ui-modal__close"
+          style={closeButtonStyle}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+        {title ? (
+          <header
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 'var(--space-1)',
+            }}
+          >
+            <h2
+              id={titleId}
+              style={{
+                margin: 0,
+                fontSize: 'var(--font-size-xl)',
+                fontWeight: 'var(--font-weight-semibold)',
+              }}
+            >
+              {title}
+            </h2>
+            {description ? (
+              <p
+                id={descriptionId}
+                style={{
+                  margin: 0,
+                  color: 'var(--muted)',
+                  fontSize: 'var(--font-size-md)',
+                }}
+              >
+                {description}
+              </p>
+            ) : null}
+          </header>
+        ) : null}
+        <div
+          className="fp-ui-modal__body"
+          style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}
+        >
+          {children}
+        </div>
+        {footer ? (
+          <footer
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: 'var(--space-2)',
+            }}
+          >
+            {footer}
+          </footer>
+        ) : null}
+      </div>
+    </div>,
+    portalElement
+  );
+};
+
+export default Modal;

--- a/fp-digital-publisher/assets/ui/components/SkeletonCard.tsx
+++ b/fp-digital-publisher/assets/ui/components/SkeletonCard.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+
+let stylesInjected = false;
+
+const ensureSkeletonStyles = () => {
+  if (stylesInjected || typeof document === 'undefined') {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.setAttribute('data-fp-ui-skeleton', '');
+  style.innerHTML = `@keyframes fpUiSkeletonShimmer {\n    0% { background-position: -200px 0; }\n    100% { background-position: calc(200px + 100%) 0; }\n  }`;
+  document.head.appendChild(style);
+  stylesInjected = true;
+};
+
+export interface SkeletonCardProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  lines?: number;
+  showHeader?: boolean;
+}
+
+export const SkeletonCard: React.FC<SkeletonCardProps> = ({
+  lines = 3,
+  showHeader = true,
+  className,
+  style,
+  ...rest
+}) => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(false);
+
+  React.useEffect(() => {
+    ensureSkeletonStyles();
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setPrefersReducedMotion(mediaQuery.matches);
+    update();
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', update);
+      return () => mediaQuery.removeEventListener('change', update);
+    }
+
+    mediaQuery.addListener(update);
+    return () => mediaQuery.removeListener(update);
+  }, []);
+
+  const mergedClassName = ['fp-ui-skeleton-card', className]
+    .filter(Boolean)
+    .join(' ');
+
+  const barStyle: React.CSSProperties = {
+    width: '100%',
+    height: '12px',
+    borderRadius: '999px',
+    backgroundColor: 'rgba(95, 107, 124, 0.12)',
+    backgroundImage:
+      'linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.6) 50%, rgba(255,255,255,0) 100%)',
+    backgroundSize: '200px 100%',
+    backgroundRepeat: 'no-repeat',
+    animation: prefersReducedMotion ? 'none' : 'fpUiSkeletonShimmer 1.3s ease-in-out infinite',
+  };
+
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--space-2)',
+    padding: 'var(--space-4)',
+    borderRadius: 'calc(var(--radius) * 0.75)',
+    backgroundColor: 'var(--panel)',
+    boxShadow: 'var(--shadow-1)',
+    border: '1px solid rgba(208, 215, 226, 0.6)',
+    ...style,
+  };
+
+  return (
+    <div {...rest} className={mergedClassName} style={containerStyle}>
+      {showHeader ? (
+        <div
+          style={{
+            ...barStyle,
+            height: '18px',
+            width: '60%',
+            marginBottom: 'var(--space-1)',
+          }}
+        />
+      ) : null}
+      {Array.from({ length: Math.max(1, lines) }).map((_, index) => (
+        <div
+          key={index}
+          style={{
+            ...barStyle,
+            width: index === lines - 1 ? '70%' : '100%',
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default SkeletonCard;

--- a/fp-digital-publisher/assets/ui/components/StatusBadge.tsx
+++ b/fp-digital-publisher/assets/ui/components/StatusBadge.tsx
@@ -1,0 +1,135 @@
+import * as React from 'react';
+import { __, _x } from '@wordpress/i18n';
+
+type StatusKey =
+  | 'draft'
+  | 'ready'
+  | 'approved'
+  | 'scheduled'
+  | 'published'
+  | 'failed'
+  | 'retrying';
+
+type Tone = {
+  background: string;
+  border: string;
+  text: string;
+};
+
+type StatusConfig = {
+  label: string;
+  tone: Tone;
+};
+
+const STATUS_MAP: Record<StatusKey, StatusConfig> = {
+  draft: {
+    label: _x('Bozza', 'content status', 'fp_publisher'),
+    tone: {
+      background: 'rgba(95, 107, 124, 0.12)',
+      border: 'rgba(95, 107, 124, 0.32)',
+      text: 'var(--muted)',
+    },
+  },
+  ready: {
+    label: _x('Pronto', 'content status', 'fp_publisher'),
+    tone: {
+      background: 'rgba(59, 130, 246, 0.12)',
+      border: 'rgba(59, 130, 246, 0.32)',
+      text: 'var(--primary)',
+    },
+  },
+  approved: {
+    label: _x('Approvato', 'content status', 'fp_publisher'),
+    tone: {
+      background: 'rgba(5, 150, 105, 0.12)',
+      border: 'rgba(5, 150, 105, 0.28)',
+      text: 'var(--success)',
+    },
+  },
+  scheduled: {
+    label: _x('Programmato', 'content status', 'fp_publisher'),
+    tone: {
+      background: 'rgba(37, 99, 235, 0.12)',
+      border: 'rgba(37, 99, 235, 0.32)',
+      text: 'var(--primary-600)',
+    },
+  },
+  published: {
+    label: _x('Pubblicato', 'content status', 'fp_publisher'),
+    tone: {
+      background: 'rgba(5, 150, 105, 0.16)',
+      border: 'rgba(5, 150, 105, 0.32)',
+      text: 'var(--success)',
+    },
+  },
+  failed: {
+    label: _x('Fallito', 'content status', 'fp_publisher'),
+    tone: {
+      background: 'rgba(220, 38, 38, 0.12)',
+      border: 'rgba(220, 38, 38, 0.36)',
+      text: 'var(--danger)',
+    },
+  },
+  retrying: {
+    label: _x('Nuovo tentativo', 'content status', 'fp_publisher'),
+    tone: {
+      background: 'rgba(217, 119, 6, 0.12)',
+      border: 'rgba(217, 119, 6, 0.36)',
+      text: 'var(--warning)',
+    },
+  },
+};
+
+export interface StatusBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  status: StatusKey;
+  children?: React.ReactNode;
+}
+
+export const StatusBadge: React.FC<StatusBadgeProps> = ({
+  status,
+  children,
+  className,
+  style,
+  ...rest
+}) => {
+  const config = STATUS_MAP[status];
+
+  const mergedClassName = ['fp-ui-status-badge', className]
+    .filter(Boolean)
+    .join(' ');
+
+  const fallbackLabel = config?.label ?? __(status, 'fp_publisher');
+
+  const badgeStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 'var(--space-1)',
+    padding: '2px 10px',
+    minHeight: '20px',
+    fontSize: 'var(--font-size-sm)',
+    fontWeight: 'var(--font-weight-medium)',
+    lineHeight: 1.2,
+    borderRadius: '999px',
+    border: '1px solid transparent',
+    textTransform: 'uppercase',
+    letterSpacing: '0.02em',
+    backgroundColor: config?.tone.background,
+    color: config?.tone.text,
+    borderColor: config?.tone.border,
+    ...style,
+  };
+
+  return (
+    <span
+      {...rest}
+      className={mergedClassName}
+      data-status={status}
+      style={badgeStyle}
+    >
+      {children ?? fallbackLabel}
+    </span>
+  );
+};
+
+export default StatusBadge;

--- a/fp-digital-publisher/assets/ui/components/StickyToolbar.tsx
+++ b/fp-digital-publisher/assets/ui/components/StickyToolbar.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+export interface StickyToolbarProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  elevation?: 'flat' | 'floating';
+}
+
+export const StickyToolbar = React.forwardRef<HTMLDivElement, StickyToolbarProps>(
+  ({ children, className, style, elevation = 'flat', ...rest }, ref) => {
+    const mergedClassName = ['fp-ui-sticky-toolbar', className]
+      .filter(Boolean)
+      .join(' ');
+
+    const toolbarStyle: React.CSSProperties = {
+      position: 'sticky',
+      top: 0,
+      zIndex: 10,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: 'var(--space-3)',
+      padding: 'var(--space-3) var(--space-4)',
+      backgroundColor: 'var(--panel)',
+      backdropFilter: 'blur(12px)',
+      borderBottom: '1px solid var(--border)',
+      boxShadow: elevation === 'floating' ? 'var(--shadow-1)' : 'none',
+      ...style,
+    };
+
+    return (
+      <div {...rest} ref={ref} className={mergedClassName} style={toolbarStyle}>
+        {children}
+      </div>
+    );
+  }
+);
+
+StickyToolbar.displayName = 'StickyToolbar';
+
+export default StickyToolbar;

--- a/fp-digital-publisher/assets/ui/components/ToastHost.tsx
+++ b/fp-digital-publisher/assets/ui/components/ToastHost.tsx
@@ -1,0 +1,260 @@
+import * as React from 'react';
+import { __ } from '@wordpress/i18n';
+
+type ToastIntent = 'neutral' | 'success' | 'warning' | 'danger';
+
+type ToastAction = {
+  label: string;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+};
+
+type ToastInput = {
+  id?: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  intent?: ToastIntent;
+  duration?: number;
+  action?: ToastAction;
+};
+
+type ToastRecord = Required<Pick<ToastInput, 'title'>> &
+  Omit<ToastInput, 'title'> & {
+    id: string;
+    createdAt: number;
+  };
+
+type ToastEvent =
+  | { type: 'add'; toast: ToastRecord }
+  | { type: 'remove'; id: string };
+
+const listeners = new Set<(event: ToastEvent) => void>();
+
+const DEFAULT_DURATION = 5000;
+
+const generateId = () =>
+  Math.random().toString(36).slice(2) + Date.now().toString(36);
+
+export const pushToast = (input: ToastInput) => {
+  const toast: ToastRecord = {
+    id: input.id ?? generateId(),
+    title: input.title,
+    description: input.description,
+    intent: input.intent ?? 'neutral',
+    duration: input.duration ?? DEFAULT_DURATION,
+    action: input.action,
+    createdAt: Date.now(),
+  };
+
+  listeners.forEach((listener) => listener({ type: 'add', toast }));
+
+  if (toast.duration && toast.duration > 0 && typeof window !== 'undefined') {
+    window.setTimeout(() => dismissToast(toast.id), toast.duration);
+  }
+
+  return toast.id;
+};
+
+export const dismissToast = (id: string) => {
+  listeners.forEach((listener) => listener({ type: 'remove', id }));
+};
+
+export interface ToastHostProps {
+  placement?: 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end';
+  maxToasts?: number;
+}
+
+const getPlacementStyles = (
+  placement: ToastHostProps['placement']
+): React.CSSProperties => {
+  const base: React.CSSProperties = {
+    position: 'fixed',
+    zIndex: 1200,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--space-2)',
+    pointerEvents: 'none',
+  };
+
+  switch (placement) {
+    case 'top-start':
+      return { ...base, top: 'var(--space-5)', left: 'var(--space-5)', alignItems: 'flex-start' };
+    case 'bottom-start':
+      return { ...base, bottom: 'var(--space-5)', left: 'var(--space-5)', alignItems: 'flex-start' };
+    case 'bottom-end':
+      return { ...base, bottom: 'var(--space-5)', right: 'var(--space-5)', alignItems: 'flex-end' };
+    case 'top-end':
+    default:
+      return { ...base, top: 'var(--space-5)', right: 'var(--space-5)', alignItems: 'flex-end' };
+  }
+};
+
+const getToastColors = (intent: ToastIntent = 'neutral') => {
+  switch (intent) {
+    case 'success':
+      return {
+        background: 'rgba(5, 150, 105, 0.16)',
+        border: 'rgba(5, 150, 105, 0.45)',
+        text: 'var(--success)',
+      };
+    case 'warning':
+      return {
+        background: 'rgba(217, 119, 6, 0.16)',
+        border: 'rgba(217, 119, 6, 0.45)',
+        text: 'var(--warning)',
+      };
+    case 'danger':
+      return {
+        background: 'rgba(220, 38, 38, 0.16)',
+        border: 'rgba(220, 38, 38, 0.45)',
+        text: 'var(--danger)',
+      };
+    case 'neutral':
+    default:
+      return {
+        background: 'rgba(59, 130, 246, 0.1)',
+        border: 'rgba(37, 99, 235, 0.3)',
+        text: 'var(--text)',
+      };
+  }
+};
+
+const emptyStateText = __('Nessuna notifica al momento.', 'fp_publisher');
+
+export const ToastHost: React.FC<ToastHostProps> = ({
+  placement = 'top-end',
+  maxToasts = 4,
+}) => {
+  const [toasts, setToasts] = React.useState<ToastRecord[]>([]);
+
+  React.useEffect(() => {
+    const listener = (event: ToastEvent) => {
+      setToasts((prev) => {
+        if (event.type === 'add') {
+          const withoutDuplicate = prev.filter((toast) => toast.id !== event.toast.id);
+          const next = [event.toast, ...withoutDuplicate]
+            .sort((a, b) => b.createdAt - a.createdAt)
+            .slice(0, maxToasts);
+          return next;
+        }
+
+        return prev.filter((toast) => toast.id !== event.id);
+      });
+    };
+
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, [maxToasts]);
+
+  const hostStyle = React.useMemo(
+    () => getPlacementStyles(placement),
+    [placement]
+  );
+
+  return (
+    <div
+      role="region"
+      aria-live="polite"
+      aria-label={__('Notifiche', 'fp_publisher')}
+      className="fp-ui-toast-host"
+      style={hostStyle}
+    >
+      {toasts.length === 0 ? (
+        <span
+          style={{
+            fontSize: 'var(--font-size-sm)',
+            color: 'var(--muted)',
+            pointerEvents: 'none',
+          }}
+        >
+          {emptyStateText}
+        </span>
+      ) : null}
+      {toasts.map((toast) => {
+        const colors = getToastColors(toast.intent ?? 'neutral');
+        return (
+          <article
+            key={toast.id}
+            className="fp-ui-toast"
+            role="status"
+            style={{
+              minWidth: '260px',
+              maxWidth: '360px',
+              backgroundColor: colors.background,
+              border: `1px solid ${colors.border}`,
+              color: colors.text,
+              borderRadius: 'calc(var(--radius) / 1.5)',
+              boxShadow: 'var(--shadow-1)',
+              padding: 'var(--space-3)',
+              pointerEvents: 'auto',
+              display: 'grid',
+              gap: 'var(--space-2)',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'flex-start',
+                gap: 'var(--space-2)',
+              }}
+            >
+              <div style={{ display: 'grid', gap: 'var(--space-1)' }}>
+                <strong style={{ fontSize: 'var(--font-size-md)' }}>
+                  {toast.title}
+                </strong>
+                {toast.description ? (
+                  <span style={{ fontSize: 'var(--font-size-sm)', color: 'var(--muted)' }}>
+                    {toast.description}
+                  </span>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                onClick={() => dismissToast(toast.id)}
+                aria-label={__('Chiudi notifica', 'fp_publisher')}
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  color: colors.text,
+                  cursor: 'pointer',
+                  fontSize: 'var(--font-size-md)',
+                  lineHeight: 1,
+                }}
+              >
+                ×
+              </button>
+            </div>
+            {toast.action ? (
+              <div>
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    toast.action?.onClick(event);
+                    dismissToast(toast.id);
+                  }}
+                  style={{
+                    backgroundColor: 'var(--primary)',
+                    border: '1px solid var(--primary)',
+                    color: '#fff',
+                    padding: '6px 12px',
+                    borderRadius: '999px',
+                    fontSize: 'var(--font-size-sm)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {toast.action.label}
+                </button>
+              </div>
+            ) : null}
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ToastHost;
+
+export type { ToastIntent, ToastAction, ToastInput, ToastRecord };

--- a/fp-digital-publisher/assets/ui/components/Tooltip.tsx
+++ b/fp-digital-publisher/assets/ui/components/Tooltip.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+
+export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactElement;
+  placement?: TooltipPlacement;
+  delay?: number;
+}
+
+const composeEventHandler = <E extends React.SyntheticEvent>(
+  theirHandler: ((event: E) => void) | undefined,
+  ourHandler: (event: E) => void
+) => (event: E) => {
+  if (theirHandler) {
+    theirHandler(event);
+  }
+  if (!event.defaultPrevented) {
+    ourHandler(event);
+  }
+};
+
+export const Tooltip: React.FC<TooltipProps> = ({
+  content,
+  children,
+  placement = 'top',
+  delay = 150,
+}) => {
+  if (!content) {
+    return children;
+  }
+
+  const tooltipId = React.useId();
+  const [open, setOpen] = React.useState(false);
+  const timerRef = React.useRef<number | null>(null);
+
+  const clearTimer = () => {
+    if (typeof window === 'undefined') {
+      timerRef.current = null;
+      return;
+    }
+
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const show = () => {
+    if (open) {
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      setOpen(true);
+      return;
+    }
+
+    clearTimer();
+    timerRef.current = window.setTimeout(() => setOpen(true), delay);
+  };
+
+  const hide = () => {
+    clearTimer();
+    setOpen(false);
+  };
+
+  React.useEffect(() => clearTimer, []);
+
+  const child = React.cloneElement(children, {
+    'aria-describedby': open
+      ? [children.props['aria-describedby'], tooltipId]
+          .filter(Boolean)
+          .join(' ')
+      : children.props['aria-describedby'],
+    onMouseEnter: composeEventHandler(children.props.onMouseEnter, show),
+    onMouseLeave: composeEventHandler(children.props.onMouseLeave, hide),
+    onFocus: composeEventHandler(children.props.onFocus, show),
+    onBlur: composeEventHandler(children.props.onBlur, hide),
+  });
+
+  const tooltipStyle: React.CSSProperties = {
+    position: 'absolute',
+    zIndex: 20,
+    padding: '6px 10px',
+    borderRadius: '6px',
+    backgroundColor: 'rgba(31, 41, 51, 0.92)',
+    color: '#fff',
+    fontSize: 'var(--font-size-sm)',
+    fontWeight: 'var(--font-weight-medium)',
+    lineHeight: 1.2,
+    maxWidth: '240px',
+    boxShadow: 'var(--shadow-1)',
+    pointerEvents: 'none',
+    opacity: open ? 1 : 0,
+    transition: 'opacity 120ms ease, transform 120ms ease',
+  };
+
+  const getPositionStyles = (): React.CSSProperties => {
+    switch (placement) {
+      case 'bottom':
+        return {
+          top: 'calc(100% + 8px)',
+          left: '50%',
+          transform: `translateY(${open ? '0' : '-4px'}) translateX(-50%)`,
+        };
+      case 'left':
+        return {
+          right: 'calc(100% + 8px)',
+          top: '50%',
+          transform: `translateX(${open ? '0' : '4px'}) translateY(-50%)`,
+        };
+      case 'right':
+        return {
+          left: 'calc(100% + 8px)',
+          top: '50%',
+          transform: `translateX(${open ? '0' : '-4px'}) translateY(-50%)`,
+        };
+      case 'top':
+      default:
+        return {
+          bottom: 'calc(100% + 8px)',
+          left: '50%',
+          transform: `translateY(${open ? '0' : '4px'}) translateX(-50%)`,
+        };
+    }
+  };
+
+  const arrowStyle: React.CSSProperties = {
+    position: 'absolute',
+    width: '8px',
+    height: '8px',
+    backgroundColor: 'inherit',
+    transform: 'rotate(45deg)',
+  };
+
+  const getArrowPosition = (): React.CSSProperties => {
+    switch (placement) {
+      case 'bottom':
+        return { top: '-4px', left: 'calc(50% - 4px)' };
+      case 'left':
+        return { right: '-4px', top: 'calc(50% - 4px)' };
+      case 'right':
+        return { left: '-4px', top: 'calc(50% - 4px)' };
+      case 'top':
+      default:
+        return { bottom: '-4px', left: 'calc(50% - 4px)' };
+    }
+  };
+
+  return (
+    <span
+      className="fp-ui-tooltip-wrapper"
+      style={{ position: 'relative', display: 'inline-flex' }}
+    >
+      {child}
+      <span
+        role="tooltip"
+        id={tooltipId}
+        aria-hidden={!open}
+        style={{ ...tooltipStyle, ...getPositionStyles() }}
+      >
+        <span style={{ ...arrowStyle, ...getArrowPosition() }} />
+        <span>{content}</span>
+      </span>
+    </span>
+  );
+};
+
+export default Tooltip;

--- a/fp-digital-publisher/assets/ui/pages/_demo/UiShowcase.tsx
+++ b/fp-digital-publisher/assets/ui/pages/_demo/UiShowcase.tsx
@@ -1,0 +1,351 @@
+import * as React from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+
+import StatusBadge from '../../components/StatusBadge';
+import StickyToolbar from '../../components/StickyToolbar';
+import EmptyState from '../../components/EmptyState';
+import SkeletonCard from '../../components/SkeletonCard';
+import Tooltip from '../../components/Tooltip';
+import Modal from '../../components/Modal';
+import DensityToggle, {
+  type DensityMode,
+} from '../../components/DensityToggle';
+import Icon from '../../components/Icon';
+import ToastHost, { pushToast } from '../../components/ToastHost';
+
+const STATUS_KEYS: Array<React.ComponentProps<typeof StatusBadge>['status']> = [
+  'draft',
+  'ready',
+  'approved',
+  'scheduled',
+  'published',
+  'failed',
+  'retrying',
+];
+
+const cardStyle: React.CSSProperties = {
+  backgroundColor: 'var(--panel)',
+  borderRadius: 'var(--radius)',
+  border: '1px solid rgba(95, 107, 124, 0.14)',
+  boxShadow: 'var(--shadow-1)',
+  padding: 'var(--space-5)',
+  display: 'grid',
+  gap: 'var(--space-4)',
+};
+
+const toolbarButtonStyle: React.CSSProperties = {
+  border: '1px solid var(--border)',
+  background: 'var(--panel)',
+  borderRadius: 'calc(var(--radius) / 2)',
+  padding: '0 var(--space-3)',
+  minHeight: '36px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 'var(--space-1)',
+  fontSize: 'var(--font-size-md)',
+  fontWeight: 'var(--font-weight-medium)',
+};
+
+const badgeWrapStyle: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 'var(--space-2)',
+};
+
+const skeletonRowStyle: React.CSSProperties = {
+  display: 'grid',
+  gap: 'var(--space-3)',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+};
+
+const tokenPreviewStyle: React.CSSProperties = {
+  display: 'grid',
+  gap: 'var(--space-3)',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+};
+
+const swatchStyle: React.CSSProperties = {
+  borderRadius: 'calc(var(--radius) / 1.8)',
+  border: '1px solid rgba(95, 107, 124, 0.18)',
+  boxShadow: 'var(--shadow-1)',
+  padding: 'var(--space-3)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-2)',
+};
+
+const UiShowcase: React.FC = () => {
+  const [densityMode, setDensityMode] = React.useState<DensityMode>('comfort');
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+
+  const heading = __(
+    'Vetrina componenti FP Digital Publisher',
+    'fp_publisher'
+  );
+  const intro = __(
+    'Panoramica rapida dei design token condivisi e dei componenti riutilizzabili dell’admin SPA.',
+    'fp_publisher'
+  );
+
+  const handleToast = (intent: 'neutral' | 'success' | 'warning' | 'danger') => {
+    pushToast({
+      title: sprintf(__('Toast %s', 'fp_publisher'), intent),
+      description: __(
+        'Questo è un esempio di notifica transiente con annuncio aria-live.',
+        'fp_publisher'
+      ),
+      intent,
+      action:
+        intent === 'danger'
+          ? {
+              label: __('Annulla', 'fp_publisher'),
+              onClick: () => {
+                pushToast({
+                  title: __('Azione annullata', 'fp_publisher'),
+                  intent: 'neutral',
+                });
+              },
+            }
+          : undefined,
+    });
+  };
+
+  return (
+    <div
+      className="fp-ui-showcase"
+      style={{
+        minHeight: '100vh',
+        background:
+          'linear-gradient(180deg, rgba(238,242,255,0.55) 0%, rgba(244,247,252,0.9) 100%)',
+        padding: 'var(--space-6)',
+        display: 'grid',
+        gap: 'var(--space-6)',
+      }}
+    >
+      <ToastHost placement="top-end" />
+      <StickyToolbar elevation="floating">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <strong style={{ fontSize: 'var(--font-size-xl)' }}>{heading}</strong>
+          <span style={{ color: 'var(--muted)', fontSize: 'var(--font-size-md)' }}>
+            {intro}
+          </span>
+        </div>
+        <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <DensityToggle mode={densityMode} onChange={setDensityMode} />
+          <Tooltip content={__('Apri modale dimostrativa', 'fp_publisher')}>
+            <button
+              type="button"
+              style={toolbarButtonStyle}
+              onClick={() => setIsModalOpen(true)}
+            >
+              <Icon name="calendar" size={16} aria-hidden />
+              <span>{__('Mostra modale', 'fp_publisher')}</span>
+            </button>
+          </Tooltip>
+          <Tooltip content={__('Invia un toast di esempio', 'fp_publisher')}>
+            <button
+              type="button"
+              style={{ ...toolbarButtonStyle, backgroundColor: 'var(--primary)', color: '#fff', borderColor: 'var(--primary)' }}
+              onClick={() => handleToast('success')}
+            >
+              <Icon name="clock" size={16} aria-hidden />
+              <span>{__('Toast rapido', 'fp_publisher')}</span>
+            </button>
+          </Tooltip>
+        </div>
+      </StickyToolbar>
+
+      <section style={cardStyle} aria-labelledby="tokens-title">
+        <div style={{ display: 'grid', gap: 'var(--space-1)' }}>
+          <h2 id="tokens-title" style={{ margin: 0, fontSize: 'var(--font-size-xl)' }}>
+            {__('Design token', 'fp_publisher')}
+          </h2>
+          <p style={{ margin: 0, color: 'var(--muted)' }}>
+            {__('Palette, spaziatura e tipografia condividono la stessa sorgente CSS (`tokens.css`).', 'fp_publisher')}
+          </p>
+        </div>
+        <div style={tokenPreviewStyle}>
+          {[
+            { label: 'Primary', token: 'var(--primary)' },
+            { label: 'Panel', token: 'var(--panel)' },
+            { label: 'Success', token: 'var(--success)' },
+            { label: 'Warning', token: 'var(--warning)' },
+            { label: 'Danger', token: 'var(--danger)' },
+            { label: 'Border', token: 'var(--border)' },
+          ].map(({ label, token }) => (
+            <div key={label} style={swatchStyle}>
+              <span style={{ fontWeight: 'var(--font-weight-semibold)' }}>{label}</span>
+              <span
+                style={{
+                  height: '36px',
+                  borderRadius: 'calc(var(--radius) / 2)',
+                  backgroundColor: token,
+                  border: '1px solid rgba(15, 23, 42, 0.05)',
+                }}
+                aria-hidden
+              />
+              <code style={{ fontSize: 'var(--font-size-sm)', color: 'var(--muted)' }}>{token}</code>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section style={cardStyle} aria-labelledby="badge-title">
+        <div style={{ display: 'grid', gap: 'var(--space-1)' }}>
+          <h2 id="badge-title" style={{ margin: 0, fontSize: 'var(--font-size-xl)' }}>
+            {__('Badge di stato', 'fp_publisher')}
+          </h2>
+          <p style={{ margin: 0, color: 'var(--muted)' }}>
+            {__('Ogni stato applica tonalità coerenti e testo leggibile.', 'fp_publisher')}
+          </p>
+        </div>
+        <div style={badgeWrapStyle}>
+          {STATUS_KEYS.map((status) => (
+            <StatusBadge key={status} status={status} />
+          ))}
+        </div>
+      </section>
+
+      <section style={cardStyle} aria-labelledby="layout-title">
+        <div style={{ display: 'grid', gap: 'var(--space-1)' }}>
+          <h2 id="layout-title" style={{ margin: 0, fontSize: 'var(--font-size-xl)' }}>
+            {__('Layout ed empty state', 'fp_publisher')}
+          </h2>
+          <p style={{ margin: 0, color: 'var(--muted)' }}>
+            {__('Componenti card, skeleton ed empty state coprono loading e vuoti di contenuto.', 'fp_publisher')}
+          </p>
+        </div>
+        <div style={{ display: 'grid', gap: 'var(--space-4)' }}>
+          <div style={skeletonRowStyle}>
+            {Array.from({ length: 3 }).map((_, index) => (
+              <SkeletonCard key={index} lines={index === 0 ? 4 : 3} showHeader={index !== 2} />
+            ))}
+          </div>
+          <EmptyState
+            title={__('Nessun contenuto programmato', 'fp_publisher')}
+            hint={__('Importa una board Trello o crea un nuovo post dal Composer.', 'fp_publisher')}
+            primaryAction={{
+              label: __('Apri Composer', 'fp_publisher'),
+              onClick: () => handleToast('neutral'),
+            }}
+            secondaryAction={{
+              label: __('Importa da Trello', 'fp_publisher'),
+              onClick: () => handleToast('warning'),
+            }}
+          />
+        </div>
+      </section>
+
+      <section style={cardStyle} aria-labelledby="toast-title">
+        <div style={{ display: 'grid', gap: 'var(--space-1)' }}>
+          <h2 id="toast-title" style={{ margin: 0, fontSize: 'var(--font-size-xl)' }}>
+            {__('Notifiche contestuali', 'fp_publisher')}
+          </h2>
+          <p style={{ margin: 0, color: 'var(--muted)' }}>
+            {__('Il ToastHost diffonde notifiche polite con azioni opzionali.', 'fp_publisher')}
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
+          {(['neutral', 'success', 'warning', 'danger'] as const).map((intent) => (
+            <button
+              key={intent}
+              type="button"
+              style={{
+                ...toolbarButtonStyle,
+                backgroundColor: intent === 'neutral' ? 'var(--panel)' : 'var(--primary)',
+                color: intent === 'neutral' ? 'var(--text)' : '#fff',
+                borderColor: intent === 'neutral' ? 'var(--border)' : 'var(--primary)',
+              }}
+              onClick={() => handleToast(intent)}
+            >
+              {__('Toast', 'fp_publisher')} {intent}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <Modal
+        isOpen={isModalOpen}
+        onDismiss={() => setIsModalOpen(false)}
+        title={__('Modal dimostrativa', 'fp_publisher')}
+        description={__('Modale con focus trap, ESC e overlay per chiusura.', 'fp_publisher')}
+        footer={
+          <button
+            type="button"
+            onClick={() => setIsModalOpen(false)}
+            style={{
+              ...toolbarButtonStyle,
+              backgroundColor: 'var(--primary)',
+              color: '#fff',
+              borderColor: 'var(--primary)',
+            }}
+          >
+            {__('Chiudi', 'fp_publisher')}
+          </button>
+        }
+      >
+        <p style={{ margin: 0, color: 'var(--text)' }}>
+          {__('Questa modale illustra le dimensioni medie con gestione accessibile della messa a fuoco.', 'fp_publisher')}
+        </p>
+        <p style={{ margin: 0, color: 'var(--muted)', fontSize: 'var(--font-size-sm)' }}>
+          {__('Utilizzare ESC o clic sull’overlay per chiudere.', 'fp_publisher')}
+        </p>
+      </Modal>
+
+      <section style={cardStyle} aria-labelledby="density-title">
+        <div style={{ display: 'grid', gap: 'var(--space-1)' }}>
+          <h2 id="density-title" style={{ margin: 0, fontSize: 'var(--font-size-xl)' }}>
+            {__('Anteprima densità elenco', 'fp_publisher')}
+          </h2>
+          <p style={{ margin: 0, color: 'var(--muted)' }}>
+            {__('Il toggle applica classi di densità su liste e tabelle per accomodare calendari affollati.', 'fp_publisher')}
+          </p>
+        </div>
+        <div
+          style={{
+            display: 'grid',
+            gap: 'var(--space-2)',
+          }}
+        >
+          <DensityToggle mode={densityMode} onChange={setDensityMode} />
+          <div
+            role="list"
+            data-density={densityMode}
+            style={{
+              display: 'grid',
+              gap: densityMode === 'compact' ? 'var(--space-1)' : 'var(--space-2)',
+            }}
+          >
+            {['Calendario editoriale', 'Composer', 'Approvals'].map((label) => (
+              <div
+                key={label}
+                role="listitem"
+                style={{
+                  border: '1px solid var(--border)',
+                  borderRadius: 'calc(var(--radius) / 2)',
+                  padding:
+                    densityMode === 'compact'
+                      ? 'var(--space-2) var(--space-3)'
+                      : 'var(--space-3) var(--space-4)',
+                  backgroundColor: 'var(--panel)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 'var(--space-2)',
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+                  <Icon name="grip" aria-hidden />
+                  <span>{label}</span>
+                </div>
+                <StatusBadge status="ready" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default UiShowcase;

--- a/fp-digital-publisher/assets/ui/tokens.css
+++ b/fp-digital-publisher/assets/ui/tokens.css
@@ -1,0 +1,112 @@
+:root {
+  color-scheme: light;
+}
+
+.fp-pub-root {
+  --bg: #f7f9fc;
+  --panel: #ffffff;
+  --text: #1f2933;
+  --muted: #5f6b7c;
+  --primary: #3b82f6;
+  --primary-600: #2563eb;
+  --success: #059669;
+  --warning: #d97706;
+  --danger: #dc2626;
+  --border: #d0d7e2;
+
+  --radius: 14px;
+
+  --shadow-1: 0 1px 2px rgba(15, 23, 42, 0.1);
+  --shadow-2: 0 20px 40px -24px rgba(15, 23, 42, 0.25);
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+
+  --font-size-xxl: 22px;
+  --font-size-xl: 18px;
+  --font-size-lg: 16px;
+  --font-size-md: 14px;
+  --font-size-sm: 12px;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+.fp-pub-root ::selection {
+  background: rgba(37, 99, 235, 0.16);
+}
+
+.fp-pub-root h1,
+.fp-pub-root h2,
+.fp-pub-root h3,
+.fp-pub-root h4,
+.fp-pub-root h5,
+.fp-pub-root h6 {
+  color: var(--text);
+  font-weight: var(--font-weight-semibold);
+}
+
+.fp-pub-root p,
+.fp-pub-root li,
+.fp-pub-root label {
+  color: var(--text);
+  font-size: var(--font-size-md);
+}
+
+.fp-pub-root small {
+  font-size: var(--font-size-sm);
+  color: var(--muted);
+}
+
+.fp-pub-root button,
+.fp-pub-root input,
+.fp-pub-root select,
+.fp-pub-root textarea {
+  font: inherit;
+  color: inherit;
+  line-height: 1.4;
+  border-radius: calc(var(--radius) / 2);
+  border: 1px solid var(--border);
+  background-color: var(--panel);
+  box-shadow: none;
+}
+
+.fp-pub-root button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  cursor: pointer;
+}
+
+.fp-pub-root button:focus-visible,
+.fp-pub-root input:focus-visible,
+.fp-pub-root select:focus-visible,
+.fp-pub-root textarea:focus-visible,
+.fp-pub-root a:focus-visible,
+.fp-pub-root [role="button"]:focus-visible,
+.fp-pub-root [role="menuitem"]:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.fp-pub-root [disabled],
+.fp-pub-root [aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.fp-pub-root hr {
+  border: none;
+  border-bottom: 1px solid var(--border);
+}

--- a/fp-digital-publisher/docs/UI-GUIDE.md
+++ b/fp-digital-publisher/docs/UI-GUIDE.md
@@ -1,0 +1,34 @@
+# FP Digital Publisher – UI Guide
+
+Questa guida riassume token, componenti e pattern introdotti nelle fasi di UI polish per l’admin SPA del plugin FP Digital Publisher.
+
+## Design Token
+- `assets/ui/tokens.css` definisce colori, radius, ombre, scala spazi e tipografia condivisa. I token sono esposti come CSS variable (`--primary`, `--radius`, `--shadow-1`, ecc.) dentro il namespace `.fp-pub-root`.
+- Caricare il foglio token il prima possibile tramite `Admin\UI\Enqueue` assicura che tutte le superfici React ereditino palette e reset coerenti.
+- I controlli interattivi (button, input, select, textarea) applicano outline `2px` su `:focus-visible` e rispettano `font: inherit` per uniformare la tipografia.
+
+## Componenti Base
+- **StatusBadge** (`assets/ui/components/StatusBadge.tsx`): visualizza stati standardizzati (`draft`, `ready`, `approved`, `scheduled`, `published`, `failed`, `retrying`) con pill arrotondate e tonalità AA.
+- **StickyToolbar** (`StickyToolbar.tsx`): barra sticky con backdrop-blur e bordo inferiore. Usare `elevation="floating"` per aggiungere ombra quando sovrapposta a contenuti.
+- **EmptyState** (`EmptyState.tsx`): layout centrato con titolo, hint, illustrazione opzionale e CTA primaria/secondaria; accetta callback o link.
+- **SkeletonCard** (`SkeletonCard.tsx`): placeholder animati che rispettano `prefers-reduced-motion` e permettono di configurare righe e header.
+- **Tooltip** (`Tooltip.tsx`): wrapper non intrusivo che fornisce `aria-describedby`, ritardo configurabile e posizionamenti top/bottom/left/right.
+- **Modal** (`Modal.tsx`): dialogo portaled con trap focus, chiusura via ESC/overlay e host condiviso `#fp-ui-modal-host`.
+- **ToastHost** (`ToastHost.tsx`): regione `aria-live="polite"` per toast; utilizzare `pushToast`/`dismissToast` per gestire notifiche e azioni.
+- **DensityToggle** (`DensityToggle.tsx`): switch `compact`/`comfort` per applicare classi di densità su tabelle o liste.
+- **Icon** (`Icon.tsx`): raccolta di SVG inline (`grip`, `calendar`, `clock`) per evitare asset binari.
+
+## Pattern Consigliati
+- **Layout**: utilizzare griglie CSS e spacing token (`var(--space-N)`) per distribuire card, moduli e liste; mantenere contenitori su sfondo `var(--panel)` con bordo `var(--border)`.
+- **Caricamento**: preferire `SkeletonCard` su fetch asincroni; passare `showHeader={false}` per placeholder compatti.
+- **Vuoti**: `EmptyState` con CTA contestuale e hint descrittivo; per import manuali aggiungere `secondaryAction` con `target="_blank"` quando necessario.
+- **Feedback**: montare `ToastHost` una sola volta per pagina; chiamare `pushToast({ title, description, intent })` per annunci success/errore/warning.
+- **Accessibilità**: assicurarsi che ogni bottone/anchor usi `Tooltip` solo come arricchimento, mantenendo label visibili; `Modal` deve sempre ricevere `onDismiss` collegato a ESC e overlay.
+
+## Convenzioni UI
+- Badge di stato mostrano testo maiuscolo con `font-weight-medium`; evitare stringhe custom se possibile e riutilizzare gli alias esistenti.
+- Toolbar sticky mantengono padding `var(--space-3) var(--space-4)` e allineano CTA a destra; quando necessario, includere `DensityToggle` accanto a filtri/ricerche.
+- Empty state e skeleton devono vivere nello stesso wrapper della tabella/lista per evitare salti di layout.
+- Toast host posizionato in alto a destra (`placement="top-end"`) è la scelta predefinita; utilizzare `bottom-start` in contesti dove l’header è affollato.
+- Per nuovi pattern, aggiornare questa guida e la demo `assets/ui/pages/_demo/UiShowcase.tsx` così da mantenere la documentazione sincronizzata.
+

--- a/fp-digital-publisher/src/Admin/UI/Enqueue.php
+++ b/fp-digital-publisher/src/Admin/UI/Enqueue.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\Publisher\Admin\UI;
+
+use function add_action;
+use function get_current_screen;
+use function str_contains;
+use function wp_enqueue_style;
+use function wp_register_style;
+
+final class Enqueue
+{
+    private const TOKENS_HANDLE = 'fp-publisher-ui-tokens';
+
+    public static function register(): void
+    {
+        add_action('admin_enqueue_scripts', [self::class, 'load'], 5);
+    }
+
+    public static function load(): void
+    {
+        $screen = get_current_screen();
+        if ($screen === null || ! str_contains((string) $screen->id, 'fp-publisher')) {
+            return;
+        }
+
+        wp_register_style(
+            self::TOKENS_HANDLE,
+            FP_PUBLISHER_URL . 'assets/ui/tokens.css',
+            [],
+            FP_PUBLISHER_VERSION
+        );
+
+        wp_enqueue_style(self::TOKENS_HANDLE);
+    }
+}

--- a/fp-digital-publisher/src/Loader.php
+++ b/fp-digital-publisher/src/Loader.php
@@ -7,6 +7,7 @@ namespace FP\Publisher;
 use FP\Publisher\Admin\Assets;
 use FP\Publisher\Admin\Menu;
 use FP\Publisher\Admin\Notices;
+use FP\Publisher\Admin\UI\Enqueue as UiEnqueue;
 use FP\Publisher\Api\Routes;
 use FP\Publisher\Infra\Capabilities;
 use FP\Publisher\Infra\DB\Migrations;
@@ -32,6 +33,7 @@ final class Loader
         Capabilities::register();
         Notices::register();
         Menu::register();
+        UiEnqueue::register();
         Assets::register();
         Routes::register();
         AssetPipeline::register();


### PR DESCRIPTION
## Summary
- add an internal UiShowcase demo page to highlight design tokens and reusable admin components
- extend the README with a dedicated "UI Kit" section including code snippets and placeholder references
- author a UI guide covering tokens, components, and patterns while marking the rebuild tracker complete for U8

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db8a5dcb38832fb4793027a40afd31