### PR TITLE
Validate built assets before packaging

### DIFF
--- a/tools/build-zip.sh
+++ b/tools/build-zip.sh
@@ -17,13 +17,19 @@ if [[ ! -d "${PLUGIN_DIR}/vendor" ]]; then
     exit 1
 fi
 
+ASSETS_DIR="${PLUGIN_DIR}/assets/dist"
+if [[ ! -d "${ASSETS_DIR}" ]] || [[ -z "$(find "${ASSETS_DIR}" -mindepth 1 -print -quit)" ]]; then
+    echo "Built assets not found in assets/dist. Run 'npm run build' before packaging." >&2
+    exit 1
+fi
+
 RSYNC_EXCLUDES=(
     "--exclude=.git"
     "--exclude=.github"
     "--exclude=tests"
     "--exclude=docs"
     "--exclude=node_modules"
-    "--exclude=dist"
+    "--exclude=/dist"
     "--exclude=build"
     "--exclude=build.sh"
     "--exclude=package*.json"


### PR DESCRIPTION
## Summary
- ensure the build zip script checks that assets/dist contains built files before packaging

## Testing
- npm run build
- composer install --no-dev
- bash tools/build-zip.sh

------
https://chatgpt.com/codex/tasks/task_e_68e281ea7dd0832f9e957b5845a3badc