### PR TITLE
Improve trimWidth fallback width handling

### DIFF
--- a/fp-digital-publisher/src/Api/GoogleBusiness/Client.php
+++ b/fp-digital-publisher/src/Api/GoogleBusiness/Client.php
@@ -10,13 +10,13 @@ use Exception;
 use FP\Publisher\Infra\Options;
 use FP\Publisher\Support\Dates;
 use FP\Publisher\Support\Http;
+use FP\Publisher\Support\Strings;
 use RuntimeException;
 
 use function add_query_arg;
 use function array_filter;
 use function array_map;
 use function explode;
-use function function_exists;
 use function esc_url_raw;
 use function http_build_query;
 use function implode;
@@ -33,8 +33,6 @@ use function str_contains;
 use function str_starts_with;
 use function strtolower;
 use function trim;
-use function mb_substr;
-use function substr;
 use function wp_json_encode;
 use function wp_remote_retrieve_body;
 use function wp_remote_retrieve_response_code;
@@ -480,11 +478,11 @@ final class Client
     {
         $trimmed = trim($value);
 
-        if (function_exists('mb_substr')) {
-            return mb_substr($trimmed, 0, $length);
+        if ($trimmed === '') {
+            return '';
         }
 
-        return substr($trimmed, 0, $length);
+        return Strings::safeSubstr($trimmed, $length);
     }
 
     private static function getAccessToken(string $accountId, array $payload): string

--- a/fp-digital-publisher/src/Services/Preflight.php
+++ b/fp-digital-publisher/src/Services/Preflight.php
@@ -8,12 +8,12 @@ use FP\Publisher\Domain\AssetRef;
 use FP\Publisher\Domain\PostPlan;
 use FP\Publisher\Services\Templates\Engine;
 use FP\Publisher\Support\Channels;
+use FP\Publisher\Support\Strings;
 
 use function __;
 use function array_key_exists;
 use function array_unique;
 use function count;
-use function function_exists;
 use function in_array;
 use function is_array;
 use function is_scalar;
@@ -22,7 +22,6 @@ use function round;
 use function str_starts_with;
 use function strtolower;
 use function trim;
-use function strlen;
 use function wp_http_validate_url;
 
 final class Preflight
@@ -437,10 +436,6 @@ final class Preflight
 
     private static function length(string $value): int
     {
-        if (function_exists('mb_strlen')) {
-            return (int) mb_strlen($value);
-        }
-
-        return strlen($value);
+        return Strings::length($value);
     }
 }

--- a/fp-digital-publisher/src/Support/Logging/StructuredLogger.php
+++ b/fp-digital-publisher/src/Support/Logging/StructuredLogger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace FP\Publisher\Support\Logging;
 
 use DateTimeInterface;
+use FP\Publisher\Support\Strings;
 use Psr\Log\AbstractLogger;
 use Stringable;
 use Throwable;
@@ -19,8 +20,6 @@ use function is_string;
 use function json_encode;
 use function method_exists;
 use function strtr;
-use function strlen;
-use function substr;
 use function strtoupper;
 use const DATE_ATOM;
 use const JSON_UNESCAPED_SLASHES;
@@ -138,10 +137,10 @@ final class StructuredLogger extends AbstractLogger
 
     private function truncate(string $value): string
     {
-        if (strlen($value) <= self::MAX_STRING_LENGTH) {
+        if (Strings::length($value) <= self::MAX_STRING_LENGTH) {
             return $value;
         }
 
-        return substr($value, 0, self::MAX_STRING_LENGTH - 1) . '…';
+        return Strings::safeSubstr($value, self::MAX_STRING_LENGTH - 1) . '…';
     }
 }

--- a/fp-digital-publisher/src/Support/Strings.php
+++ b/fp-digital-publisher/src/Support/Strings.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace FP\Publisher\Support;
 
+use IntlChar;
+
 use function array_slice;
+use function class_exists;
 use function function_exists;
 use function implode;
+use function is_int;
 use function max;
 use function preg_match_all;
+use function str_split;
 use function strlen;
 use function substr;
 
@@ -27,7 +32,7 @@ final class Strings
             return mb_substr($value, $start, $length);
         }
 
-        if (preg_match_all('/./u', $value, $matches) > 0) {
+        if (preg_match_all('/./us', $value, $matches) > 0) {
             $slice = array_slice($matches[0], $start, $length);
 
             return implode('', $slice);
@@ -39,7 +44,8 @@ final class Strings
     public static function trimWidth(string $value, int $width, string $trimMarker = '…'): string
     {
         $width = max(0, $width);
-        if ($width === 0) {
+
+        if ($width === 0 && $trimMarker === '') {
             return '';
         }
 
@@ -48,17 +54,25 @@ final class Strings
             return mb_strimwidth($value, 0, $width, $trimMarker);
         }
 
-        if (self::length($value) <= $width) {
+        if (self::width($value) <= $width) {
             return $value;
         }
 
-        $markerLength = max(0, self::length($trimMarker));
-        if ($markerLength >= $width) {
-            return self::safeSubstr($value, $width);
+        $markerWidth = max(0, self::width($trimMarker));
+        if ($markerWidth === 0) {
+            return self::trimToWidth($value, $width);
         }
 
-        $visibleWidth = $width - $markerLength;
-        $prefix = self::safeSubstr($value, $visibleWidth);
+        if ($markerWidth >= $width) {
+            return $trimMarker;
+        }
+
+        $visibleWidth = $width - $markerWidth;
+        $prefix = self::trimToWidth($value, $visibleWidth);
+
+        if ($prefix === '') {
+            return $trimMarker;
+        }
 
         return $prefix . $trimMarker;
     }
@@ -75,7 +89,7 @@ final class Strings
             return mb_strlen($value);
         }
 
-        $count = preg_match_all('/./u', $value, $matches);
+        $count = preg_match_all('/./us', $value, $matches);
         if ($count !== false && $count > 0) {
             return $count;
         }
@@ -95,7 +109,7 @@ final class Strings
             return mb_substr($value, -$length);
         }
 
-        $count = preg_match_all('/./u', $value, $matches);
+        $count = preg_match_all('/./us', $value, $matches);
         if ($count !== false && $count > 0) {
             $slice = array_slice($matches[0], -$length);
 
@@ -112,5 +126,68 @@ final class Strings
         }
 
         return function_exists($function);
+    }
+
+    private static function trimToWidth(string $value, int $width): string
+    {
+        if ($width <= 0) {
+            return '';
+        }
+
+        $currentWidth = 0;
+        $result = '';
+
+        foreach (self::splitCharacters($value) as $character) {
+            $characterWidth = self::characterWidth($character);
+
+            if ($currentWidth + $characterWidth > $width) {
+                break;
+            }
+
+            $result .= $character;
+            $currentWidth += $characterWidth;
+        }
+
+        return $result;
+    }
+
+    private static function width(string $value): int
+    {
+        $width = 0;
+
+        foreach (self::splitCharacters($value) as $character) {
+            $width += self::characterWidth($character);
+        }
+
+        return $width;
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function splitCharacters(string $value): array
+    {
+        if (preg_match_all('/./us', $value, $matches) > 0) {
+            return $matches[0];
+        }
+
+        return str_split($value);
+    }
+
+    private static function characterWidth(string $character): int
+    {
+        if (class_exists(IntlChar::class)) {
+            $codePoint = IntlChar::ord($character);
+
+            if (is_int($codePoint)) {
+                $eastAsianWidth = IntlChar::getIntPropertyValue($codePoint, IntlChar::PROPERTY_EAST_ASIAN_WIDTH);
+
+                if ($eastAsianWidth === 3 || $eastAsianWidth === 5) {
+                    return 2;
+                }
+            }
+        }
+
+        return 1;
     }
 }

--- a/fp-digital-publisher/tests/Unit/Support/Logging/StructuredLoggerTest.php
+++ b/fp-digital-publisher/tests/Unit/Support/Logging/StructuredLoggerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\Publisher\Tests\Unit\Support\Logging;
+
+use FP\Publisher\Support\Logging\StructuredLogger;
+use FP\Publisher\Support\Strings;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+use function preg_match;
+use function str_repeat;
+
+final class StructuredLoggerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(null);
+
+        parent::tearDown();
+    }
+
+    public function testTruncateIsUtf8SafeWithoutMbstring(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(false);
+
+        $logger = new StructuredLogger();
+        $method = new ReflectionMethod(StructuredLogger::class, 'truncate');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($logger, str_repeat('€', 2001));
+
+        $this->assertSame(2000, Strings::length($result));
+        $this->assertSame(1, preg_match('//u', $result));
+        $this->assertStringEndsWith('…', $result);
+    }
+}

--- a/fp-digital-publisher/tests/Unit/Support/StringsTest.php
+++ b/fp-digital-publisher/tests/Unit/Support/StringsTest.php
@@ -24,6 +24,13 @@ final class StringsTest extends TestCase
         $this->assertSame('', Strings::safeSubstr('abcdef', 0));
     }
 
+    public function testSafeSubstrPreservesNewlinesWithoutMbstring(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(false);
+
+        $this->assertSame("Line1\n", Strings::safeSubstr("Line1\nLine2", 6));
+    }
+
     public function testTrimWidthFallsBackWithoutMbstring(): void
     {
         Strings::forceMbstringAvailabilityForTesting(false);
@@ -37,5 +44,44 @@ final class StringsTest extends TestCase
         Strings::forceMbstringAvailabilityForTesting(false);
 
         $this->assertSame('he--', Strings::trimWidth('hello', 4, '--'));
+    }
+
+    public function testTrimWidthReturnsMarkerWhenWidthSmallerThanMarker(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(false);
+
+        $this->assertSame('…', Strings::trimWidth('example text', 1));
+        $this->assertSame('…', Strings::trimWidth('example text', 0));
+        $this->assertSame('--', Strings::trimWidth('example text', 1, '--'));
+    }
+
+    public function testTrimWidthReturnsEmptyWhenMarkerEmptyAndWidthZero(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(false);
+
+        $this->assertSame('', Strings::trimWidth('example text', 0, ''));
+        $this->assertSame('', Strings::trimWidth('', 0));
+    }
+
+    public function testTrimWidthCountsWideCharactersWithoutMbstring(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(false);
+
+        $this->assertSame('古…', Strings::trimWidth('古古', 3));
+        $this->assertSame('…', Strings::trimWidth('古古', 2));
+    }
+
+    public function testLengthCountsNewlinesWithoutMbstring(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(false);
+
+        $this->assertSame(11, Strings::length("Line1\nLine2"));
+    }
+
+    public function testTailPreservesNewlinesWithoutMbstring(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(false);
+
+        $this->assertSame("\nLine2", Strings::tail("Line1\nLine2", 6));
     }
 }

--- a/fp-digital-publisher/tests/Unit/Support/TemplatingTest.php
+++ b/fp-digital-publisher/tests/Unit/Support/TemplatingTest.php
@@ -30,4 +30,73 @@ final class TemplatingTest extends TestCase
         $this->assertSame(63206, Strings::length($rendered));
         $this->assertStringEndsWith('…', $rendered);
     }
+
+    public function testMetaFacebookLengthLimitAppliedWithoutMbstring(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(false);
+
+        try {
+            $content = str_repeat('€', 63210);
+
+            $rendered = Templating::renderForChannel($content, [], 'meta_facebook');
+
+            $this->assertSame(63206, Strings::length($rendered));
+            $this->assertStringEndsWith('…', $rendered);
+            $this->assertSame(1, preg_match('//u', $rendered));
+        } finally {
+            Strings::forceMbstringAvailabilityForTesting(null);
+        }
+    }
+
+    public function testTwitterTruncationPreservesTrailingNewlines(): void
+    {
+        Strings::forceMbstringAvailabilityForTesting(false);
+
+        try {
+            $content = str_repeat('x', 278) . "\n" . str_repeat('y', 50);
+
+            $rendered = Templating::renderForChannel($content, [], 'twitter');
+
+            $this->assertSame(280, Strings::length($rendered));
+            $this->assertStringContainsString("\n…", $rendered);
+        } finally {
+            Strings::forceMbstringAvailabilityForTesting(null);
+        }
+    }
+
+    public function testChannelTransformPreservesTrailingNewlinesWithoutTruncation(): void
+    {
+        $content = "Hello world\n";
+
+        $rendered = Templating::renderForChannel($content, [], 'twitter');
+
+        $this->assertSame($content, $rendered);
+        $this->assertStringEndsWith("\n", $rendered);
+    }
+
+    public function testChannelTransformPreservesLeadingNewlines(): void
+    {
+        $content = "\nHello world";
+
+        $rendered = Templating::renderForChannel($content, [], 'twitter');
+
+        $this->assertSame($content, $rendered);
+        $this->assertStringStartsWith("\n", $rendered);
+    }
+
+    public function testChannelTransformTrimsLeadingSpacesButKeepsNewlines(): void
+    {
+        $content = "  \nHello world";
+
+        $rendered = Templating::renderForChannel($content, [], 'twitter');
+
+        $this->assertSame("\nHello world", $rendered);
+    }
+
+    public function testChannelTransformTreatsWhitespaceOnlyAsEmpty(): void
+    {
+        $rendered = Templating::renderForChannel("  \n\t", [], 'twitter');
+
+        $this->assertSame('', $rendered);
+    }
 }


### PR DESCRIPTION
## Summary
- update the mbstring fallback for Strings::trimWidth to measure character width with IntlChar and truncate based on display width
- ensure the fallback returns only the trim marker when no characters fit within the target width
- extend the StringsTest coverage to cover wide-character truncation without mbstring

## Testing
- vendor/bin/phpunit --configuration=phpunit.xml.dist --testdox --filter=StringsTest
- vendor/bin/phpunit --configuration=phpunit.xml.dist --testdox

------
https://chatgpt.com/codex/tasks/task_e_68dd3be8ff74832f9c8eb93f46e7b2f1