### PR TITLE
Trim whitespace in array string validation

### DIFF
--- a/fp-digital-publisher/src/Support/Validation.php
+++ b/fp-digital-publisher/src/Support/Validation.php
@@ -119,7 +119,15 @@ final class Validation
         return array_values(self::arrayOf(
             $values,
             static function (mixed $value) use ($field, $allowEmpty): string {
-                return self::string($value, $field, $allowEmpty);
+                $string = self::string($value, $field, $allowEmpty);
+
+                $trimmed = trim($string);
+
+                if ($trimmed === '') {
+                    return '';
+                }
+
+                return $trimmed;
             },
             $field
         ));

--- a/fp-digital-publisher/tests/Unit/Support/ValidationTest.php
+++ b/fp-digital-publisher/tests/Unit/Support/ValidationTest.php
@@ -48,4 +48,25 @@ final class ValidationTest extends TestCase
         $values = Validation::arrayOfStrings(['a', 'b'], 'items');
         $this->assertSame(['a', 'b'], $values);
     }
+
+    public function testArrayOfStringsTrimsWhitespace(): void
+    {
+        $values = Validation::arrayOfStrings(["  alpha  ", "\tBeta\n"], 'items');
+
+        $this->assertSame(['alpha', 'Beta'], $values);
+    }
+
+    public function testArrayOfStringsAllowsEmptyStringsWhenEnabled(): void
+    {
+        $values = Validation::arrayOfStrings(['   ', ''], 'items', true);
+
+        $this->assertSame(['', ''], $values);
+    }
+
+    public function testArrayOfStringsRejectsWhitespaceOnlyValuesWhenNotAllowed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Validation::arrayOfStrings(['   '], 'items');
+    }
 }


### PR DESCRIPTION
## Summary
- trim whitespace from values returned by `Validation::arrayOfStrings` while preserving optional empty entries
- extend validation unit tests to cover trimming behavior and whitespace-only handling

## Testing
- composer test
- composer test:integration

------
https://chatgpt.com/codex/tasks/task_e_68e288995578832fb70b53dccadb5443