### PR TITLE
Handle zero-width trim markers correctly

### DIFF
--- a/fp-digital-publisher/src/Support/Strings.php
+++ b/fp-digital-publisher/src/Support/Strings.php
@@ -45,8 +45,12 @@ final class Strings
     {
         $width = max(0, $width);
 
-        if ($width === 0 && $trimMarker === '') {
-            return '';
+        if ($width === 0) {
+            if ($trimMarker === '' || $value === '') {
+                return '';
+            }
+
+            return $trimMarker;
         }
 
         if (self::mbFunctionAvailable('mb_strimwidth')) {


### PR DESCRIPTION
## Summary
- ensure `Strings::trimWidth` returns an empty string when the trim marker is empty or the source string has no content at zero width to avoid stray ellipses

## Testing
- vendor/bin/phpunit tests/Unit/Support/StringsTest.php
- vendor/bin/phpunit tests/Unit

------
https://chatgpt.com/codex/tasks/task_e_68e28a7fdc38832f97f3aa31b91103ea